### PR TITLE
feat: 添加上传进度条、图片点击预览、Ctrl+A 全选快捷键

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -392,3 +392,63 @@ header p {
     background: #f8d7da;
     color: #721c24;
 }
+
+/* === 上传进度条 === */
+.progress-container {
+    margin-top: 15px;
+    display: none;
+}
+
+.progress-bar-bg {
+    width: 100%;
+    height: 20px;
+    background: #e0e0e0;
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.progress-bar-fill {
+    height: 100%;
+    width: 0%;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    border-radius: 10px;
+    transition: width 0.3s;
+}
+
+.progress-text {
+    text-align: center;
+    margin-top: 5px;
+    font-size: 0.9em;
+    color: #666;
+}
+
+/* === 图片预览模态框 === */
+.img-modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.8);
+    z-index: 1000;
+    justify-content: center;
+    align-items: center;
+    cursor: zoom-out;
+}
+
+.img-modal.active {
+    display: flex;
+}
+
+.img-modal img {
+    max-width: 90%;
+    max-height: 90%;
+    object-fit: contain;
+    border-radius: 8px;
+    box-shadow: 0 0 30px rgba(0, 0, 0, 0.5);
+}
+
+.question-content img {
+    cursor: zoom-in;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -61,6 +61,14 @@
                 <input type="file" id="fileInput" accept=".pdf,.png,.jpg,.jpeg,.bmp,.tiff,.webp" multiple>
             </div>
 
+            <!-- 上传进度条 -->
+            <div class="progress-container" id="progressContainer">
+                <div class="progress-bar-bg">
+                    <div class="progress-bar-fill" id="progressBarFill"></div>
+                </div>
+                <div class="progress-text" id="progressText">0%</div>
+            </div>
+
             <!-- 文件信息 -->
             <div class="file-info" id="fileInfo">
                 <div class="file-info-item">
@@ -96,6 +104,11 @@
             <!-- 题目预览 -->
             <div class="questions-preview" id="questionsPreview"></div>
         </div>
+    </div>
+
+    <!-- 图片预览模态框 -->
+    <div class="img-modal" id="imgModal">
+        <img id="imgModalContent" src="" alt="预览">
     </div>
 
     <script>
@@ -164,8 +177,8 @@
             if (files.length > 0) handleFileUpload(files);
         });
 
-        // 处理文件上传（支持多文件）
-        async function handleFileUpload(files) {
+        // 处理文件上传（支持多文件，带进度条）
+        function handleFileUpload(files) {
             const formData = new FormData();
             const fileNames = [];
             for (let i = 0; i < files.length; i++) {
@@ -173,39 +186,54 @@
                 fileNames.push(files[i].name);
             }
 
-            // 显示加载状态
+            // 显示进度条和加载状态
             const fileLabel = files.length > 1 ? `${files.length} 个文件` : fileNames[0];
+            const progressContainer = document.getElementById('progressContainer');
+            const progressBarFill = document.getElementById('progressBarFill');
+            const progressText = document.getElementById('progressText');
+            progressContainer.style.display = 'block';
+            progressBarFill.style.width = '0%';
+            progressText.textContent = '0%';
             showLoading(`正在上传和处理 ${fileLabel}...`);
             setStep(2);
 
-            try {
-                const response = await fetch('/api/upload', {
-                    method: 'POST',
-                    body: formData
-                });
+            const xhr = new XMLHttpRequest();
 
-                const data = await response.json();
-
-                if (data.success) {
-                    // 显示成功信息
-                    showSuccess(`文件处理成功！共 ${data.result.file_count} 个文件，识别到 ${data.result.image_count} 张图片`);
-
-                    // 更新文件信息
-                    document.getElementById('fileName').textContent = fileNames.join('、');
-                    document.getElementById('imageCount').textContent = data.result.image_count;
-                    document.getElementById('ocrCount').textContent = data.result.ocr_count;
-                    document.getElementById('fileInfo').style.display = 'block';
-
-                    // 启用分割按钮
-                    document.getElementById('splitBtn').disabled = false;
-
-                    setStep(3);
-                } else {
-                    showError(data.error || '文件处理失败');
+            xhr.upload.addEventListener('progress', (e) => {
+                if (e.lengthComputable) {
+                    const percent = Math.round((e.loaded / e.total) * 100);
+                    progressBarFill.style.width = percent + '%';
+                    progressText.textContent = percent + '%';
                 }
-            } catch (error) {
-                showError('上传失败: ' + error.message);
-            }
+            });
+
+            xhr.addEventListener('load', () => {
+                progressContainer.style.display = 'none';
+                try {
+                    const data = JSON.parse(xhr.responseText);
+                    if (data.success) {
+                        showSuccess(`文件处理成功！共 ${data.result.file_count} 个文件，识别到 ${data.result.image_count} 张图片`);
+                        document.getElementById('fileName').textContent = fileNames.join('、');
+                        document.getElementById('imageCount').textContent = data.result.image_count;
+                        document.getElementById('ocrCount').textContent = data.result.ocr_count;
+                        document.getElementById('fileInfo').style.display = 'block';
+                        document.getElementById('splitBtn').disabled = false;
+                        setStep(3);
+                    } else {
+                        showError(data.error || '文件处理失败');
+                    }
+                } catch (e) {
+                    showError('上传失败: 服务器响应异常');
+                }
+            });
+
+            xhr.addEventListener('error', () => {
+                progressContainer.style.display = 'none';
+                showError('上传失败: 网络错误');
+            });
+
+            xhr.open('POST', '/api/upload');
+            xhr.send(formData);
         }
 
         // 分割题目
@@ -383,7 +411,7 @@
                     } else if (block.block_type === 'image') {
                         const imgPath = block.content || '';
                         if (imgPath) {
-                            html += `<img src="${imgPath}" style="max-width: 100%; margin: 10px 0;">`;
+                            html += `<img src="${imgPath}" style="max-width: 100%; margin: 10px 0; cursor: zoom-in;" onclick="showImagePreview(this.src)">`;
                         } else {
                             html += `<p style="color: #ff9800;">📷 图片资源</p>`;
                         }
@@ -447,6 +475,28 @@
                 }
             }
         }
+
+        // 图片预览
+        function showImagePreview(src) {
+            const modal = document.getElementById('imgModal');
+            document.getElementById('imgModalContent').src = src;
+            modal.classList.add('active');
+        }
+
+        document.getElementById('imgModal').addEventListener('click', () => {
+            document.getElementById('imgModal').classList.remove('active');
+        });
+
+        // 键盘快捷键：Ctrl+A 全选题目，ESC 关闭预览
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') {
+                document.getElementById('imgModal').classList.remove('active');
+            }
+            if ((e.ctrlKey || e.metaKey) && e.key === 'a' && currentQuestions.length > 0) {
+                e.preventDefault();
+                selectAll();
+            }
+        });
 
         // 页面加载时检查系统状态
         window.addEventListener('load', checkSystemStatus);


### PR DESCRIPTION
## 任务 1.1 前端功能完善

### 改动内容
1. **上传进度条** - 使用 XMLHttpRequest 替代 fetch，实时显示上传百分比（兼容多文件上传）
2. **图片点击放大预览** - 添加模态框，点击题目中的图片可放大查看，ESC 关闭
3. **Ctrl+A 全选快捷键** - 在题目列表中按 Ctrl+A 可快速全选所有题目

### 改动文件
- `templates/index.html` - 前端页面逻辑
- `static/css/style.css` - 进度条和模态框样式