### PR TITLE
feat(chat): AI 回复支持 Markdown 渲染，优化条形图间距

### DIFF
--- a/frontend/app.html
+++ b/frontend/app.html
@@ -38,6 +38,9 @@
     <!-- Chart.js -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 
+    <!-- marked (Markdown 解析) -->
+    <script src="https://cdn.jsdelivr.net/npm/marked@15/marked.min.js"></script>
+
     <!-- 预加载界面：像素猫掌机风格 -->
     <style>
       :root {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -170,8 +170,9 @@ export async function updateReviewStatus(questionId, reviewStatus) {
 }
 
 export async function fetchDashboardStats(subject) {
-  const qs = subject ? `?subject=${encodeURIComponent(subject)}` : ''
-  const resp = await fetch(`/api/dashboard-stats${qs}`)
+  const qs = new URLSearchParams()
+  if (subject) qs.set('subject', subject)
+  const resp = await fetch(`/api/dashboard-stats?${qs}`)
   if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
   const data = await resp.json()
   if (data && data.success) return data

--- a/frontend/src/components/ChatView.vue
+++ b/frontend/src/components/ChatView.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, computed, nextTick, onMounted, onBeforeUnmount, watch, inject } from 'vue'
 import { fetchMessages, streamChat } from '../api.js'
-import { getQuestionSnippet, sanitizeHtml, typesetMath } from '../utils.js'
+import { getQuestionSnippet, renderMarkdown, typesetMath } from '../utils.js'
 
 const PAGE_SIZE = 30
 
@@ -21,6 +21,7 @@ const messages = ref([])
 const inputText = ref('')
 const streaming = ref(false)
 const listEl = ref(null)
+const snippetEl = ref(null)
 const hasMore = ref(false)
 const loadingMore = ref(false)
 
@@ -154,10 +155,17 @@ const onKeydown = (e) => {
   }
 }
 
-onMounted(loadHistory)
+onMounted(() => {
+  loadHistory()
+  typesetMath(snippetEl.value)
+})
 watch(() => props.sessionId, () => {
   abortCtrl?.abort()
   loadHistory()
+})
+watch(snippet, async () => {
+  await nextTick()
+  typesetMath(snippetEl.value)
 })
 onBeforeUnmount(() => {
   abortCtrl?.abort()
@@ -180,7 +188,7 @@ onBeforeUnmount(() => {
       </button>
 
       <div class="min-w-0 flex-1">
-        <p class="truncate text-sm font-bold text-slate-800 dark:text-slate-200">
+        <p ref="snippetEl" class="truncate text-sm font-bold text-slate-800 dark:text-slate-200">
           {{ snippet }}
         </p>
         <div class="mt-0.5 flex items-center gap-2">
@@ -260,7 +268,7 @@ onBeforeUnmount(() => {
                 : 'border border-slate-200/60 bg-white text-slate-800 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-200'
             "
           >
-            <div v-if="msg.role === 'assistant'" class="chat-content whitespace-pre-wrap" v-html="sanitizeHtml(msg.content)"></div>
+            <div v-if="msg.role === 'assistant'" class="chat-content whitespace-pre-wrap" v-html="renderMarkdown(msg.content)"></div>
             <div v-else class="whitespace-pre-wrap">{{ msg.content }}</div>
 
             <!-- 流式加载指示器 -->

--- a/frontend/src/components/ChatView.vue
+++ b/frontend/src/components/ChatView.vue
@@ -25,7 +25,7 @@ const snippetEl = ref(null)
 const hasMore = ref(false)
 const loadingMore = ref(false)
 
-const snippet = computed(() => getQuestionSnippet(props.question, 50, '未知题目'))
+const snippet = computed(() => getQuestionSnippet(props.question, 0, '未知题目'))
 
 let abortCtrl = null
 let scrollRafId = null

--- a/frontend/src/components/ChatView.vue
+++ b/frontend/src/components/ChatView.vue
@@ -29,6 +29,11 @@ const snippet = computed(() => getQuestionSnippet(props.question, 0, '未知题�
 
 let abortCtrl = null
 let scrollRafId = null
+const mdCache = new Map()
+const cachedRenderMarkdown = (text) => {
+  if (!mdCache.has(text)) mdCache.set(text, renderMarkdown(text))
+  return mdCache.get(text)
+}
 const scrollToBottom = async () => {
   await nextTick()
   if (scrollRafId) return
@@ -155,12 +160,10 @@ const onKeydown = (e) => {
   }
 }
 
-onMounted(() => {
-  loadHistory()
-  typesetMath(snippetEl.value)
-})
+onMounted(loadHistory)
 watch(() => props.sessionId, () => {
   abortCtrl?.abort()
+  mdCache.clear()
   loadHistory()
 })
 watch(snippet, async () => {
@@ -268,7 +271,7 @@ onBeforeUnmount(() => {
                 : 'border border-slate-200/60 bg-white text-slate-800 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-200'
             "
           >
-            <div v-if="msg.role === 'assistant'" class="chat-content whitespace-pre-wrap" v-html="renderMarkdown(msg.content)"></div>
+            <div v-if="msg.role === 'assistant'" class="chat-content whitespace-pre-wrap" v-html="cachedRenderMarkdown(msg.content)"></div>
             <div v-else class="whitespace-pre-wrap">{{ msg.content }}</div>
 
             <!-- 流式加载指示器 -->

--- a/frontend/src/components/Dashboard.vue
+++ b/frontend/src/components/Dashboard.vue
@@ -166,8 +166,9 @@ const initBarChart = (isDark, textColor, gridColor) => {
         backgroundColor: colors.map(c => c + '99'),
         borderColor: colors,
         borderWidth: 1,
-        borderRadius: 4,
-        barThickness: 22,
+        borderRadius: 2,
+        barPercentage: 0.85,
+        categoryPercentage: 1.0,
       }]
     },
     options: {

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -30,6 +30,22 @@ export const getQuestionSnippet = (q, maxLen = 0, fallback = '') => {
   return raw
 }
 
+/** 将 Markdown 文本渲染为净化后的 HTML（用于聊天消息） */
+export const renderMarkdown = (text) => {
+  if (!text) return ''
+  const parse = window.marked?.parse ?? ((s) => s)
+  const html = parse(text, { breaks: true })
+  return DOMPurify.sanitize(html, {
+    ALLOWED_TAGS: [
+      ...ALLOWED_HTML_TAGS,
+      'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+      'ul', 'ol', 'li', 'code', 'pre', 'blockquote', 'hr',
+      'a',
+    ],
+    ALLOWED_ATTR: ['href', 'target', 'rel'],
+  })
+}
+
 /** 对指定元素触发 MathJax 公式渲染 */
 export const typesetMath = async (el) => {
   const mj = window.MathJax


### PR DESCRIPTION
- 引入 marked.js CDN，新增 renderMarkdown() 工具函数（DOMPurify 净化）
- ChatView 中 AI 消息改用 renderMarkdown 渲染，支持标题/列表/代码块/引用
- 修复题目摘要区域数学公式未触发 typesetMath 的问题
- Dashboard 条形图 barPercentage 调整，条形变细、间距更清晰