### PR TITLE
feat:实现错题库REST API端点

### DIFF
--- a/backend/db/crud.py
+++ b/backend/db/crud.py
@@ -5,7 +5,7 @@
 import hashlib
 import json
 from datetime import datetime
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Tuple
 
 from sqlalchemy.orm import Session
 from sqlalchemy import func
@@ -196,3 +196,134 @@ def get_statistics(db: Session) -> Dict[str, Any]:
         "total_tags": total_tags or 0,
         "by_subject": {s: c for s, c in subject_stats}
     }
+
+
+def get_history_questions(
+    db: Session,
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+    page: int = 1,
+    page_size: int = 20
+) -> Tuple[List[Question], int]:
+    """
+    分页查询历史题目（全部题目）
+
+    Args:
+        db: 数据库会话
+        start_date: 开始日期筛选
+        end_date: 结束日期筛选
+        page: 页码（从1开始）
+        page_size: 每页数量
+
+    Returns:
+        (题目列表, 总数)
+    """
+    query = db.query(Question).join(UploadBatch)
+
+    if start_date:
+        query = query.filter(UploadBatch.upload_time >= start_date)
+    if end_date:
+        query = query.filter(UploadBatch.upload_time <= end_date)
+
+    # 获取总数
+    total = query.count()
+
+    # 分页查询
+    offset = (page - 1) * page_size
+    questions = query.order_by(Question.created_at.desc()).offset(offset).limit(page_size).all()
+
+    return questions, total
+
+
+def search_questions(
+    db: Session,
+    keyword: Optional[str] = None,
+    knowledge_tag: Optional[str] = None,
+    question_type: Optional[str] = None,
+    page: int = 1,
+    page_size: int = 20
+) -> Tuple[List[Question], int]:
+    """
+    搜索题目（知识点/题型/关键字）
+
+    Args:
+        db: 数据库会话
+        keyword: 关键字搜索（匹配题目内容 content_json）
+        knowledge_tag: 知识点标签筛选
+        question_type: 题型筛选
+        page: 页码（从1开始）
+        page_size: 每页数量
+
+    Returns:
+        (题目列表, 总数)
+    """
+    query = db.query(Question)
+
+    # 关键字搜索：匹配 content_json 中的内容
+    if keyword:
+        query = query.filter(Question.content_json.ilike(f"%{keyword}%"))
+
+    # 题型筛选
+    if question_type:
+        query = query.filter(Question.question_type == question_type)
+
+    # 知识点标签筛选
+    if knowledge_tag:
+        query = query.join(QuestionTagMapping).join(KnowledgeTag).filter(
+            KnowledgeTag.tag_name == knowledge_tag
+        )
+
+    # 获取总数（需要先去除distinct，因为join可能产生重复）
+    total = query.distinct().count()
+
+    # 分页查询
+    offset = (page - 1) * page_size
+    questions = query.distinct().order_by(Question.created_at.desc()).offset(offset).limit(page_size).all()
+
+    return questions, total
+
+
+def get_knowledge_stats(db: Session) -> List[Dict]:
+    """
+    获取知识点统计信息
+
+    Returns:
+        [{"tag_name": "xxx", "count": 10}, ...]
+    """
+    stats = db.query(
+        KnowledgeTag.tag_name,
+        func.count(QuestionTagMapping.question_id).label("count")
+    ).join(
+        QuestionTagMapping, QuestionTagMapping.tag_id == KnowledgeTag.id
+    ).group_by(
+        KnowledgeTag.id, KnowledgeTag.tag_name
+    ).order_by(
+        func.count(QuestionTagMapping.question_id).desc()
+    ).all()
+
+    return [{"tag_name": tag_name, "count": count} for tag_name, count in stats]
+
+
+def delete_question(db: Session, question_id: int) -> bool:
+    """
+    删除题目
+
+    Args:
+        db: 数据库会话
+        question_id: 题目ID
+
+    Returns:
+        是否删除成功
+    """
+    question = db.query(Question).filter(Question.id == question_id).first()
+    if not question:
+        return False
+
+    # 删除关联的标签映射
+    db.query(QuestionTagMapping).filter(QuestionTagMapping.question_id == question_id).delete()
+
+    # 删除题目
+    db.delete(question)
+    db.commit()
+
+    return True

--- a/backend/web_app.py
+++ b/backend/web_app.py
@@ -8,6 +8,8 @@ import json
 import uuid
 import threading
 import mimetypes
+from datetime import datetime
+from typing import Optional
 
 # Windows 注册表可能将 .js 映射为 text/plain，导致浏览器拒绝加载 ES module
 mimetypes.add_type('application/javascript', '.js')
@@ -26,6 +28,8 @@ from config import (
     ALLOWED_EXTENSIONS,
 )
 from db import init_db
+from db import crud
+from db.models import Question, UploadBatch, KnowledgeTag
 
 # 加载环境变量
 load_dotenv()
@@ -552,6 +556,197 @@ def get_status():
             'success': False,
             'error': f'获取系统状态失败：{str(e)}'
         }), 500
