### PR TITLE
Fix/db  SQLite 只读错误返回详细错误信息

### DIFF
--- a/backend/web_app.py
+++ b/backend/web_app.py
@@ -1042,6 +1042,8 @@ def save_to_db():
 
     except Exception as e:
         logger.exception("导入错题库失败")
+        if 'readonly database' in str(e).lower():
+            return jsonify({'success': False, 'error': '数据库文件为只读，请检查文件权限（error_book.db）'}), 500
         return jsonify({'success': False, 'error': '导入错题库失败，请稍后重试'}), 500
 
 


### PR DESCRIPTION
## 变更内容

捕获 SQLite 只读错误，返回明确提示代替通用错误信息。

**之前**：导入错题库失败时前端只显示「导入错题库失败，请稍后重试」

**之后**：数据库文件权限不足时显示「数据库文件为只读，请检查文件权限（error_book.db）」

## 改动文件

- `backend/web_app.py`：`save_to_db` 异常处理中新增对 `readonly database` 的专项捕获

## 测试方式

- [x] 将 `runtime_data/error_book.db` 改为只读（`chmod 444`），尝试导入错题库，应看到明确的权限错误提示
- [x] 恢复正常权限（`chmod 644`），导入流程正常