### PR TITLE
fix(ui): 恢复 AI 分割任务的全屏 loading 遮罩动画

### DIFF
--- a/frontend/src/components/SplitLoading.vue
+++ b/frontend/src/components/SplitLoading.vue
@@ -1,0 +1,249 @@
+<script setup>
+// AI 现代化扫描处理动画
+</script>
+
+<template>
+  <Transition name="fade">
+    <div class="loading-overlay">
+      <div class="loading-content">
+        <!-- 核心扫描动画区 -->
+        <div class="scanner-container">
+          <!-- 背景光晕 -->
+          <div class="scanner-glow"></div>
+
+          <!-- 旋转轨道 -->
+          <div class="orbit orbit-1"></div>
+          <div class="orbit orbit-2"></div>
+          <div class="orbit orbit-3"></div>
+
+          <!-- 核心图标 -->
+          <div class="core-icon">
+            <i class="fa-solid fa-brain"></i>
+            <!-- 核心脉冲 -->
+            <div class="core-pulse"></div>
+          </div>
+
+          <!-- 扫描线 -->
+          <div class="scan-line"></div>
+        </div>
+
+        <!-- 文本引导 -->
+        <div class="text-container">
+          <h3 class="status-title">AI 正在深度解析</h3>
+          <p class="status-subtitle">正在识别题目结构、提取知识点并构建图谱</p>
+
+          <!-- 模拟进度条 -->
+          <div class="progress-container">
+            <div class="progress-bar">
+              <div class="progress-glow"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.loading-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.4);
+  backdrop-filter: blur(12px);
+}
+
+:root.dark .loading-overlay {
+  background: rgba(10, 10, 15, 0.6);
+}
+
+.loading-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3rem;
+}
+
+/* --- 核心动画容器 --- */
+.scanner-container {
+  position: relative;
+  width: 160px;
+  height: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.scanner-glow {
+  position: absolute;
+  width: 120%;
+  height: 120%;
+  background: radial-gradient(circle, rgba(59, 130, 246, 0.15) 0%, transparent 70%);
+  filter: blur(20px);
+  animation: breathe 4s ease-in-out infinite;
+}
+
+/* 旋转轨道 */
+.orbit {
+  position: absolute;
+  border-radius: 50%;
+  border: 1.5px solid rgba(59, 130, 246, 0.1);
+  border-top-color: rgba(59, 130, 246, 0.5);
+}
+
+.orbit-1 {
+  width: 100%;
+  height: 100%;
+  animation: rotate 8s linear infinite;
+}
+
+.orbit-2 {
+  width: 75%;
+  height: 75%;
+  animation: rotate 5s linear infinite reverse;
+  border-top-color: rgba(99, 102, 241, 0.5);
+}
+
+.orbit-3 {
+  width: 50%;
+  height: 50%;
+  animation: rotate 3s linear infinite;
+  border-top-color: rgba(139, 92, 246, 0.5);
+}
+
+/* 核心图标 */
+.core-icon {
+  position: relative;
+  z-index: 10;
+  width: 56px;
+  height: 56px;
+  background: white;
+  border-radius: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 10px 25px rgba(59, 130, 246, 0.2);
+  color: #2563eb;
+  font-size: 1.5rem;
+}
+
+:root.dark .core-icon {
+  background: #1e1e2e;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+  color: #818cf8;
+}
+
+.core-pulse {
+  position: absolute;
+  inset: -4px;
+  border-radius: 1.25rem;
+  background: rgba(59, 130, 246, 0.2);
+  animation: pulse 2s ease-out infinite;
+}
+
+/* 扫描线 */
+.scan-line {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, rgba(59, 130, 246, 0.8), transparent);
+  box-shadow: 0 0 15px rgba(59, 130, 246, 0.5);
+  z-index: 5;
+  animation: scan 3s ease-in-out infinite;
+}
+
+/* --- 文本容器 --- */
+.text-container {
+  text-align: center;
+  max-width: 300px;
+}
+
+.status-title {
+  font-size: 1.125rem;
+  font-weight: 900;
+  color: #0f172a;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+
+:root.dark .status-title {
+  color: white;
+}
+
+.status-subtitle {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #64748b;
+  line-height: 1.5;
+}
+
+/* --- 进度条 --- */
+.progress-container {
+  margin-top: 1.5rem;
+  width: 100%;
+  height: 4px;
+  background: rgba(59, 130, 246, 0.05);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.progress-bar {
+  width: 40%;
+  height: 100%;
+  background: linear-gradient(90deg, #2563eb, #818cf8);
+  border-radius: 10px;
+  position: relative;
+  animation: progress-move 2.5s ease-in-out infinite;
+}
+
+.progress-glow {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: 20px;
+  background: white;
+  filter: blur(4px);
+  opacity: 0.5;
+}
+
+/* --- 关键帧 --- */
+@keyframes rotate {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes breathe {
+  0%, 100% { opacity: 0.5; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.1); }
+}
+
+@keyframes pulse {
+  0% { transform: scale(0.95); opacity: 0.8; }
+  100% { transform: scale(1.4); opacity: 0; }
+}
+
+@keyframes scan {
+  0%, 100% { top: 0; opacity: 0; }
+  20%, 80% { opacity: 1; }
+  50% { top: 100%; }
+}
+
+@keyframes progress-move {
+  0% { transform: translateX(-100%); }
+  50% { transform: translateX(150%); }
+  100% { transform: translateX(-100%); }
+}
+
+/* --- Transition --- */
+.fade-enter-active, .fade-leave-active {
+  transition: opacity 0.4s ease;
+}
+.fade-enter-from, .fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -11,6 +11,7 @@ import FileList from '../components/FileList.vue'
 import FileUploader from '../components/FileUploader.vue'
 import QuestionList from '../components/QuestionList.vue'
 import ActionBar from '../components/ActionBar.vue'
+import SplitLoading from '../components/SplitLoading.vue'
 import ImageModal from '../components/ImageModal.vue'
 import ToastContainer from '../components/ToastContainer.vue'
 import Dashboard from '../components/Dashboard.vue'
@@ -790,6 +791,7 @@ onBeforeUnmount(() => {
                   :split-completed="splitCompleted"
                   @split="doSplit"
                 />
+
               </div>
             </div>
 
@@ -842,6 +844,9 @@ onBeforeUnmount(() => {
             </div>
           </Transition>
         </div>
+
+        <!-- AI 分割任务全局遮罩 -->
+        <SplitLoading v-if="splitting" />
       </div>
       </Transition>
 


### PR DESCRIPTION
## Summary
- 恢复在 `56728bd` 中被误删的 AI 分割 loading 遮罩组件，重命名为 `SplitLoading.vue`
- 将遮罩挂载到工作台外层 `relative` 容器，确保覆盖整个工作区（不含侧边栏）
- 修复切换页面再返回时遮罩延迟渲染的问题

## Test plan
- [x] 上传文件后点击「开始智能分割」，确认全屏 loading 遮罩正常显示（大脑图标 + 旋转轨道 + 扫描线 + 进度条）
- [x] 分割过程中切换到其他页面再切回，确认遮罩立即全屏覆盖，无延迟
- [x] 分割完成后确认遮罩正常消失