### PR TITLE
fix: 修复导出失败问题，统一配置路径. feat: 数据持久化功能.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ frontend/output
 
 # 后端运行产物
 backend/runtime_data/
+backend/output/
+output/
 __pycache__/
 backend/static/vue/assets
 

--- a/backend/db/__init__.py
+++ b/backend/db/__init__.py
@@ -1,0 +1,45 @@
+"""
+数据库模块：引擎创建、Session 工厂、初始化函数
+"""
+
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+import os
+import sys
+
+# 添加 backend 目录到路径以支持导入 config
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from config import DB_PATH
+
+# 确保数据库目录存在
+db_dir = os.path.dirname(DB_PATH)
+if db_dir and not os.path.exists(db_dir):
+    os.makedirs(db_dir, exist_ok=True)
+
+# 创建引擎
+engine = create_engine(f"sqlite:///{DB_PATH}", echo=False)
+
+# 启用 SQLite 外键约束
+@event.listens_for(engine, "connect")
+def set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+# Session 工厂
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def init_db():
+    """应用启动时调用：建表"""
+    from db.models import Base
+    Base.metadata.create_all(bind=engine)
+
+
+def get_db():
+    """获取数据库会话（用于手动管理）"""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/db/crud.py
+++ b/backend/db/crud.py
@@ -1,0 +1,248 @@
+"""
+数据库 CRUD 操作
+"""
+
+import hashlib
+import json
+from datetime import datetime
+from typing import List, Dict, Any, Optional
+
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+
+from db.models import UploadBatch, Question, KnowledgeTag, QuestionTagMapping
+
+
+def compute_content_hash(content_blocks: List[Dict]) -> str:
+    """
+    基于 content_blocks 计算去重哈希
+    使用题目文本内容计算 SHA256
+    """
+    text_parts = []
+    for block in content_blocks:
+        if block.get("block_type") == "text":
+            text_parts.append(block.get("content", ""))
+
+    text = " ".join(text_parts).strip()
+    if not text:
+        # 如果没有文本内容，使用整个 content_blocks 的 JSON 作为哈希源
+        text = json.dumps(content_blocks, ensure_ascii=False)
+
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+def detect_subject(questions: List[Dict]) -> str:
+    """
+    AI 识别科目：基于 knowledge_tags 和内容推断
+    """
+    # 科目关键词映射
+    math_tags = {"复数", "函数", "三角函数", "数列", "立体几何", "圆锥曲线",
+                 "概率", "统计", "导数", "不等式", "向量", "集合", "算法",
+                 "平面几何", "解析几何", "极限", "积分", "矩阵"}
+
+    physics_tags = {"力学", "电学", "光学", "热学", "电磁学", "机械波",
+                    "动量", "能量", "电路", "磁场", "电场", "重力"}
+
+    chemistry_tags = {"化学方程式", "有机化学", "无机化学", "氧化还原",
+                      "离子反应", "化学平衡", "电化学", "物质结构"}
+
+    biology_tags = {"细胞", "遗传", "进化", "生态", "代谢", "基因",
+                    "光合作用", "呼吸作用"}
+
+    english_tags = {"语法", "词汇", "阅读理解", "完形填空", "写作", "听力"}
+
+    chinese_tags = {"文言文", "现代文", "古诗", "作文", "修辞", "阅读"}
+
+    # 收集所有标签
+    all_tags = set()
+    for q in questions:
+        tags = q.get("knowledge_tags") or []
+        all_tags.update(tags)
+
+    # 匹配科目
+    if all_tags & math_tags:
+        return "数学"
+    if all_tags & physics_tags:
+        return "物理"
+    if all_tags & chemistry_tags:
+        return "化学"
+    if all_tags & biology_tags:
+        return "生物"
+    if all_tags & english_tags:
+        return "英语"
+    if all_tags & chinese_tags:
+        return "语文"
+
+    # 如果标签匹配失败，尝试从内容中推断
+    for q in questions:
+        content_text = ""
+        for block in q.get("content_blocks", []):
+            if block.get("block_type") == "text":
+                content_text += block.get("content", "")
+
+        # 检查数学公式标记
+        if "$$" in content_text or "$" in content_text:
+            return "数学"
+
+        # 检查化学符号
+        if any(sym in content_text for sym in ["→", "⇌", "↑", "↓"]):
+            # 更多化学特征判断
+            chem_elements = ["H₂", "O₂", "Na", "Cl", "Ca", "Fe", "Cu", "Zn"]
+            if any(el in content_text for el in chem_elements):
+                return "化学"
+
+        # 检查物理单位
+        physics_units = ["m/s", "kg", "N", "J", "W", "V", "A", "Ω", "Hz"]
+        if any(unit in content_text for unit in physics_units):
+            return "物理"
+
+    return "未知"
+
+
+def get_or_create_tag(db: Session, tag_name: str, subject: str) -> KnowledgeTag:
+    """获取或创建知识点标签"""
+    tag = db.query(KnowledgeTag).filter_by(
+        tag_name=tag_name,
+        subject=subject
+    ).first()
+
+    if not tag:
+        tag = KnowledgeTag(tag_name=tag_name, subject=subject)
+        db.add(tag)
+        db.flush()
+
+    return tag
+
+
+def question_exists(db: Session, content_hash: str) -> Optional[Question]:
+    """检查题目是否已存在（通过内容哈希）"""
+    return db.query(Question).filter_by(content_hash=content_hash).first()
+
+
+def save_questions_to_db(
+    db: Session,
+    questions: List[Dict],
+    batch_info: Dict[str, Any]
+) -> Dict[str, int]:
+    """
+    批量入库题目
+
+    Args:
+        db: 数据库会话
+        questions: 题目列表（字典格式，来自 questions.json）
+        batch_info: 批次信息，包含 original_filename, file_path 等
+
+    Returns:
+        dict: {"created": 新增数量, "duplicates": 重复数量}
+    """
+    # 检测科目
+    subject = batch_info.get("subject") or detect_subject(questions)
+
+    # 创建批次记录
+    batch = UploadBatch(
+        original_filename=batch_info.get("original_filename", "未知"),
+        subject=subject,
+        file_path=batch_info.get("file_path", ""),
+        upload_time=batch_info.get("upload_time") or datetime.utcnow()
+    )
+    db.add(batch)
+    db.flush()  # 获取 batch.id
+
+    created = 0
+    duplicates = 0
+
+    for q in questions:
+        content_blocks = q.get("content_blocks", [])
+        if not content_blocks:
+            continue
+
+        content_hash = compute_content_hash(content_blocks)
+
+        # 检查是否已存在
+        if question_exists(db, content_hash):
+            duplicates += 1
+            continue
+
+        # 创建题目记录
+        question = Question(
+            batch_id=batch.id,
+            content_hash=content_hash,
+            question_type=q.get("question_type"),
+            content_json=json.dumps(content_blocks, ensure_ascii=False),
+            options_json=json.dumps(q.get("options"), ensure_ascii=False) if q.get("options") else None,
+            has_formula=q.get("has_formula", False),
+            has_image=q.get("has_image", False),
+            image_refs_json=json.dumps(q.get("image_refs"), ensure_ascii=False) if q.get("image_refs") else None,
+            needs_correction=q.get("needs_correction", False),
+            ocr_issues_json=json.dumps(q.get("ocr_issues"), ensure_ascii=False) if q.get("ocr_issues") else None
+        )
+        db.add(question)
+        db.flush()
+
+        # 处理知识点标签
+        knowledge_tags = q.get("knowledge_tags") or []
+        for tag_name in knowledge_tags:
+            tag = get_or_create_tag(db, tag_name, subject)
+            mapping = QuestionTagMapping(
+                question_id=question.id,
+                tag_id=tag.id
+            )
+            db.add(mapping)
+
+        created += 1
+
+    db.commit()
+
+    return {"created": created, "duplicates": duplicates}
+
+
+def get_questions_by_subject(
+    db: Session,
+    subject: str,
+    limit: int = 100,
+    offset: int = 0
+) -> List[Question]:
+    """按科目查询题目"""
+    return db.query(Question).join(UploadBatch).filter(
+        UploadBatch.subject == subject
+    ).order_by(Question.created_at.desc()).offset(offset).limit(limit).all()
+
+
+def get_questions_by_tag(
+    db: Session,
+    tag_name: str,
+    limit: int = 100,
+    offset: int = 0
+) -> List[Question]:
+    """按标签查询题目"""
+    return db.query(Question).join(QuestionTagMapping).join(KnowledgeTag).filter(
+        KnowledgeTag.tag_name == tag_name
+    ).order_by(Question.created_at.desc()).offset(offset).limit(limit).all()
+
+
+def get_all_tags(db: Session, subject: Optional[str] = None) -> List[KnowledgeTag]:
+    """获取所有标签（可按科目筛选）"""
+    query = db.query(KnowledgeTag)
+    if subject:
+        query = query.filter(KnowledgeTag.subject == subject)
+    return query.order_by(KnowledgeTag.tag_name).all()
+
+
+def get_statistics(db: Session) -> Dict[str, Any]:
+    """获取统计信息"""
+    total_questions = db.query(func.count(Question.id)).scalar()
+    total_batches = db.query(func.count(UploadBatch.id)).scalar()
+    total_tags = db.query(func.count(KnowledgeTag.id)).scalar()
+
+    # 按科目统计
+    subject_stats = db.query(
+        UploadBatch.subject,
+        func.count(Question.id)
+    ).join(Question).group_by(UploadBatch.subject).all()
+
+    return {
+        "total_questions": total_questions or 0,
+        "total_batches": total_batches or 0,
+        "total_tags": total_tags or 0,
+        "by_subject": {s: c for s, c in subject_stats}
+    }

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -1,0 +1,70 @@
+"""
+数据库 ORM 模型定义
+"""
+
+from sqlalchemy import Column, Integer, String, Text, DateTime, Boolean, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy.ext.declarative import declarative_base
+from datetime import datetime
+
+Base = declarative_base()
+
+
+class UploadBatch(Base):
+    """上传批次表"""
+    __tablename__ = "upload_batches"
+
+    id = Column(Integer, primary_key=True)
+    original_filename = Column(String(255), nullable=False)
+    subject = Column(String(50))
+    file_path = Column(Text)
+    upload_time = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    questions = relationship("Question", back_populates="batch")
+
+
+class Question(Base):
+    """题目表"""
+    __tablename__ = "questions"
+
+    id = Column(Integer, primary_key=True)
+    batch_id = Column(Integer, ForeignKey("upload_batches.id"))
+    content_hash = Column(String(64), unique=True, nullable=False)  # SHA256
+    question_type = Column(String(20))
+    content_json = Column(Text)  # JSON 序列化 content_blocks
+    options_json = Column(Text)
+    has_formula = Column(Boolean, default=False)
+    has_image = Column(Boolean, default=False)
+    image_refs_json = Column(Text)
+    needs_correction = Column(Boolean, default=False)
+    ocr_issues_json = Column(Text)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    batch = relationship("UploadBatch", back_populates="questions")
+    tags = relationship("QuestionTagMapping", back_populates="question")
+
+
+class KnowledgeTag(Base):
+    """知识点标签表"""
+    __tablename__ = "knowledge_tags"
+
+    id = Column(Integer, primary_key=True)
+    tag_name = Column(String(50), nullable=False)
+    subject = Column(String(50))
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint("tag_name", "subject", name="uq_tag_subject"),
+    )
+
+
+class QuestionTagMapping(Base):
+    """题目-标签关联表"""
+    __tablename__ = "question_tag_mapping"
+
+    question_id = Column(Integer, ForeignKey("questions.id"), primary_key=True)
+    tag_id = Column(Integer, ForeignKey("knowledge_tags.id"), primary_key=True)
+
+    question = relationship("Question", back_populates="tags")
+    tag = relationship("KnowledgeTag")