+
+
+@app.route('/api/history', methods=['GET'])
+def get_history():
+    """
+    分页查询历史题目（全部题目，非仅错题）
+
+    Query参数:
+        page: 页码（默认1）
+        page_size: 每页数量（默认20）
+        start_date: 开始日期（可选，格式：YYYY-MM-DD）
+        end_date: 结束日期（可选，格式：YYYY-MM-DD）
+    """
+    from db import SessionLocal
+
+    try:
+        page = request.args.get('page', 1, type=int)
+        page_size = request.args.get('page_size', 20, type=int)
+        start_date_str = request.args.get('start_date')
+        end_date_str = request.args.get('end_date')
+
+        # 解析日期
+        start_date = None
+        end_date = None
+        if start_date_str:
+            start_date = datetime.strptime(start_date_str, '%Y-%m-%d')
+        if end_date_str:
+            end_date = datetime.strptime(end_date_str, '%Y-%m-%d')
+
+        db = SessionLocal()
+        try:
+            questions, total = crud.get_history_questions(
+                db,
+                start_date=start_date,
+                end_date=end_date,
+                page=page,
+                page_size=page_size
+            )
+
+            total_pages = (total + page_size - 1) // page_size
+
+            # 序列化题目
+            items = []
+            for q in questions:
+                items.append({
+                    'id': q.id,
+                    'question_type': q.question_type,
+                    'content_json': json.loads(q.content_json) if q.content_json else [],
+                    'options_json': json.loads(q.options_json) if q.options_json else None,
+                    'has_formula': q.has_formula,
+                    'has_image': q.has_image,
+                    'needs_correction': q.needs_correction,
+                    'created_at': q.created_at.isoformat() if q.created_at else None,
+                })
+
+            return jsonify({
+                'items': items,
+                'total': total,
+                'page': page,
+                'page_size': page_size,
+                'total_pages': total_pages
+            })
+        finally:
+            db.close()
+
+    except ValueError as e:
+        return jsonify({'success': False, 'error': f'日期格式错误：{str(e)}'}), 400
+    except Exception as e:
+        return jsonify({'success': False, 'error': f'查询失败：{str(e)}'}), 500
+
+
+@app.route('/api/search', methods=['GET'])
+def search_questions():
+    """
+    搜索题目（知识点/题型/关键字）
+
+    Query参数:
+        keyword: 关键字搜索（匹配题目内容）
+        knowledge_tag: 知识点标签筛选
+        question_type: 题型筛选
+        page: 页码（默认1）
+        page_size: 每页数量（默认20）
+    """
+    from db import SessionLocal
+
+    try:
+        page = request.args.get('page', 1, type=int)
+        page_size = request.args.get('page_size', 20, type=int)
+        keyword = request.args.get('keyword', type=str)
+        knowledge_tag = request.args.get('knowledge_tag', type=str)
+        question_type = request.args.get('question_type', type=str)
+
+        # 至少需要一个搜索条件
+        if not any([keyword, knowledge_tag, question_type]):
+            return jsonify({
+                'success': False,
+                'error': '至少需要提供一个搜索条件（keyword/knowledge_tag/question_type）'
+            }), 400
+
+        db = SessionLocal()
+        try:
+            questions, total = crud.search_questions(
+                db,
+                keyword=keyword if keyword else None,
+                knowledge_tag=knowledge_tag if knowledge_tag else None,
+                question_type=question_type if question_type else None,
+                page=page,
+                page_size=page_size
+            )
+
+            total_pages = (total + page_size - 1) // page_size
+
+            # 序列化题目
+            items = []
+            for q in questions:
+                items.append({
+                    'id': q.id,
+                    'question_type': q.question_type,
+                    'content_json': json.loads(q.content_json) if q.content_json else [],
+                    'options_json': json.loads(q.options_json) if q.options_json else None,
+                    'has_formula': q.has_formula,
+                    'has_image': q.has_image,
+                    'needs_correction': q.needs_correction,
+                    'created_at': q.created_at.isoformat() if q.created_at else None,
+                })
+
+            return jsonify({
+                'items': items,
+                'total': total,
+                'page': page,
+                'page_size': page_size,
+                'total_pages': total_pages
+            })
+        finally:
+            db.close()
+
+    except Exception as e:
+        return jsonify({'success': False, 'error': f'搜索失败：{str(e)}'}), 500
+
+
+@app.route('/api/stats', methods=['GET'])
+def get_stats():
+    """
+    获取知识点统计信息
+    """
+    from db import SessionLocal
+
+    try:
+        db = SessionLocal()
+        try:
+            stats = crud.get_knowledge_stats(db)
+            return jsonify({
+                'stats': stats,
+                'total_tags': len(stats)
+            })
+        finally:
+            db.close()
+
+    except Exception as e:
+        return jsonify({'success': False, 'error': f'获取统计失败：{str(e)}'}), 500
+
+
+@app.route('/api/question/<int:question_id>', methods=['DELETE'])
+def delete_question(question_id):
+    """
+    删除题目
+
+    Path参数:
+        question_id: 题目ID
+    """
+    from db import SessionLocal
+
+    try:
+        db = SessionLocal()
+        try:
+            success = crud.delete_question(db, question_id)
+            if success:
+                return jsonify({
+                    'success': True,
+                    'message': '题目已删除'
+                })
+            else:
+                return jsonify({
+                    'success': False,
+                    'error': '题目不存在'
+                }), 404
+        finally:
+            db.close()
+
+    except Exception as e:
+        return jsonify({'success': False, 'error': f'删除失败：{str(e)}'}), 500
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
新增功能:
- GET /api/history: 分页查询历史题目(全部),支持日期范围筛选
- GET /api/search: 关键字/知识点/题型搜索
- GET /api/stats: 知识点统计
- DELETE /api/question/{id}: 删除题目

本地测试:
<img width="774" height="517" alt="image" src="https://github.com/user-attachments/assets/1e1fb8d0-c676-46bc-bfce-0631923e4fe3" />

<img width="940" height="698" alt="image" src="https://github.com/user-attachments/assets/fc78432a-2c8f-4af3-bbaa-e2453f478918" />
