### PR TITLE
fix(ui): 修复题目卡片中表格数据不渲染的问题

### DIFF
--- a/backend/error_correction_agent/prompts.py
+++ b/backend/error_correction_agent/prompts.py
@@ -44,6 +44,10 @@ SPLIT_PROMPT_LITE = """# 试卷题目分割
 
 行内公式 $...$，独占行 $$...$$，嵌入 text 类型的 content 中。
 
+## 表格处理
+
+内容含表格数据时，转为 HTML 放入 text 块：`<table><thead><tr><th>...</th></tr></thead><tbody><tr><td>...</td></tr></tbody></table>`，单元格内公式仍用 LaTeX。
+
 ## OCR 变量下标还原
 
 OCR 常丢失下标：xi → $x_i$，an → $a_n$，Sn → $S_n$。请在数学语境中还原。
@@ -199,6 +203,14 @@ SPLIT_PROMPT = """# 错题本题目分割专家
    - 对于选择题，如果你已经把选项提取到 `options` 数组中，则必须从 `content_blocks` 的文本中移除选项部分
    - `content_blocks` 只保留题干（题目正文），不包含选项文本
    - 例如原始文本为 "下列说法正确的是（）\\nA. xxx B. yyy"，则 content_blocks 中的 text 只保留 "下列说法正确的是（）"，选项 "A. xxx"、"B. yyy" 放入 options 数组
+
+8. **表格处理（重要）**
+   - 如果题目内容中包含表格数据（如实验数据、统计数据、对比数据），必须将其转换为 HTML 表格
+   - 使用如下结构，放入 `text` 类型的 content_block：
+     `<table><thead><tr><th>列1</th><th>列2</th></tr></thead><tbody><tr><td>值1</td><td>值2</td></tr></tbody></table>`
+   - 表格单元格内的公式仍然用 LaTeX 标记（如 `<td>$x_i$</td>`）
+   - 每行数据对应一个 `<tr>`，表头行放在 `<thead>` 中，数据行放在 `<tbody>` 中
+   - 例如：试验序号/伸缩率数据应输出为包含 `<table>` 的 HTML 字符串，而不是纯文本
 
 ## 示例
 

--- a/frontend/src/components/QuestionCard.vue
+++ b/frontend/src/components/QuestionCard.vue
@@ -174,3 +174,16 @@ const cancelUserAnswer = () => { editingUserAnswer.value = false }
     </div>
   </div>
 </template>
+
+<style>
+.question-content table {
+  @apply my-4 w-full border-collapse text-sm;
+}
+.question-content th,
+.question-content td {
+  @apply border border-slate-200 px-3 py-2 text-center dark:border-white/10;
+}
+.question-content th {
+  @apply bg-slate-50 font-bold dark:bg-white/[0.04];
+}
+</style>


### PR DESCRIPTION
## 问题描述

题目内容中包含表格数据（如实验序号、伸缩率对比等统计数据）时，前端将其渲染为纯文本，表格结构完全丢失，可读性差。

**根本原因**：
- LLM 分割提示词未要求将表格数据输出为 HTML，导致 LLM 以纯文本输出表格行
- 前端 `isHtml()` 检测不到 `<table>` 标签，降级为纯文本渲染
- `QuestionCard` 组件缺少表格 CSS 样式

## 改动内容

### `backend/error_correction_agent/prompts.py`
- `SPLIT_PROMPT`：新增第 8 条注意事项「表格处理」，要求 LLM 检测到表格数据时输出 `<table><thead>…</thead><tbody>…</tbody></table>` HTML 结构，放入 `text` 类型的 content_block，单元格内公式仍用 LaTeX
- `SPLIT_PROMPT_LITE`：同步新增「表格处理」章节

### `frontend/src/components/QuestionCard.vue`
- 新增 `<style>` 块，使用 `@apply` 为 `.question-content` 内的 `table / th / td` 设置 Tailwind 样式
- 支持亮色模式（`border-slate-200`、`bg-slate-50`）和暗色模式（`dark:border-white/10`、`dark:bg-white/[0.04]`）

## 测试说明

- [x] 重新上传含表格数据的试卷，确认分割后表格以 HTML 形式存入 content_blocks
- [x] 亮色模式下表格正常渲染，表头有浅灰背景
- [x] 暗色模式下表头背景不过亮，边框颜色与卡片风格一致
- [x] 已有纯文本格式的旧数据不受影响（`isHtml` 返回 false 时降级为文本渲染）