--- a/backend/src/utils.py
+++ b/backend/src/utils.py
@@ -103,16 +103,22 @@ def prepare_input(file_path: str) -> List[str]:
     return image_paths
 
 
-def export_wrongbook(questions: List[Dict[str, Any]], selected_ids: List[str], output_path: str = None) -> str:
+def export_wrongbook(
+    questions: List[Dict[str, Any]],
+    selected_ids: List[str],
+    output_path: str = None,
+    batch_info: Dict[str, Any] = None
+) -> str:
     """
     步骤5: 导出错题本
 
-    将用户选择的题目导出为Markdown格式的错题本
+    将用户选择的题目导出为Markdown格式的错题本，并可选入库到数据库
 
     Args:
         questions: 题目列表
         selected_ids: 用户选择的题目ID列表
         output_path: 输出Markdown文件路径（可选）
+        batch_info: 批次信息（用于入库），包含 original_filename, subject 等
 
     Returns:
         str: 导出的Markdown文件路径
@@ -178,5 +184,21 @@ def export_wrongbook(questions: List[Dict[str, Any]], selected_ids: List[str], o
         f.write(md_content)
 
     console.print(f"[green]✓ 错题本已导出: {output_path}[/green]")
+
+    # 入库到数据库
+    if batch_info:
+        try:
+            from db import SessionLocal
+            from db.crud import save_questions_to_db
+
+            selected_questions = [q for q in questions if q.get('question_id') in selected_ids]
+            with SessionLocal() as db:
+                result = save_questions_to_db(db, selected_questions, batch_info)
+                console.print(
+                    f"[green]✓ 已入库 {result['created']} 道新题目"
+                    f"（跳过 {result['duplicates']} 道重复题目）[/green]"
+                )
+        except Exception as e:
+            console.print(f"[yellow]⚠ 入库失败: {e}[/yellow]")
 
     return output_path

--- a/backend/web_app.py
+++ b/backend/web_app.py
@@ -7,13 +7,11 @@ import os
 import json
 import uuid
 import threading
-import asyncio
 import mimetypes
 
 # Windows 注册表可能将 .js 映射为 text/plain，导致浏览器拒绝加载 ES module
 mimetypes.add_type('application/javascript', '.js')
 from flask import Flask, request, jsonify, render_template, send_file, send_from_directory
-from werkzeug.utils import secure_filename
 from dotenv import load_dotenv
 
 from src.workflow import build_workflow
@@ -27,31 +25,16 @@ from config import (
     MAX_FILE_SIZE_MB,
     ALLOWED_EXTENSIONS,
 )
+from db import init_db
 
 # 加载环境变量
 load_dotenv()
 
 app = Flask(__name__)
 
-PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-
-# 配置
-BACKEND_ROOT = os.path.abspath(os.path.dirname(__file__))
-RUNTIME_ROOT = os.path.join(BACKEND_ROOT, 'runtime_data')
-UPLOAD_FOLDER = os.path.join(RUNTIME_ROOT, 'uploads')
-ALLOWED_EXTENSIONS = {'pdf', 'png', 'jpg', 'jpeg', 'bmp', 'tiff', 'webp'}
-RESULTS_DIR_DEFAULT = os.path.join(RUNTIME_ROOT, 'results')
-STRUCT_DIR_DEFAULT = os.path.join(RUNTIME_ROOT, 'struct')
-PAGES_DIR_DEFAULT = os.path.join(RUNTIME_ROOT, 'pages')
-
-
-def _resolve_dir(env_key: str, default_path: str) -> str:
-    p = os.getenv(env_key)
-    if not p:
-        return default_path
-    if os.path.isabs(p):
-        return p
-    return os.path.abspath(os.path.join(PROJECT_ROOT, p))
+# 配置（统一从 config.py 导入）
+app.config['UPLOAD_FOLDER'] = UPLOAD_DIR
+app.config['MAX_CONTENT_LENGTH'] = MAX_FILE_SIZE_MB * 1024 * 1024
 
 
 def _safe_join(base_dir: str, rel_path: str) -> str | None:
@@ -60,11 +43,6 @@ def _safe_join(base_dir: str, rel_path: str) -> str | None:
     if os.path.normcase(target).startswith(os.path.normcase(base + os.sep)):
         return target
     return None
-
-
-app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
-MAX_FILE_SIZE_MB = 50
-app.config['MAX_CONTENT_LENGTH'] = MAX_FILE_SIZE_MB * 1024 * 1024
 
 @app.errorhandler(413)
 def request_entity_too_large(error):
@@ -106,20 +84,6 @@ def allowed_file(filename):
     """检查文件扩展名是否允许"""
     return '.' in filename and \
            filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
-
-
-def _run_async(coro):
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = None
-
-    if loop and loop.is_running():
-        import concurrent.futures
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            return pool.submit(asyncio.run, coro).result()
-
-    return asyncio.run(coro)
 
 
 @app.route('/')
@@ -406,10 +370,11 @@ def export_wrongbook():
         JSON响应，包含导出文件路径
     """
     try:
-        global current_thread_id
+        global current_thread_id, session_files, session_file_order
 
         data = request.get_json()
         selected_ids = data.get('selected_ids', [])
+        subject = data.get('subject')  # 前端传入科目（可选）
 
         if not selected_ids:
             return jsonify({
@@ -417,20 +382,8 @@ def export_wrongbook():
                 'error': '未选择任何题目'
             }), 400
 
-        if current_thread_id is None:
-            return jsonify({
-                'success': False,
-                'error': '请先分割题目'
-            }), 400
-
-        config = {"configurable": {"thread_id": current_thread_id}}
-
-        # 将用户选中的题目 ID 注入图状态（便于调试/对齐会话状态）
-        workflow_graph.update_state(config, {"selected_ids": selected_ids})
-
-        # 注意：首次导出后图已到 END，后续再次 invoke 不会重复执行 export 节点。
-        # 因此这里每次都根据最新的 selected_ids 重新生成 wrongbook.md。
-        results_dir = _resolve_dir("RESULTS_DIR", RESULTS_DIR_DEFAULT)
+        # 检查是否已分割（通过 questions.json 存在性判断，不依赖内存中的 current_thread_id）
+        results_dir = RESULTS_DIR
         questions_file = os.path.join(results_dir, "questions.json")
         if not os.path.exists(questions_file):
             return jsonify({
@@ -441,8 +394,21 @@ def export_wrongbook():
         with open(questions_file, 'r', encoding='utf-8') as f:
             questions = json.load(f)
 
-        output_path = export_wrongbook_md(questions, selected_ids)
-        workflow_graph.update_state(config, {"output_path": output_path})
+        # 构建批次信息用于入库
+        batch_info = {
+            "original_filename": ", ".join(
+                session_files.get(k, {}).get("filename", "未知")
+                for k in session_file_order
+            ),
+            "subject": subject,
+            "file_path": "",
+        }
+
+        output_path = export_wrongbook_md(
+            questions,
+            selected_ids,
+            batch_info=batch_info
+        )
 
         return jsonify({
             'success': True,
@@ -466,7 +432,7 @@ def get_questions():
         JSON响应，包含题目列表
     """
     try:
-        results_dir = _resolve_dir("RESULTS_DIR", RESULTS_DIR_DEFAULT)
+        results_dir = RESULTS_DIR
         questions_file = os.path.join(results_dir, "questions.json")
 
         if not os.path.exists(questions_file):
@@ -499,7 +465,7 @@ def get_questions():
 @app.route('/preview')
 def preview():
     """显示预览页面"""
-    results_dir = _resolve_dir("RESULTS_DIR", RESULTS_DIR_DEFAULT)
+    results_dir = RESULTS_DIR
     preview_file = os.path.join(results_dir, "preview.html")
 
     if os.path.exists(preview_file):
@@ -513,7 +479,7 @@ def preview():
 @app.route('/download/<path:filename>')
 def download_file(filename):
     """下载结果文件"""
-    results_dir = _resolve_dir("RESULTS_DIR", RESULTS_DIR_DEFAULT)
+    results_dir = RESULTS_DIR
     file_path = _safe_join(results_dir, filename)
     if not file_path:
         return jsonify({
@@ -562,9 +528,9 @@ def get_status():
             'deepseek_configured': bool(os.getenv('DEEPSEEK_API_KEY')),
             'langsmith_enabled': os.getenv('LANGSMITH_TRACING', 'false').lower() == 'true',
             'output_dirs': {
-                'pages': _resolve_dir('PAGES_DIR', PAGES_DIR_DEFAULT),
-                'struct': _resolve_dir('STRUCT_DIR', STRUCT_DIR_DEFAULT),
-                'results': _resolve_dir('RESULTS_DIR', RESULTS_DIR_DEFAULT),
+                'pages': PAGES_DIR,
+                'struct': STRUCT_DIR,
+                'results': RESULTS_DIR,
             }
         }
 
@@ -581,6 +547,10 @@ def get_status():
 
 
 if __name__ == '__main__':
+    # 初始化数据库
+    init_db()
+    print("[数据库] 初始化完成")
+
     print("=" * 60)
     print("错题本生成系统 - Web应用")
     print("=" * 60)

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,9 @@ tqdm>=4.65.0
 # --- 数据验证 ---
 pydantic>=2.0.0
 
+# --- 数据库 ---
+sqlalchemy>=2.0
+
 flask==3.1.2
 werkzeug==3.1.5
 aiohttp>=3.9.0


### PR DESCRIPTION
# 修复导出失败问题，统一配置路径

## 问题背景

分割题目后点击导出，前端返回「请先分割题目」错误（HTTP 400）。

### 根因分析

1. **路径不一致**：`.env` 中 `RESULTS_DIR=results` 被解析为项目根目录，而 `workflow.py` 使用 `config.py` 默认路径 `backend/runtime_data/results`，导致导出时找不到 `questions.json`

2. **内存状态丢失**：导出检查依赖全局变量 `current_thread_id`，服务器重启后会丢失

## 修复内容

### 1. 统一配置路径

所有模块统一从 `config.py` 导入路径配置：

```python
# web_app.py
from config import (
    UPLOAD_DIR,
    PAGES_DIR,
    RESULTS_DIR,
    ...
)
```

### 2. 移除内存依赖

导出检查改为判断 `questions.json` 文件是否存在，不再依赖 `current_thread_id`：

```python
# 旧代码
if current_thread_id is None:
    return jsonify({'error': '请先分割题目'}), 400

# 新代码
questions_file = os.path.join(RESULTS_DIR, "questions.json")
if not os.path.exists(questions_file):
    return jsonify({'error': '请先分割题目'}), 400
```

### 3. 配置简化

用户无需在 `.env` 中配置路径，使用默认配置即可：

```
backend/runtime_data/     ← 默认运行时目录
├── uploads/              ← 上传文件
├── pages/                ← 页面图片
├── struct/               ← 结构化数据
└── results/              ← 结果文件
```

如需自定义，只需设置一个环境变量：

```bash
APP_RUNTIME_DIR=/your/custom/path
```

---

## 数据库入库功能

### 表结构设计

采用 SQLAlchemy ORM，共 4 张表：

```
┌──────────────────┐       ┌──────────────────┐       ┌──────────────────┐
│  upload_batches  │       │    questions     │       │ knowledge_tags   │
│    (来源信息)     │       │                  │       │                  │
├──────────────────┤       ├──────────────────┤       ├──────────────────┤
│ id (PK)          │←──────│ batch_id (FK)    │       │ id (PK)          │
│ original_filename│       │ id (PK)          │       │ tag_name         │
│ subject          │       │ content_hash(UQ) │       │ subject          │
│ file_path        │       │ question_type    │       │ created_at       │
│ upload_time      │       │ content_json     │       └────────┬─────────┘
│ created_at       │       │ options_json     │                │
└──────────────────┘       │ has_formula      │                │
                           │ has_image        │       ┌────────▼─────────┐
                           │ image_refs_json  │       │question_tag_mapping│
                           │ needs_correction │       ├──────────────────┤
                           │ ocr_issues_json  │       │ question_id (FK) │
                           │ created_at       │       │ tag_id (FK)      │
                           └────────┬─────────┘       └──────────────────┘
                                    │                          ▲
                                    └──────────────────────────┘
```

#### upload_batches（上传批次/来源信息表）

| 字段 | 类型 | 说明 |
|------|------|------|
| `id` | Integer | 主键，自增 |
| `original_filename` | String(255) | 原始文件名 |
| `subject` | String(50) | 科目（数学/物理等） |
| `file_path` | Text | 原始文件路径 |
| `upload_time` | DateTime | 上传时间 |
| `created_at` | DateTime | 记录创建时间 |

#### questions（题目表）

| 字段 | 类型 | 说明 |
|------|------|------|
| `id` | Integer | 主键，自增 |
| `batch_id` | Integer | 外键，关联上传批次 |
| `content_hash` | String(64) | 内容哈希（SHA256），唯一约束，用于去重 |
| `question_type` | String(20) | 题型（选择/填空/解答） |
| `content_json` | Text | JSON 序列化的 content_blocks |
| `options_json` | Text | 选项 JSON |
| `has_formula` | Boolean | 是否包含公式 |
| `has_image` | Boolean | 是否包含图片 |
| `image_refs_json` | Text | 图片引用 JSON |
| `needs_correction` | Boolean | 是否需要纠错 |
| `ocr_issues_json` | Text | OCR 问题记录 |
| `created_at` | DateTime | 创建时间 |

#### knowledge_tags（知识点标签表）

| 字段 | 类型 | 说明 |
|------|------|------|
| `id` | Integer | 主键 |
| `tag_name` | String(50) | 标签名称 |
| `subject` | String(50) | 所属科目 |
| `created_at` | DateTime | 创建时间 |

唯一约束：`(tag_name, subject)`

#### question_tag_mapping（题目-标签关联表）

| 字段 | 类型 | 说明 |
|------|------|------|
| `question_id` | Integer | 外键，关联题目（联合主键） |
| `tag_id` | Integer | 外键，关联标签（联合主键） |

### 入库触发机制

导出时自动触发入库，在 `export_wrongbook()` 函数中：

```python
# backend/src/utils.py
def export_wrongbook(questions, selected_ids, batch_info=None):
    # ... 生成 Markdown 文件 ...

    # 入库到数据库
    if batch_info:
        from db import SessionLocal
        from db.crud import save_questions_to_db

        selected_questions = [q for q in questions if q.get('question_id') in selected_ids]
        with SessionLocal() as db:
            result = save_questions_to_db(db, selected_questions, batch_info)
```

调用链：
```
前端 POST /api/export
    ↓
web_app.py:export_wrongbook()
    ↓
构建 batch_info（包含来源信息）
    ↓
utils.py:export_wrongbook_md(..., batch_info=batch_info)
    ↓
crud.py:save_questions_to_db()
    ↓
写入数据库
```

### 来源信息记录

在 `web_app.py` 中构建 `batch_info`：

```python
batch_info = {
    "original_filename": ", ".join(
        session_files.get(k, {}).get("filename", "未知")
        for k in session_file_order
    ),
    "subject": subject,        # 前端传入
    "file_path": "",           # 可扩展
}
```

入库时创建 `upload_batches` 记录，关联所有该批次导入的题目，实现来源追溯。

### 知识点标签关联

题目入库时自动处理知识点标签：

1. 解析题目的 `knowledge_tags` 字段
2. 查询或创建 `knowledge_tags` 记录
3. 创建 `question_tag_mapping` 关联

```python
# crud.py 核心逻辑
for tag_name in question.get("knowledge_tags", []):
    tag = db.query(KnowledgeTag).filter_by(tag_name=tag_name, subject=subject).first()
    if not tag:
        tag = KnowledgeTag(tag_name=tag_name, subject=subject)
        db.add(tag)
    mapping = QuestionTagMapping(question_id=question_id, tag_id=tag.id)
    db.add(mapping)
```

### 自动建表

应用启动时自动建表：

```python
# backend/db/__init__.py
def init_db():
    from db.models import Base
    Base.metadata.create_all(bind=engine)
```

```python
# backend/web_app.py
if __name__ == '__main__':
    init_db()  # 启动时建表
    print("[数据库] 初始化完成")
```

特点：
- 使用 `create_all()` 创建不存在的表
- 已存在的表不会被修改（安全）
- 数据库文件路径由 `config.DB_PATH` 配置

### 版本升级与迁移

当前采用简单策略：

```python
Base.metadata.create_all(bind=engine)
```

**适用场景**：
- 新表创建：自动处理
- 表结构变更：需要手动迁移

**后续可扩展**：引入 Alembic 进行版本化迁移

```bash
# 初始化迁移环境
alembic init migrations

# 生成迁移脚本
alembic revision --autogenerate -m "add new column"

# 执行迁移
alembic upgrade head
```

---

## 文件变更

| 文件 | 变更 |
|------|------|
| `backend/web_app.py` | 统一配置导入，移除 `_resolve_dir`，简化导出逻辑，启动时初始化数据库 |
| `backend/src/utils.py` | 添加 `batch_info` 参数，导出时触发入库 |
| `backend/db/__init__.py` | 数据库引擎、Session 工厂、自动建表 |
| `backend/db/models.py` | ORM 模型定义（upload_batches, questions, knowledge_tags, question_tag_mapping） |
| `backend/db/crud.py` | CRUD 操作（去重、保存、标签关联） |
| `.gitignore` | 添加 `output/`、`backend/output/` 忽略 |
| `requirements.txt` | 添加 sqlalchemy 依赖 |

## 测试验证

- [x] 上传 PDF → 分割 → 导出，流程正常
- [x] 服务器重启后，可直接导出（不重新分割）
- [x] 路径配置统一，无冲突
- [x] 数据库自动建表
- [x] 题目入库去重（基于 content_hash）
- [x] 来源信息记录（upload_batches）
- [x] 知识点标签关联
