### PR TITLE
fix(math): 修复首页及 AI 辅导页面 LaTeX 公式未渲染的问题

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,6 +20,15 @@
             }
         }
     </script>
+    <!-- MathJax（效果演示区 LaTeX 公式渲染） -->
+    <script>
+      MathJax = {
+        tex: { inlineMath: [['$', '$']], displayMath: [['$$', '$$']] },
+        svg: { fontCache: 'global' }
+      };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js" async></script>
+
     <!-- 引入 Lucide 图标库 -->
     <!--
       外部 CDN 依赖说明 & 离线降级策略

--- a/frontend/src/components/ChatView.vue
+++ b/frontend/src/components/ChatView.vue
@@ -51,6 +51,8 @@ const loadHistory = async () => {
     messages.value = data.messages.map(toMsg)
     hasMore.value = data.hasMore
     scrollToBottom()
+    await nextTick()
+    await typesetMath(listEl.value)
   } catch (e) {
     pushToast('error', '加载对话历史失败')
   }
@@ -81,6 +83,7 @@ const loadOlder = async () => {
     if (el) {
       el.scrollTop = el.scrollHeight - prevHeight
     }
+    await typesetMath(listEl.value)
   } catch (e) {
     pushToast('error', '加载更早消息失败')
   }
@@ -161,7 +164,11 @@ const onKeydown = (e) => {
   }
 }
 
-onMounted(loadHistory)
+onMounted(async () => {
+  await loadHistory()
+  await nextTick()
+  typesetMath(snippetEl.value)
+})
 watch(() => props.sessionId, () => {
   abortCtrl?.abort()
   mdCache.clear()
@@ -192,9 +199,8 @@ onBeforeUnmount(() => {
       </button>
 
       <div class="min-w-0 flex-1">
-        <p ref="snippetEl" class="truncate text-sm font-bold text-slate-800 dark:text-slate-200">
-          {{ snippet }}
-        </p>
+        <p ref="snippetEl" class="truncate text-sm font-bold text-slate-800 dark:text-slate-200"
+           v-html="snippet"></p>
         <div class="mt-0.5 flex items-center gap-2">
           <span
             v-if="question?.subject"

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -46,12 +46,30 @@ export const renderMarkdown = (text) => {
   })
 }
 
+/** 等待 MathJax 加载就绪（最多等 10 秒） */
+const waitForMathJax = () => new Promise((resolve) => {
+  const mj = window.MathJax
+  if (mj && typeof mj.typesetPromise === 'function') return resolve(mj)
+  let tries = 0
+  const timer = setInterval(() => {
+    const mj = window.MathJax
+    if (mj && typeof mj.typesetPromise === 'function') {
+      clearInterval(timer)
+      resolve(mj)
+    } else if (++tries > 100) {
+      clearInterval(timer)
+      resolve(null)
+    }
+  }, 100)
+})
+
 /** 对指定元素触发 MathJax 公式渲染 */
 export const typesetMath = async (el) => {
-  const mj = window.MathJax
-  if (!mj || typeof mj.typesetPromise !== 'function') return
+  const mj = await waitForMathJax()
+  if (!mj) return
   try {
     if (el) {
+      mj.typesetClear?.([el])
       await mj.typesetPromise([el])
     } else {
       await mj.typesetPromise()


### PR DESCRIPTION
变更内容
- fix: 首页 index.html 添加 MathJax CDN 引用 效果演示区的 LaTeX 公式（如 $f(x) = 2\sin(\omega x + \varphi)$） 现在能正确渲染为数学符号
- fix: ChatView 标题改用 v-html 渲染，支持 MathJax 排版
- fix: onMounted 时对标题元素调用 typesetMath， 解决首次渲染不触发 watch 的问题
- fix: 加载对话历史和更早消息后补充 typesetMath 调用
- fix: utils.js typesetMath 增加 waitForMathJax 等待机制， 解决 CDN async 加载时 MathJax 未就绪导致排版跳过的问题
- fix: typesetMath 调用前先 typesetClear 清除缓存， 避免对已排版元素重复调用时被跳过

测试清单
 □ 首页效果演示区 LaTeX 公式正确渲染为数学符号
 □ AI 辅导页面标题中含 LaTeX 公式时正确渲染
 □ 加载对话历史后消息中的公式正确渲染
 □ 分割历史展开详情后公式正确渲染
 □ 浅色/深色模式下公式显示正常