### PR TITLE
feat(settings): API Provider 配置迁移到数据库，移除环境变量依赖

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,47 +1,24 @@
 # ============================================================================
-# Flask Session Secret Key
+# Flask 会话密钥（必须配置）
 # ============================================================================
 SECRET_KEY=your-random-secret-key-change-this
 
 # ============================================================================
-# LangSmith Configuration
+# LangSmith 配置（可选，用于调试追踪）
 # ============================================================================
-LANGSMITH_TRACING=true
-LANGSMITH_ENDPOINT=https://api.smith.langchain.com
-LANGSMITH_API_KEY=your_langsmith_api_key_here
-LANGSMITH_PROJECT="error-correction"
+LANGSMITH_TRACING=false
+# LANGSMITH_ENDPOINT=https://api.smith.langchain.com
+# LANGSMITH_API_KEY=你的_langsmith_api_key
+# LANGSMITH_PROJECT="error-correction"
 
 # ============================================================================
-# OpenAI 兼容 API（支持 OpenAI / DeepSeek / Qwen / Moonshot 等）
-# 通过 OPENAI_BASE_URL 切换不同供应商
+# 输出目录配置（可选）
 # ============================================================================
-OPENAI_API_KEY=your_openai_api_key_here
-# OPENAI_BASE_URL=https://api.deepseek.com          # 留空则使用 OpenAI 官方
-# OPENAI_MODEL_NAME=gpt-4o-mini                     # 默认模型
-# OPENAI_LIGHT_MODEL_NAME=gpt-4o-mini               # 轻量模型（科目识别等，可选）
-# OPENAI_SUPPORTS_FUNCTION_CALLING=true              # 文心一言等不支持 function calling 的供应商需设为 false
-
-# ============================================================================
-# Anthropic API
-# ============================================================================
-# ANTHROPIC_API_KEY=your_anthropic_api_key_here
-# ANTHROPIC_BASE_URL=                                # 留空则使用 Anthropic 官方
-# ANTHROPIC_MODEL_NAME=claude-sonnet-4-20250514      # 默认模型
-
-# ============================================================================
-# PaddleOCR API Configuration
-# ============================================================================
-PADDLEOCR_API_URL=https://paddleocr.aistudio-app.com/api/v2/ocr/jobs
-PADDLEOCR_API_TOKEN=your_paddleocr_api_token_here
-PADDLEOCR_MODEL=PaddleOCR-VL-1.5
-# PaddleOCR Feature Toggles
-PADDLEOCR_USE_DOC_ORIENTATION=false
-PADDLEOCR_USE_DOC_UNWARPING=false
-PADDLEOCR_USE_CHART_RECOGNITION=false
-
-# ============================================================================
-# Output Directory Configuration
-# ============================================================================
-# The directory configuration is centrally managed by config.py (default: backend/runtime_data/)
-# To override the root directory for runtime outputs, set APP_RUNTIME_DIR (absolute path)
+# 目录配置由 config.py 集中管理（默认：backend/runtime_data/）
+# 如需覆盖运行时输出的根目录，请设置 APP_RUNTIME_DIR（绝对路径）
 # APP_RUNTIME_DIR=
+
+# ============================================================================
+# 注意：API Provider 配置（OpenAI / Anthropic / PaddleOCR）已迁移到数据库，
+# 每个用户在系统设置页面独立管理自己的 API Key 和供应商配置。
+# ============================================================================

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,12 @@
+# TODO
+
+## 用户级 API Key 存储
+
+每个用户独立配置自己的 LLM API Key（AES-256 加密存 DB），替代系统全局 .env 配置。
+
+- [ ] DB：用户表新增加密 api_key 字段（per provider）
+- [ ] 后端：加解密工具函数（AES-256，密钥从 .env 读取）
+- [ ] 后端：设置接口（POST 保存 / DELETE 删除 / GET 状态查询，不返回明文）
+- [ ] 后端：调用 LLM 时优先使用用户 key，fallback 到系统全局 key
+- [ ] 前端：设置页 API Key 管理 UI（输入、保存、删除、状态显示）
+- [ ] .env.example：新增 API_KEY_ENCRYPTION_SECRET 配置项

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import re
 import threading
 import time
 from pathlib import Path
@@ -25,8 +24,7 @@ _ENV_FILE = _PROJECT_ROOT / ".env"
 class LLMProviderConfig(BaseSettings):
     """单个 LLM 供应商配置基类
 
-    字段名匹配环境变量后缀（如 OPENAI_API_KEY → api_key），
-    由子类通过 env_prefix 绑定具体前缀。
+    凭据通过 load_providers_from_db() 从数据库注入。
     子类实现 create_llm() 工厂方法以创建对应的 LangChain Chat 模型。
     """
     model_config = SettingsConfigDict(extra="ignore")
@@ -115,7 +113,7 @@ class LLMProviderConfig(BaseSettings):
 
 class OpenAICompatibleConfig(LLMProviderConfig):
     """OpenAI 兼容接口供应商（DeepSeek、Qwen、Moonshot 等均可通过 base_url 接入）"""
-    model_config = SettingsConfigDict(env_prefix="OPENAI_", env_file=_ENV_FILE, extra="ignore")
+    model_config = SettingsConfigDict(extra="ignore")
     model_name: str = "gpt-4o-mini"
 
     def _create_raw_client(self, timeout: int = 10):
@@ -132,7 +130,7 @@ class OpenAICompatibleConfig(LLMProviderConfig):
 
 class AnthropicCompatibleConfig(LLMProviderConfig):
     """Anthropic 接口供应商"""
-    model_config = SettingsConfigDict(env_prefix="ANTHROPIC_", env_file=_ENV_FILE, extra="ignore")
+    model_config = SettingsConfigDict(extra="ignore")
     model_name: str = "claude-sonnet-4-20250514"
 
     def _create_raw_client(self, timeout: int = 10):
@@ -227,19 +225,43 @@ class Settings(BaseSettings):
             return self._normalize_provider(name) in self.llm_providers
 
     def reload_providers(self) -> None:
-        """热重载 LLM 供应商配置（从更新后的环境变量重新读取）
+        """重置 LLM 供应商配置为空（清除缓存）
 
-        就地替换 llm_providers 字典值，保持 settings 对象引用不变。
-        同时清除 agent 缓存和连接缓存。
+        调用后需通过 load_providers_from_db() 重新加载用户凭据。
         """
-        new_openai = OpenAICompatibleConfig()
-        new_anthropic = AnthropicCompatibleConfig()
-
         with _providers_lock:
-            self.llm_providers["openai"] = new_openai
-            self.llm_providers["anthropic"] = new_anthropic
+            self.llm_providers["openai"] = OpenAICompatibleConfig()
+            self.llm_providers["anthropic"] = AnthropicCompatibleConfig()
 
-        # 清除 agent 缓存
+        self._clear_agent_cache()
+
+    def load_providers_from_db(self, user_id: int) -> None:
+        """从数据库加载用户的 LLM provider 配置，注入到 settings 中
+
+        在请求入口调用，使整个下游链路（init_model / agent 等）
+        自动使用数据库中的凭据，无需逐层传参。
+        """
+        from db import SessionLocal
+        from db.crud import get_active_provider
+
+        with SessionLocal() as db:
+            for category, ConfigClass in [("openai", OpenAICompatibleConfig), ("anthropic", AnthropicCompatibleConfig)]:
+                provider = get_active_provider(db, user_id, category)
+                if provider and provider.api_key:
+                    cfg = ConfigClass(
+                        api_key=provider.api_key,
+                        base_url=provider.base_url or "",
+                        model_name=provider.model_name or ConfigClass.model_fields["model_name"].default,
+                        light_model_name=provider.light_model_name or None,
+                        supports_function_calling=provider.supports_function_calling if hasattr(provider, 'supports_function_calling') else True,
+                    )
+                    with _providers_lock:
+                        self.llm_providers[category] = cfg
+
+        self._clear_agent_cache()
+
+    def _clear_agent_cache(self):
+        """清除 agent 缓存"""
         try:
             from error_correction_agent.agent import _agent_cache, _agent_cache_lock
             with _agent_cache_lock:
@@ -247,112 +269,6 @@ class Settings(BaseSettings):
         except ImportError:
             pass
 
-    def get_config_for_ui(self) -> dict:
-        """返回可编辑配置项（API key 脱敏），供前端设置界面使用"""
-        openai_cfg = self.llm_providers["openai"]
-        anthropic_cfg = self.llm_providers["anthropic"]
-
-        return {
-            "openai": {
-                "api_key_set": bool(openai_cfg.api_key),
-                "api_key_hint": _mask_secret(openai_cfg.api_key),
-                "base_url": openai_cfg.base_url or "",
-                "model_name": openai_cfg.model_name or "",
-                "light_model_name": openai_cfg.light_model_name or "",
-                "supports_function_calling": openai_cfg.supports_function_calling,
-            },
-            "anthropic": {
-                "api_key_set": bool(anthropic_cfg.api_key),
-                "api_key_hint": _mask_secret(anthropic_cfg.api_key),
-                "base_url": anthropic_cfg.base_url or "",
-                "model_name": anthropic_cfg.model_name or "",
-            },
-            "paddleocr": {
-                "api_url": os.getenv("PADDLEOCR_API_URL", ""),
-                "api_token_set": bool(os.getenv("PADDLEOCR_API_TOKEN")),
-                "api_token_hint": _mask_secret(os.getenv("PADDLEOCR_API_TOKEN", "")),
-                "model": os.getenv("PADDLEOCR_MODEL", "PaddleOCR-VL-1.5"),
-                "use_doc_orientation": os.getenv("PADDLEOCR_USE_DOC_ORIENTATION", "false").lower() == "true",
-                "use_doc_unwarping": os.getenv("PADDLEOCR_USE_DOC_UNWARPING", "false").lower() == "true",
-                "use_chart_recognition": os.getenv("PADDLEOCR_USE_CHART_RECOGNITION", "false").lower() == "true",
-            },
-        }
-
-    def get_available_models(self) -> list[dict]:
-        """返回可用模型列表，供 /api/status 等接口使用（含连通性检测 + 模型列表）"""
-        from concurrent.futures import ThreadPoolExecutor
-
-        items = list(self.llm_providers.items())
-
-        def _check_and_list(kv):
-            key, cfg = kv
-            status = cfg.check_connection()
-            models = cfg.list_models() if status == "配置成功" else []
-            return status, models
-
-        with ThreadPoolExecutor(max_workers=len(items)) as pool:
-            results = list(pool.map(_check_and_list, items))
-
-        provider_labels = {"openai": "OpenAI", "anthropic": "Anthropic"}
-
-        return [
-            {
-                "value": key,
-                "label": provider_labels.get(key, key),
-                "configured": status == "配置成功",
-                "status": status or "未配置",
-                "default_model": cfg.model_name,
-                "models": models if models else [cfg.model_name],
-            }
-            for (key, cfg), (status, models) in zip(items, results)
-        ]
-
-
-def _mask_secret(value: str, visible: int = 4) -> str:
-    """脱敏显示密钥：仅保留末尾几位"""
-    if not value:
-        return ""
-    if len(value) <= visible:
-        return "*" * len(value)
-    return "*" * 4 + value[-visible:]
-
-
-_env_file_lock = threading.Lock()
-
-
-def update_env_file(updates: dict[str, str]) -> None:
-    """安全写入 .env 文件
-
-    读取现有内容 → 按行匹配 KEY= 替换 → 不存在的键追加 → 写回文件。
-    写入后调用 load_dotenv(override=True) 刷新 os.environ。
-    使用锁保护并发写入。
-    """
-    from dotenv import load_dotenv
-
-    env_path = _ENV_FILE
-    with _env_file_lock:
-        lines = []
-        if env_path.exists():
-            lines = env_path.read_text(encoding="utf-8").splitlines(keepends=True)
-
-        remaining = dict(updates)
-
-        new_lines = []
-        for line in lines:
-            stripped = line.strip()
-            match = re.match(r'^#?\s*([A-Z_][A-Z0-9_]*)=', stripped)
-            if match and match.group(1) in remaining:
-                key = match.group(1)
-                val = remaining.pop(key)
-                new_lines.append(f"{key}={val}\n")
-            else:
-                new_lines.append(line if line.endswith("\n") else line + "\n")
-
-        for key, val in remaining.items():
-            new_lines.append(f"{key}={val}\n")
-
-        env_path.write_text("".join(new_lines), encoding="utf-8")
-        load_dotenv(env_path, override=True)
 
 
 settings = Settings()

--- a/backend/db/crud.py
+++ b/backend/db/crud.py
@@ -14,7 +14,7 @@ from sqlalchemy import func
 
 logger = logging.getLogger(__name__)
 
-from db.models import UploadBatch, Question, KnowledgeTag, QuestionTagMapping, ChatSession, ChatMessage, SplitRecord, User
+from db.models import UploadBatch, Question, KnowledgeTag, QuestionTagMapping, ChatSession, ChatMessage, SplitRecord, User, ProviderConfig
 
 
 def _filter_by_subject(query, subject: Optional[str]):
@@ -941,3 +941,162 @@ def get_all_chat_sessions(
         .all()
     )
     return sessions, total
+
+
+# ── Provider Config CRUD ──────────────────────────────────────
+
+
+def _mask_secret(value: str, visible: int = 4) -> str:
+    """脱敏显示密钥"""
+    if not value:
+        return ""
+    if len(value) <= visible:
+        return "*" * len(value)
+    return "*" * 4 + value[-visible:]
+
+
+def _serialize_provider(p: ProviderConfig) -> dict:
+    """序列化 ProviderConfig 为前端可用 dict（密钥脱敏）"""
+    d = {
+        "id": p.id,
+        "name": p.name,
+        "is_active": p.is_active,
+        "api_key_set": bool(p.api_key),
+        "api_key_hint": _mask_secret(p.api_key),
+        "base_url": p.base_url or "",
+        "model_name": p.model_name or "",
+    }
+    if p.category == "openai":
+        d["light_model_name"] = p.light_model_name or ""
+        d["supports_function_calling"] = p.supports_function_calling
+    elif p.category == "paddleocr":
+        d["use_doc_orientation"] = p.use_doc_orientation
+        d["use_doc_unwarping"] = p.use_doc_unwarping
+        d["use_chart_recognition"] = p.use_chart_recognition
+    return d
+
+
+def get_user_providers(db: Session, user_id: int) -> dict:
+    """获取用户的所有 provider 配置，按类别分组返回"""
+    providers = db.query(ProviderConfig).filter(
+        ProviderConfig.user_id == user_id
+    ).order_by(ProviderConfig.created_at).all()
+
+    result = {
+        "openai_providers": [],
+        "anthropic_providers": [],
+        "paddleocr_providers": [],
+        "active_openai_id": None,
+        "active_anthropic_id": None,
+        "active_paddleocr_id": None,
+    }
+    category_key = {
+        "openai": "openai_providers",
+        "anthropic": "anthropic_providers",
+        "paddleocr": "paddleocr_providers",
+    }
+    active_key = {
+        "openai": "active_openai_id",
+        "anthropic": "active_anthropic_id",
+        "paddleocr": "active_paddleocr_id",
+    }
+
+    for p in providers:
+        key = category_key.get(p.category)
+        if key:
+            result[key].append(_serialize_provider(p))
+        if p.is_active:
+            ak = active_key.get(p.category)
+            if ak:
+                result[ak] = p.id
+
+    return result
+
+
+def save_user_providers(db: Session, user_id: int, data: dict) -> None:
+    """保存用户的 provider 配置（全量覆盖）
+
+    data 结构:
+        openai_providers: [{ id, name, api_key?, base_url, model_name, ... }]
+        anthropic_providers: [...]
+        paddleocr_providers: [...]
+        active_openai_id: str | None
+        active_anthropic_id: str | None
+        active_paddleocr_id: str | None
+    """
+    active_ids = {
+        "openai": data.get("active_openai_id"),
+        "anthropic": data.get("active_anthropic_id"),
+        "paddleocr": data.get("active_paddleocr_id"),
+    }
+
+    # 读取已有配置（用于保留未重新提交的 api_key）
+    existing = {
+        p.id: p for p in db.query(ProviderConfig).filter(
+            ProviderConfig.user_id == user_id
+        ).all()
+    }
+
+    # 收集本次提交的所有 ID
+    submitted_ids = set()
+    items_to_save = []
+
+    category_map = {
+        "openai_providers": "openai",
+        "anthropic_providers": "anthropic",
+        "paddleocr_providers": "paddleocr",
+    }
+
+    for list_key, category in category_map.items():
+        for item in data.get(list_key, []):
+            pid = item.get("id")
+            submitted_ids.add(pid)
+            old = existing.get(pid)
+
+            # API Key：前端提交了新值则更新，否则保留旧值
+            new_api_key = item.get("api_key") or item.get("api_token") or ""
+            if not new_api_key and old:
+                new_api_key = old.api_key or ""
+
+            base_url = item.get("base_url") or item.get("api_url") or ""
+            model_name = item.get("model_name") or item.get("model") or ""
+
+            items_to_save.append({
+                "id": pid,
+                "category": category,
+                "name": item.get("name", ""),
+                "is_active": pid == active_ids.get(category),
+                "api_key": new_api_key,
+                "base_url": base_url,
+                "model_name": model_name,
+                "light_model_name": item.get("light_model_name", ""),
+                "supports_function_calling": item.get("supports_function_calling", True),
+                "use_doc_orientation": item.get("use_doc_orientation", False),
+                "use_doc_unwarping": item.get("use_doc_unwarping", False),
+                "use_chart_recognition": item.get("use_chart_recognition", False),
+            })
+
+    # 删除已移除的 provider
+    for pid in set(existing.keys()) - submitted_ids:
+        db.delete(existing[pid])
+
+    # 更新或新增
+    for item in items_to_save:
+        old = existing.get(item["id"])
+        if old:
+            for k, v in item.items():
+                setattr(old, k, v)
+        else:
+            p = ProviderConfig(user_id=user_id, **item)
+            db.add(p)
+
+    db.commit()
+
+
+def get_active_provider(db: Session, user_id: int, category: str) -> Optional[ProviderConfig]:
+    """获取用户指定类别的激活 provider（用于后端调用 LLM/OCR 时读取凭据）"""
+    return db.query(ProviderConfig).filter(
+        ProviderConfig.user_id == user_id,
+        ProviderConfig.category == category,
+        ProviderConfig.is_active == True,
+    ).first()

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -24,6 +24,31 @@ class User(Base):
     questions = relationship("Question", back_populates="user")
     upload_batches = relationship("UploadBatch", back_populates="user")
     split_records = relationship("SplitRecord", back_populates="user")
+    provider_configs = relationship("ProviderConfig", back_populates="user", cascade="all, delete-orphan")
+
+
+class ProviderConfig(Base):
+    """用户级 API 供应商配置（每用户可配置多个，同类激活一个）"""
+    __tablename__ = "provider_configs"
+
+    id = Column(String(36), primary_key=True)  # UUID
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    category = Column(String(20), nullable=False)  # 'openai' | 'anthropic' | 'paddleocr'
+    name = Column(String(100), default="")
+    is_active = Column(Boolean, default=False)
+    api_key = Column(Text, default="")  # 加密存储（后续）
+    base_url = Column(Text, default="")
+    model_name = Column(String(100), default="")
+    light_model_name = Column(String(100), default="")
+    supports_function_calling = Column(Boolean, default=True)
+    # PaddleOCR 专用
+    use_doc_orientation = Column(Boolean, default=False)
+    use_doc_unwarping = Column(Boolean, default=False)
+    use_chart_recognition = Column(Boolean, default=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    user = relationship("User", back_populates="provider_configs")
 
 
 class UploadBatch(Base):

--- a/backend/llm.py
+++ b/backend/llm.py
@@ -13,6 +13,11 @@ def init_model(
     provider: str = "openai",
     model_name: str | None = None,
     use_light: bool = False,
+    *,
+    api_key: str | None = None,
+    base_url: str | None = None,
+    light_model_name: str | None = None,
+    supports_function_calling: bool | None = None,
 ):
     """初始化 LLM 模型
 
@@ -21,11 +26,33 @@ def init_model(
         provider: 模型供应商名称
         model_name: 指定模型名称，为 None 时使用配置默认值
         use_light: 使用轻量模型（用于科目识别等低成本任务）
+        api_key: 直接传入 API Key（优先于数据库配置）
+        base_url: 直接传入 Base URL
+        light_model_name: 直接传入轻量模型名称
+        supports_function_calling: 是否支持 function calling
     """
-    cfg = settings.get_provider(provider)
+    if api_key:
+        # 用传入的凭据动态构建配置，跳过环境变量
+        from config import OpenAICompatibleConfig, AnthropicCompatibleConfig
+        if provider == "anthropic":
+            cfg = AnthropicCompatibleConfig(
+                api_key=api_key,
+                base_url=base_url or "",
+                model_name=model_name or "claude-sonnet-4-20250514",
+            )
+        else:
+            cfg = OpenAICompatibleConfig(
+                api_key=api_key,
+                base_url=base_url or "",
+                model_name=model_name or "gpt-4o-mini",
+                light_model_name=light_model_name,
+                supports_function_calling=supports_function_calling if supports_function_calling is not None else True,
+            )
+    else:
+        cfg = settings.get_provider(provider)
 
     if not cfg.configured:
-        raise ValueError(f"使用 {provider} 需要配置 API Key 环境变量")
+        raise ValueError(f"使用 {provider} 需要配置 API Key，请在设置中配置")
 
     effective_model = cfg.resolve_model_name(model_name, use_light=use_light)
 

--- a/backend/src/paddleocr_client.py
+++ b/backend/src/paddleocr_client.py
@@ -10,11 +10,7 @@ from pathlib import Path
 from typing import Dict, Any, Optional, List
 import requests
 import aiohttp
-from dotenv import load_dotenv
 from rich.console import Console
-
-# 加载环境变量
-load_dotenv()
 
 console = Console()
 
@@ -27,20 +23,22 @@ POLL_TIMEOUT = 300
 class PaddleOCRClient:
     """PaddleOCR V2 异步任务 API 客户端"""
 
-    def __init__(self):
-        """初始化客户端，从环境变量读取配置"""
-        self.api_url = os.getenv("PADDLEOCR_API_URL")
-        self.token = os.getenv("PADDLEOCR_API_TOKEN")
-        self.model = os.getenv("PADDLEOCR_MODEL", "PaddleOCR-VL-1.5")
-        self.use_doc_orientation = os.getenv("PADDLEOCR_USE_DOC_ORIENTATION", "false").lower() == "true"
-        self.use_doc_unwarping = os.getenv("PADDLEOCR_USE_DOC_UNWARPING", "false").lower() == "true"
-        self.use_chart_recognition = os.getenv("PADDLEOCR_USE_CHART_RECOGNITION", "false").lower() == "true"
-        # 验证必需的配置
+    def __init__(self, *, api_url=None, token=None, model=None,
+                 use_doc_orientation=None, use_doc_unwarping=None,
+                 use_chart_recognition=None):
+        """初始化客户端
+
+        优先使用传入的参数，未提供时回退到环境变量。
+        """
+        self.api_url = api_url or ""
+        self.token = token or ""
+        self.model = model or "PaddleOCR-VL-1.5"
+        self.use_doc_orientation = use_doc_orientation or False
+        self.use_doc_unwarping = use_doc_unwarping or False
+        self.use_chart_recognition = use_chart_recognition or False
         if not self.api_url or not self.token:
             raise ValueError(
-                "缺少必需的环境变量。请确保 .env 文件中配置了：\n"
-                "- PADDLEOCR_API_URL\n"
-                "- PADDLEOCR_API_TOKEN"
+                "缺少 PaddleOCR 配置，请在设置页面配置 PaddleOCR 服务"
             )
 
     @property

--- a/backend/src/workflow.py
+++ b/backend/src/workflow.py
@@ -9,14 +9,11 @@ import logging
 import time
 from typing import List, Dict, Any, TypedDict
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dotenv import load_dotenv
 from rich.console import Console
 from langgraph.graph import StateGraph, START, END
 from langgraph.checkpoint.memory import MemorySaver
 from config import settings
 from .utils import prepare_input, export_wrongbook, simplify_ocr_results, run_async
-
-load_dotenv()
 console = Console()
 
 # 配置日志
@@ -45,6 +42,9 @@ class WorkflowState(TypedDict, total=False):
     model_provider: str                  # 模型供应商: "openai" | "anthropic"
     model_name: str                      # 用户选择的具体模型名称（可选，None 时使用 provider 默认）
     warnings: List[str]                  # 步骤警告信息（供前端展示）
+    # 数据库凭据（由路由层注入，避免环境变量依赖）
+    llm_credentials: Dict[str, Any]      # {api_key, base_url, light_model_name, supports_function_calling}
+    ocr_credentials: Dict[str, Any]      # {api_url, token, model, use_doc_orientation, ...}
 
 
 # ── 节点函数 ──────────────────────────────────────────────
@@ -67,7 +67,7 @@ def prepare_input_node(state: WorkflowState) -> dict:
 # ── 并行分割辅助函数 ──────────────────────────────────────────
 
 
-def _run_ocr_and_simplify(file_paths: List[str]) -> List[Dict[str, Any]]:
+def _run_ocr_and_simplify(file_paths: List[str], ocr_credentials: Dict[str, Any] = None) -> List[Dict[str, Any]]:
     """执行 OCR 解析并简化结果（含重试机制）
 
     支持混合文件类型：PDF 直传 API，图片并行上传。
@@ -78,7 +78,15 @@ def _run_ocr_and_simplify(file_paths: List[str]) -> List[Dict[str, Any]]:
     """
     from src.paddleocr_client import PaddleOCRClient
 
-    client = PaddleOCRClient()
+    creds = ocr_credentials or {}
+    client = PaddleOCRClient(
+        api_url=creds.get("api_url"),
+        token=creds.get("token"),
+        model=creds.get("model"),
+        use_doc_orientation=creds.get("use_doc_orientation"),
+        use_doc_unwarping=creds.get("use_doc_unwarping"),
+        use_chart_recognition=creds.get("use_chart_recognition"),
+    )
 
     # 按文件类型分组
     pdf_paths = [p for p in file_paths if p.lower().endswith(".pdf")]
@@ -341,6 +349,8 @@ def split_questions_node(state: WorkflowState) -> dict:
     file_paths = state["image_paths"]
     model_provider = state.get("model_provider", "openai")
     model_name = state.get("model_name")
+    llm_credentials = state.get("llm_credentials") or {}
+    ocr_credentials = state.get("ocr_credentials") or {}
 
     # 清空旧的 questions.json 和 split_metadata.json
     questions_file = os.path.join(results_dir, "questions.json")
@@ -354,7 +364,7 @@ def split_questions_node(state: WorkflowState) -> dict:
     console.print(f"[cyan]OCR 解析 {len(file_paths)} 个文件...[/cyan]")
     ocr_start = time.time()
 
-    ocr_data = _run_ocr_and_simplify(file_paths)
+    ocr_data = _run_ocr_and_simplify(file_paths, ocr_credentials=ocr_credentials)
 
     if not ocr_data:
         logger.error("OCR 解析失败，无数据返回")

--- a/backend/web_app.py
+++ b/backend/web_app.py
@@ -491,6 +491,23 @@ def split_questions():
                 'error': f'不支持的模型供应商: {model_provider}'
             }), 400
 
+        # 从数据库加载用户的 LLM + OCR 凭据
+        user_id = session.get('user_id')
+        ocr_credentials = {}
+        if user_id:
+            settings.load_providers_from_db(user_id)
+            with SessionLocal() as db:
+                ocr_provider = crud.get_active_provider(db, user_id, 'paddleocr')
+                if ocr_provider:
+                    ocr_credentials = {
+                        "api_url": ocr_provider.base_url,
+                        "token": ocr_provider.api_key,
+                        "model": ocr_provider.model_name,
+                        "use_doc_orientation": ocr_provider.use_doc_orientation,
+                        "use_doc_unwarping": ocr_provider.use_doc_unwarping,
+                        "use_chart_recognition": ocr_provider.use_chart_recognition,
+                    }
+
         with session_lock:
             keys = list(session_file_order)
             file_paths = []
@@ -509,7 +526,13 @@ def split_questions():
         current_thread_id = str(uuid.uuid4())
         config = {"configurable": {"thread_id": current_thread_id}}
 
-        workflow_graph.invoke({"file_paths": file_paths, "model_provider": model_provider, "model_name": model_name}, config=config)
+        initial_state = {
+            "file_paths": file_paths,
+            "model_provider": model_provider,
+            "model_name": model_name,
+            "ocr_credentials": ocr_credentials,
+        }
+        workflow_graph.invoke(initial_state, config=config)
         state = workflow_graph.invoke(None, config=config)
 
         questions = state.get('questions', [])
@@ -863,15 +886,26 @@ def list_models():
         api_key = data.get('api_key') or ''
         base_url = data.get('base_url') or ''
 
-        # 如果前端没传 key，尝试从环境变量回退
+        # 如果前端没传 key，从数据库读取已保存的配置
         if not api_key:
-            if provider_type == 'openai':
-                api_key = os.getenv('OPENAI_API_KEY', '')
-            elif provider_type == 'anthropic':
-                api_key = os.getenv('ANTHROPIC_API_KEY', '')
+            user_id = session.get('user_id')
+            provider_id = data.get('provider_id')
+            if user_id:
+                with SessionLocal() as db:
+                    if provider_id:
+                        provider = db.query(crud.ProviderConfig).filter_by(
+                            id=provider_id, user_id=user_id
+                        ).first()
+                    else:
+                        provider = crud.get_active_provider(db, user_id, provider_type)
+                    if provider:
+                        if not api_key:
+                            api_key = provider.api_key or ''
+                        if not base_url:
+                            base_url = provider.base_url or ''
 
         if not api_key:
-            return jsonify({'error': '未提供 API Key，且系统未配置默认 Key'}), 400
+            return jsonify({'error': '未提供 API Key，请先在设置中配置'}), 400
 
         if provider_type == 'openai':
             url = (base_url.rstrip('/') if base_url else 'https://api.openai.com') + '/v1/models'
@@ -1658,6 +1692,11 @@ def stream_chat(session_id):
 
         if not settings.is_valid_provider(model_provider):
             return jsonify({'success': False, 'error': f'不支持的模型供应商: {model_provider}'}), 400
+
+        # 从数据库加载用户的 LLM 凭据
+        user_id = session.get('user_id')
+        if user_id:
+            settings.load_providers_from_db(user_id)
 
         with SessionLocal() as db:
             from db.models import ChatSession as ChatSessionModel, QuestionTagMapping

--- a/backend/web_app.py
+++ b/backend/web_app.py
@@ -13,6 +13,8 @@ from datetime import datetime
 from pathlib import PurePath
 from typing import Optional
 
+import requests as http_requests
+
 # Windows 注册表可能将 .js 映射为 text/plain，导致浏览器拒绝加载 ES module
 mimetypes.add_type('application/javascript', '.js')
 from flask import Flask, request, jsonify, send_file, send_from_directory, redirect, session
@@ -21,7 +23,7 @@ from dotenv import load_dotenv
 from werkzeug.security import generate_password_hash, check_password_hash
 from src.workflow import build_workflow
 from src.utils import export_wrongbook as export_wrongbook_md
-from config import settings, update_env_file
+from config import settings
 from db import init_db, SessionLocal
 from db import crud
 from db.models import Question, UploadBatch, KnowledgeTag
@@ -778,9 +780,14 @@ def get_status():
 
 @app.route('/api/config', methods=['GET'])
 def get_config():
-    """获取当前可编辑配置（API key 脱敏）"""
+    """获取当前用户的 provider 配置"""
     try:
-        return jsonify({'success': True, 'config': settings.get_config_for_ui()})
+        user_id = session.get('user_id')
+        if not user_id:
+            return jsonify({'success': False, 'error': '请先登录'}), 401
+        with SessionLocal() as db:
+            config = crud.get_user_providers(db, user_id)
+        return jsonify({'success': True, 'config': config})
     except Exception as e:
         logger.exception("获取配置失败")
         return jsonify({'success': False, 'error': '获取配置失败'}), 500
@@ -788,63 +795,136 @@ def get_config():
 
 @app.route('/api/config', methods=['PUT'])
 def update_config():
-    """更新配置并热重载
-
-    接收 JSON body，结构与 GET /api/config 返回的 config 一致。
-    密钥字段不发送或发送 null 则跳过，发送空字符串则清空。
-    """
+    """保存当前用户的 provider 配置到数据库"""
     try:
         data = request.get_json(force=True) or {}
-        updates = {}
+        user_id = session.get('user_id')
 
-        # 字段→环境变量映射
-        field_map = {
-            'openai': {
-                'api_key': 'OPENAI_API_KEY',
-                'base_url': 'OPENAI_BASE_URL',
-                'model_name': 'OPENAI_MODEL_NAME',
-                'light_model_name': 'OPENAI_LIGHT_MODEL_NAME',
-                'supports_function_calling': 'OPENAI_SUPPORTS_FUNCTION_CALLING',
-            },
-            'anthropic': {
-                'api_key': 'ANTHROPIC_API_KEY',
-                'base_url': 'ANTHROPIC_BASE_URL',
-                'model_name': 'ANTHROPIC_MODEL_NAME',
-            },
-            'paddleocr': {
-                'api_url': 'PADDLEOCR_API_URL',
-                'api_token': 'PADDLEOCR_API_TOKEN',
-                'model': 'PADDLEOCR_MODEL',
-                'use_doc_orientation': 'PADDLEOCR_USE_DOC_ORIENTATION',
-                'use_doc_unwarping': 'PADDLEOCR_USE_DOC_UNWARPING',
-                'use_chart_recognition': 'PADDLEOCR_USE_CHART_RECOGNITION',
-            },
-        }
+        if not user_id:
+            return jsonify({'success': False, 'error': '请先登录'}), 401
 
-        for section, mapping in field_map.items():
-            section_data = data.get(section)
-            if not isinstance(section_data, dict):
-                continue
-            for field, env_key in mapping.items():
-                if field not in section_data:
-                    continue
-                val = section_data[field]
-                if val is None:
-                    continue
-                # 布尔值转字符串
-                if isinstance(val, bool):
-                    val = 'true' if val else 'false'
-                updates[env_key] = str(val)
-
-        if updates:
-            update_env_file(updates)
-            settings.reload_providers()
-
+        with SessionLocal() as db:
+            try:
+                crud.save_user_providers(db, user_id, data)
+            except Exception:
+                db.rollback()
+                raise
         return jsonify({'success': True})
 
     except Exception as e:
         logger.exception("更新配置失败")
         return jsonify({'success': False, 'error': '更新配置失败，请检查日志'}), 500
+
+
+@app.route('/api/models/list', methods=['POST'])
+def list_models():
+    """代理请求目标 API 的模型列表，绕过浏览器 CORS 限制。
+
+    请求体:
+        type: 'openai' | 'anthropic'
+        api_key: API Key（可选，留空则使用系统已配置的 key）
+        base_url: Base URL（可选）
+        provider_id: 已有 provider 的 id（可选，用于回退读取已存 key）
+    """
+    try:
+        data = request.get_json(force=True) or {}
+        provider_type = data.get('type', 'openai')
+        api_key = data.get('api_key') or ''
+        base_url = data.get('base_url') or ''
+
+        # 如果前端没传 key，尝试从环境变量回退
+        if not api_key:
+            if provider_type == 'openai':
+                api_key = os.getenv('OPENAI_API_KEY', '')
+            elif provider_type == 'anthropic':
+                api_key = os.getenv('ANTHROPIC_API_KEY', '')
+
+        if not api_key:
+            return jsonify({'error': '未提供 API Key，且系统未配置默认 Key'}), 400
+
+        if provider_type == 'openai':
+            url = (base_url.rstrip('/') if base_url else 'https://api.openai.com') + '/v1/models'
+            headers = {'Authorization': f'Bearer {api_key}'}
+            resp = http_requests.get(url, headers=headers, timeout=15)
+
+            # 部分 OpenAI 兼容 API 的路径可能不带 /v1
+            if resp.status_code == 404:
+                url_alt = (base_url.rstrip('/') if base_url else 'https://api.openai.com') + '/models'
+                resp = http_requests.get(url_alt, headers=headers, timeout=15)
+
+            if resp.status_code != 200:
+                return jsonify({'error': f'API 返回 {resp.status_code}: {resp.text[:200]}'}), 502
+
+            body = resp.json()
+            models = sorted([m['id'] for m in body.get('data', [])]) if 'data' in body else []
+            return jsonify({'models': models})
+
+        elif provider_type == 'anthropic':
+            # Anthropic 没有官方 list models 接口，返回常用模型列表
+            models = [
+                'claude-opus-4-20250514',
+                'claude-sonnet-4-20250514',
+                'claude-haiku-4-20250506',
+                'claude-3-5-sonnet-20241022',
+                'claude-3-5-haiku-20241022',
+                'claude-3-opus-20240229',
+            ]
+            return jsonify({'models': models})
+
+        else:
+            return jsonify({'error': f'不支持的 provider 类型: {provider_type}'}), 400
+
+    except http_requests.Timeout:
+        return jsonify({'error': '请求超时，请检查 Base URL 是否正确'}), 504
+    except http_requests.ConnectionError:
+        return jsonify({'error': '无法连接目标 API，请检查 Base URL'}), 502
+    except Exception as e:
+        logger.exception("获取模型列表失败")
+        return jsonify({'error': str(e)}), 500
+
+
+@app.route('/api/paddleocr/test', methods=['POST'])
+def test_paddleocr():
+    """测试 PaddleOCR API Token 是否可用。
+
+    请求体:
+        api_token: API Token
+        api_url: API URL
+    """
+    try:
+        data = request.get_json(force=True) or {}
+        api_token = data.get('api_token') or ''
+        api_url = data.get('api_url') or ''
+
+        if not api_token:
+            api_token = os.getenv('PADDLEOCR_API_TOKEN', '')
+        if not api_url:
+            api_url = os.getenv('PADDLEOCR_API_URL', '')
+
+        if not api_token or not api_url:
+            return jsonify({'error': '未提供 API Token 或 API URL'}), 400
+
+        # 用 GET 请求 API URL，带 token 验证认证是否有效
+        headers = {'Authorization': f'bearer {api_token}'}
+        resp = http_requests.get(api_url, headers=headers, timeout=10)
+
+        # 401/403 表示 token 无效
+        if resp.status_code in (401, 403):
+            return jsonify({'success': False, 'error': '认证失败，请检查 API Token 是否正确'})
+
+        # 其他非 5xx 状态码都认为 token 有效（包括 404/405 等，因为 GET 可能不被支持但认证通过了）
+        if resp.status_code >= 500:
+            return jsonify({'success': False, 'error': f'服务端错误 ({resp.status_code})，请检查 API URL'})
+
+        return jsonify({'success': True, 'message': 'API Token 验证通过'})
+
+    except http_requests.Timeout:
+        return jsonify({'success': False, 'error': '请求超时，请检查 API URL 是否正确'}), 504
+    except http_requests.ConnectionError:
+        return jsonify({'success': False, 'error': '无法连接，请检查 API URL'}), 502
+    except Exception as e:
+        logger.exception("测试 PaddleOCR 连接失败")
+        return jsonify({'success': False, 'error': str(e)}), 500
 
 
 @app.route('/api/history', methods=['GET'])

--- a/backend/web_app.py
+++ b/backend/web_app.py
@@ -750,9 +750,40 @@ def get_status():
         JSON响应，包含系统配置和状态
     """
     try:
-        # 检查配置
-        paddleocr_configured = bool(os.getenv('PADDLEOCR_API_URL'))
-        available_models = settings.get_available_models()
+        user_id = session.get('user_id')
+
+        if user_id:
+            # 已登录：从数据库读取用户配置
+            with SessionLocal() as db:
+                paddle_provider = crud.get_active_provider(db, user_id, 'paddleocr')
+                paddleocr_configured = bool(paddle_provider and paddle_provider.api_key and paddle_provider.base_url)
+
+                # 构建用户级可用模型列表
+                available_models = []
+                for category, label in [('openai', 'OpenAI'), ('anthropic', 'Anthropic')]:
+                    provider = crud.get_active_provider(db, user_id, category)
+                    if provider and provider.api_key:
+                        available_models.append({
+                            'value': category,
+                            'label': provider.name or label,
+                            'configured': True,
+                            'status': '配置成功',
+                            'default_model': provider.model_name or '',
+                            'models': [provider.model_name] if provider.model_name else [],
+                        })
+                    else:
+                        available_models.append({
+                            'value': category,
+                            'label': label,
+                            'configured': False,
+                            'status': '未配置',
+                            'default_model': '',
+                            'models': [],
+                        })
+        else:
+            # 未登录：返回空状态
+            paddleocr_configured = False
+            available_models = []
 
         status = {
             'paddleocr_configured': paddleocr_configured,
@@ -888,18 +919,32 @@ def test_paddleocr():
     """测试 PaddleOCR API Token 是否可用。
 
     请求体:
-        api_token: API Token
-        api_url: API URL
+        api_token: API Token（可选，留空则从数据库读取）
+        api_url: API URL（可选，留空则从数据库读取）
+        provider_id: 已有 provider 的 id（可选，用于回退读取已存 token）
     """
     try:
         data = request.get_json(force=True) or {}
         api_token = data.get('api_token') or ''
         api_url = data.get('api_url') or ''
 
-        if not api_token:
-            api_token = os.getenv('PADDLEOCR_API_TOKEN', '')
-        if not api_url:
-            api_url = os.getenv('PADDLEOCR_API_URL', '')
+        # 前端未提供凭据时，从数据库读取已保存的配置
+        if not api_token or not api_url:
+            user_id = session.get('user_id')
+            provider_id = data.get('provider_id')
+            if user_id:
+                with SessionLocal() as db:
+                    if provider_id:
+                        provider = db.query(crud.ProviderConfig).filter_by(
+                            id=provider_id, user_id=user_id
+                        ).first()
+                    else:
+                        provider = crud.get_active_provider(db, user_id, 'paddleocr')
+                    if provider:
+                        if not api_token:
+                            api_token = provider.api_key or ''
+                        if not api_url:
+                            api_url = provider.base_url or ''
 
         if not api_token or not api_url:
             return jsonify({'error': '未提供 API Token 或 API URL'}), 400

--- a/frontend/src/components/FileUploader.vue
+++ b/frontend/src/components/FileUploader.vue
@@ -10,6 +10,7 @@ const props = defineProps({
   splitting: { type: Boolean, default: false },
   splitCompleted: { type: Boolean, default: false },
   expand: { type: Boolean, default: false },
+  disabled: { type: Boolean, default: false },
 })
 
 const emit = defineEmits(['upload', 'remove-file'])
@@ -18,6 +19,7 @@ const fileInputEl = ref(null)
 const uploadHover = ref(false)
 
 const onFileInput = (e) => {
+  if (props.disabled) return
   emit('upload', e.target.files)
   e.target.value = ''
 }
@@ -25,7 +27,13 @@ const onFileInput = (e) => {
 const onDrop = (e) => {
   e.preventDefault()
   uploadHover.value = false
+  if (props.disabled) return
   emit('upload', e.dataTransfer.files)
+}
+
+const onClickZone = () => {
+  if (props.disabled) return
+  fileInputEl.value?.click()
 }
 </script>
 
@@ -38,15 +46,16 @@ const onDrop = (e) => {
         uploadHover
           ? 'border-blue-500/50 bg-slate-900/10 shadow-2xl shadow-blue-500/20 dark:border-indigo-500/50 dark:bg-white/10'
           : 'border-slate-900/10 bg-slate-900/[0.05] shadow-[0_8px_30px_rgba(0,0,0,0.06)] hover:border-blue-200 hover:bg-slate-900/10 dark:border-white/5 dark:bg-white/5 dark:shadow-none dark:hover:border-indigo-500/20 dark:hover:bg-white/10',
-        expand ? 'flex-1 py-12 min-h-[280px]' : 'py-10'
+        expand ? 'flex-1 py-12 min-h-[280px]' : 'py-10',
+        disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
       ]"
       @dragenter.prevent="uploadHover = true"
       @dragover.prevent="uploadHover = true"
       @dragleave.prevent="uploadHover = false"
       @drop="onDrop"
-      @click="() => fileInputEl?.click()"
-      @keydown.enter.prevent="() => fileInputEl?.click()"
-      @keydown.space.prevent="() => fileInputEl?.click()"
+      @click="onClickZone"
+      @keydown.enter.prevent="onClickZone"
+      @keydown.space.prevent="onClickZone"
       role="button"
       tabindex="0"
     >
@@ -63,7 +72,10 @@ const onDrop = (e) => {
         </div>
 
         <div class="max-w-xs">
-          <h4 class="text-sm font-black tracking-tight text-slate-900 dark:text-white">
+          <h4 v-if="disabled" class="text-sm font-black tracking-tight text-slate-500 dark:text-slate-400">
+            请先在 <span class="text-blue-600 dark:text-indigo-400">系统设置</span> 中配置 API 模型
+          </h4>
+          <h4 v-else class="text-sm font-black tracking-tight text-slate-900 dark:text-white">
             点击 <span class="text-blue-600 dark:text-indigo-400">选择文件</span> 或拖拽至此
           </h4>
           <div class="mt-4 flex flex-wrap justify-center gap-1.5">

--- a/frontend/src/components/ProviderDialog.vue
+++ b/frontend/src/components/ProviderDialog.vue
@@ -1,0 +1,409 @@
+<script setup>
+import { ref, computed, watch } from 'vue'
+
+const props = defineProps({
+  open: { type: Boolean, default: false },
+  type: { type: String, default: 'openai' }, // 'openai' | 'anthropic' | 'paddleocr'
+  editData: { type: Object, default: null }, // null=新增, object=编辑
+})
+
+const emit = defineEmits(['close', 'confirm'])
+
+const isEdit = computed(() => !!props.editData)
+
+const typeConfig = computed(() => ({
+  openai: {
+    title: isEdit.value ? '编辑 OpenAI 兼容供应商' : '添加 OpenAI 兼容供应商',
+    iconBg: 'bg-emerald-50 dark:bg-emerald-500/10',
+    iconCls: 'fa-bolt text-emerald-600 dark:text-emerald-400',
+    btnCls: 'bg-emerald-600 hover:bg-emerald-700 dark:bg-emerald-500 dark:hover:bg-emerald-600',
+    namePlaceholder: '例如：DeepSeek / Qwen / Moonshot',
+    urlPlaceholder: '留空使用 OpenAI 官方，或填入 https://api.deepseek.com 等',
+    modelPlaceholder: 'gpt-4o-mini',
+    defaultName: 'OpenAI Provider',
+    secretLabel: 'API Key',
+    secretPlaceholder: '输入 API Key',
+    urlLabel: 'Base URL',
+  },
+  anthropic: {
+    title: isEdit.value ? '编辑 Anthropic 供应商' : '添加 Anthropic 供应商',
+    iconBg: 'bg-orange-50 dark:bg-orange-500/10',
+    iconCls: 'fa-brain text-orange-600 dark:text-orange-400',
+    btnCls: 'bg-orange-600 hover:bg-orange-700 dark:bg-orange-500 dark:hover:bg-orange-600',
+    namePlaceholder: '例如：Claude Official',
+    urlPlaceholder: '留空使用 Anthropic 官方',
+    modelPlaceholder: 'claude-sonnet-4-20250514',
+    defaultName: 'Anthropic Provider',
+    secretLabel: 'API Key',
+    secretPlaceholder: '输入 API Key',
+    urlLabel: 'Base URL',
+  },
+  paddleocr: {
+    title: isEdit.value ? '编辑 PaddleOCR 服务' : '添加 PaddleOCR 服务',
+    iconBg: 'bg-blue-50 dark:bg-blue-500/10',
+    iconCls: 'fa-eye text-blue-600 dark:text-blue-400',
+    btnCls: 'bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600',
+    namePlaceholder: '例如：PaddleOCR 官方',
+    urlPlaceholder: 'https://paddleocr.aistudio-app.com/api/v2/ocr/jobs',
+    modelPlaceholder: 'PaddleOCR-VL-1.5',
+    defaultName: 'PaddleOCR',
+    secretLabel: 'API Token',
+    secretPlaceholder: '输入 API Token',
+    urlLabel: 'API URL',
+  },
+}[props.type]))
+
+const defaultForm = () => ({
+  name: '',
+  api_key: '',
+  base_url: '',
+  model_name: '',
+  light_model_name: '',
+  supports_function_calling: true,
+  // PaddleOCR 专用
+  use_doc_orientation: false,
+  use_doc_unwarping: false,
+  use_chart_recognition: false,
+})
+
+const form = ref(defaultForm())
+
+// 模型列表相关
+const modelList = ref([])
+const fetchingModels = ref(false)
+const fetchModelError = ref('')
+
+const canFetchModels = computed(() => {
+  if (props.type === 'paddleocr') return false
+  // 需要有 API Key（新输入或已设置）
+  const hasKey = form.value.api_key || (props.editData?.api_key_set)
+  return !!hasKey
+})
+
+const fetchModels = async () => {
+  if (fetchingModels.value) return
+  fetchingModels.value = true
+  fetchModelError.value = ''
+  modelList.value = []
+  try {
+    const res = await fetch('/api/models/list', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: props.type,
+        api_key: form.value.api_key || undefined,
+        base_url: form.value.base_url || undefined,
+        provider_id: props.editData?.id || undefined,
+      }),
+    })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      throw new Error(err.error || `HTTP ${res.status}`)
+    }
+    const data = await res.json()
+    modelList.value = data.models || []
+    if (modelList.value.length === 0) {
+      fetchModelError.value = '未获取到可用模型'
+    }
+  } catch (e) {
+    fetchModelError.value = e.message || '获取失败'
+  } finally {
+    fetchingModels.value = false
+  }
+}
+
+const selectModel = (field, modelId) => {
+  form.value[field] = modelId
+}
+
+// 每次打开时重置或回填表单
+watch(() => props.open, (v) => {
+  if (!v) return
+  modelList.value = []
+  fetchModelError.value = ''
+  testResult.value = null
+  if (props.editData) {
+    form.value = {
+      ...defaultForm(),
+      name: props.editData.name || '',
+      api_key: '',
+      base_url: props.editData.base_url || '',
+      model_name: props.editData.model_name || '',
+      light_model_name: props.editData.light_model_name || '',
+      supports_function_calling: props.editData.supports_function_calling ?? true,
+      use_doc_orientation: props.editData.use_doc_orientation || false,
+      use_doc_unwarping: props.editData.use_doc_unwarping || false,
+      use_chart_recognition: props.editData.use_chart_recognition || false,
+    }
+  } else {
+    form.value = defaultForm()
+  }
+})
+
+// PaddleOCR 连接测试
+const testingConnection = ref(false)
+const testResult = ref(null) // { success: boolean, message: string } | null
+
+const canTestConnection = computed(() => {
+  const hasToken = form.value.api_key || (props.editData?.api_key_set)
+  const hasUrl = form.value.base_url
+  return !!hasToken && !!hasUrl
+})
+
+const testConnection = async () => {
+  if (testingConnection.value) return
+  testingConnection.value = true
+  testResult.value = null
+  try {
+    const res = await fetch('/api/paddleocr/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        api_token: form.value.api_key || undefined,
+        api_url: form.value.base_url || undefined,
+      }),
+    })
+    const data = await res.json()
+    testResult.value = {
+      success: data.success,
+      message: data.success ? data.message : data.error,
+    }
+  } catch (e) {
+    testResult.value = { success: false, message: e.message || '请求失败' }
+  } finally {
+    testingConnection.value = false
+  }
+}
+
+const confirm = () => {
+  if (!form.value.name.trim()) {
+    form.value.name = typeConfig.value.defaultName
+  }
+  emit('confirm', { ...form.value })
+}
+
+const inputCls = 'w-full rounded-xl border border-slate-200/80 bg-white px-4 py-2.5 text-sm text-slate-800 placeholder-slate-400 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-200 dark:placeholder-slate-500'
+const selectCls = 'w-full rounded-xl border border-slate-200/80 bg-white px-4 py-2.5 text-sm text-slate-800 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-200 appearance-none cursor-pointer bg-[url("data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'12\' height=\'12\' viewBox=\'0 0 12 12\'%3E%3Cpath fill=\'%2394a3b8\' d=\'M2 4l4 4 4-4\'/%3E%3C/svg%3E")] bg-[length:12px] bg-[right_12px_center] bg-no-repeat pr-10'
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="dialog-fade">
+      <div v-if="open" class="fixed inset-0 z-[100] flex items-center justify-center p-4" @click.self="emit('close')">
+        <!-- 背景遮罩 -->
+        <div class="absolute inset-0 bg-black/40 backdrop-blur-sm"></div>
+
+        <!-- 弹窗主体 -->
+        <div class="relative w-full max-w-lg rounded-2xl border border-slate-200/60 bg-white/70 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-white/[0.03]">
+          <!-- 头部 -->
+          <div class="flex items-center justify-between border-b border-slate-100 px-6 py-4 dark:border-white/5">
+            <div class="flex items-center gap-3">
+              <div class="flex h-9 w-9 items-center justify-center rounded-xl" :class="typeConfig.iconBg">
+                <i class="fa-solid text-base" :class="typeConfig.iconCls"></i>
+              </div>
+              <h3 class="text-base font-bold text-slate-800 dark:text-slate-200">
+                {{ typeConfig.title }}
+              </h3>
+            </div>
+            <button
+              @click="emit('close')"
+              class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-white/5 dark:hover:text-slate-300"
+            >
+              <i class="fa-solid fa-xmark"></i>
+            </button>
+          </div>
+
+          <!-- 表单 -->
+          <form autocomplete="off" class="space-y-4 px-6 py-5" @submit.prevent="confirm">
+            <div>
+              <label class="mb-1.5 block text-xs font-bold text-slate-600 dark:text-slate-400">{{ type === 'paddleocr' ? '服务名称' : '供应商名称' }}</label>
+              <input
+                v-model="form.name"
+                type="text"
+                :placeholder="typeConfig.namePlaceholder"
+                :class="inputCls"
+                autofocus
+              />
+            </div>
+
+            <div>
+              <label class="mb-1.5 block text-xs font-bold text-slate-600 dark:text-slate-400">{{ typeConfig.secretLabel }}</label>
+              <input
+                v-model="form.api_key"
+                type="password"
+                :placeholder="isEdit && editData?.api_key_set ? `已设置 (${editData.api_key_hint})，留空则不修改` : typeConfig.secretPlaceholder"
+                :class="inputCls"
+              />
+            </div>
+
+            <div>
+              <label class="mb-1.5 block text-xs font-bold text-slate-600 dark:text-slate-400">{{ typeConfig.urlLabel }}</label>
+              <input
+                v-model="form.base_url"
+                type="text"
+                :placeholder="typeConfig.urlPlaceholder"
+                :class="inputCls"
+              />
+            </div>
+
+            <!-- 获取模型列表按钮（仅 OpenAI / Anthropic） -->
+            <div v-if="type !== 'paddleocr'" class="flex items-center gap-3">
+              <button
+                @click="fetchModels"
+                :disabled="!canFetchModels || fetchingModels"
+                class="inline-flex items-center gap-1.5 rounded-xl border border-slate-200/60 bg-white/60 px-3.5 py-2 text-xs font-bold text-slate-600 transition-all hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-white/10 dark:bg-white/5 dark:text-slate-300 dark:hover:bg-white/10"
+              >
+                <i class="fa-solid text-[10px]" :class="fetchingModels ? 'fa-circle-notch fa-spin' : 'fa-arrows-rotate'"></i>
+                {{ fetchingModels ? '获取中...' : '获取模型列表' }}
+              </button>
+              <span v-if="fetchModelError" class="text-xs font-medium text-rose-500 dark:text-rose-400">{{ fetchModelError }}</span>
+              <span v-else-if="modelList.length > 0" class="text-xs font-medium text-emerald-600 dark:text-emerald-400">{{ modelList.length }} 个模型可用</span>
+              <span v-else-if="!canFetchModels" class="text-xs text-slate-400 dark:text-slate-500">请先填写 API Key</span>
+            </div>
+
+            <div class="grid gap-4" :class="type === 'openai' ? 'sm:grid-cols-2' : ''">
+              <div>
+                <label class="mb-1.5 block text-xs font-bold text-slate-600 dark:text-slate-400">
+                  {{ type === 'paddleocr' ? 'OCR 模型' : '默认模型' }}
+                </label>
+                <!-- 有模型列表时用 select -->
+                <select
+                  v-if="modelList.length > 0 && type !== 'paddleocr'"
+                  v-model="form.model_name"
+                  :class="selectCls"
+                >
+                  <option value="" disabled>请选择模型</option>
+                  <option v-for="m in modelList" :key="m" :value="m">{{ m }}</option>
+                </select>
+                <!-- 无模型列表时用 input -->
+                <input
+                  v-else
+                  v-model="form.model_name"
+                  type="text"
+                  :placeholder="typeConfig.modelPlaceholder"
+                  :class="inputCls"
+                />
+              </div>
+              <div v-if="type === 'openai'">
+                <label class="mb-1.5 block text-xs font-bold text-slate-600 dark:text-slate-400">轻量模型 <span class="font-normal text-slate-400">（可选）</span></label>
+                <select
+                  v-if="modelList.length > 0"
+                  v-model="form.light_model_name"
+                  :class="selectCls"
+                >
+                  <option value="">不使用</option>
+                  <option v-for="m in modelList" :key="m" :value="m">{{ m }}</option>
+                </select>
+                <input
+                  v-else
+                  v-model="form.light_model_name"
+                  type="text"
+                  placeholder="科目识别等轻量任务使用"
+                  :class="inputCls"
+                />
+              </div>
+            </div>
+
+            <!-- Function Calling 开关（仅 OpenAI） -->
+            <div v-if="type === 'openai'" class="border-t border-slate-100 pt-4 dark:border-white/5">
+              <label class="flex cursor-pointer items-center justify-between">
+                <div>
+                  <span class="text-sm font-medium text-slate-700 dark:text-slate-300">支持 Function Calling</span>
+                  <p class="mt-0.5 text-xs text-slate-400 dark:text-slate-500">文心一言、通义千问等不支持时需关闭</p>
+                </div>
+                <button
+                  type="button"
+                  @click="form.supports_function_calling = !form.supports_function_calling"
+                  class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                  :class="form.supports_function_calling ? 'bg-blue-600 dark:bg-indigo-500' : 'bg-slate-200 dark:bg-slate-700'"
+                >
+                  <span
+                    class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
+                    :class="form.supports_function_calling ? 'translate-x-5' : 'translate-x-0'"
+                  ></span>
+                </button>
+              </label>
+            </div>
+
+            <!-- PaddleOCR 测试连接 -->
+            <div v-if="type === 'paddleocr'" class="flex items-center gap-3">
+              <button
+                @click="testConnection"
+                :disabled="!canTestConnection || testingConnection"
+                class="inline-flex items-center gap-1.5 rounded-xl border border-slate-200/60 bg-white/60 px-3.5 py-2 text-xs font-bold text-slate-600 transition-all hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-white/10 dark:bg-white/5 dark:text-slate-300 dark:hover:bg-white/10"
+              >
+                <i class="fa-solid text-[10px]" :class="testingConnection ? 'fa-circle-notch fa-spin' : 'fa-plug-circle-check'"></i>
+                {{ testingConnection ? '检测中...' : '测试连接' }}
+              </button>
+              <span v-if="testResult?.success" class="text-xs font-medium text-emerald-600 dark:text-emerald-400">
+                <i class="fa-solid fa-circle-check mr-1"></i>{{ testResult.message }}
+              </span>
+              <span v-else-if="testResult && !testResult.success" class="text-xs font-medium text-rose-500 dark:text-rose-400">
+                <i class="fa-solid fa-circle-xmark mr-1"></i>{{ testResult.message }}
+              </span>
+              <span v-else-if="!canTestConnection" class="text-xs text-slate-400 dark:text-slate-500">请先填写 API Token 和 URL</span>
+            </div>
+
+            <!-- PaddleOCR 功能开关 -->
+            <div v-if="type === 'paddleocr'" class="border-t border-slate-100 pt-4 dark:border-white/5">
+              <p class="mb-3 text-xs font-bold text-slate-600 dark:text-slate-400">功能开关</p>
+              <div class="space-y-3">
+                <label
+                  v-for="toggle in [
+                    { key: 'use_doc_orientation', label: '文档方向检测' },
+                    { key: 'use_doc_unwarping', label: '文档去畸变' },
+                    { key: 'use_chart_recognition', label: '图表识别' },
+                  ]"
+                  :key="toggle.key"
+                  class="flex cursor-pointer items-center justify-between"
+                >
+                  <span class="text-sm font-medium text-slate-700 dark:text-slate-300">{{ toggle.label }}</span>
+                  <button
+                    type="button"
+                    @click="form[toggle.key] = !form[toggle.key]"
+                    class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                    :class="form[toggle.key] ? 'bg-blue-600 dark:bg-indigo-500' : 'bg-slate-200 dark:bg-slate-700'"
+                  >
+                    <span
+                      class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
+                      :class="form[toggle.key] ? 'translate-x-5' : 'translate-x-0'"
+                    ></span>
+                  </button>
+                </label>
+              </div>
+            </div>
+          </form>
+
+          <!-- 底部按钮 -->
+          <div class="flex items-center justify-end gap-3 border-t border-slate-100 px-6 py-4 dark:border-white/5">
+            <button
+              @click="emit('close')"
+              class="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200/60 bg-white/60 px-5 py-2.5 text-sm font-bold text-slate-700 transition-all hover:bg-slate-50 dark:border-white/10 dark:bg-slate-800/60 dark:text-slate-300 dark:hover:bg-slate-700"
+            >
+              取消
+            </button>
+            <button
+              @click="confirm"
+              class="inline-flex items-center justify-center gap-2 rounded-xl px-5 py-2.5 text-sm font-bold text-white shadow-md transition-all"
+              :class="typeConfig.btnCls"
+            >
+              <i class="fa-solid text-xs" :class="isEdit ? 'fa-check' : 'fa-plus'"></i>
+              {{ isEdit ? '保存修改' : '添加供应商' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.dialog-fade-enter-active,
+.dialog-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+.dialog-fade-enter-from,
+.dialog-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/frontend/src/components/ProviderDialog.vue
+++ b/frontend/src/components/ProviderDialog.vue
@@ -155,13 +155,15 @@ const testConnection = async () => {
   testingConnection.value = true
   testResult.value = null
   try {
+    const payload = {
+      api_token: form.value.api_key || undefined,
+      api_url: form.value.base_url || undefined,
+      provider_id: props.editData?.id || undefined,
+    }
     const res = await fetch('/api/paddleocr/test', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        api_token: form.value.api_key || undefined,
-        api_url: form.value.base_url || undefined,
-      }),
+      body: JSON.stringify(payload),
     })
     const data = await res.json()
     testResult.value = {
@@ -220,6 +222,7 @@ const selectCls = 'w-full rounded-xl border border-slate-200/80 bg-white px-4 py
               <input
                 v-model="form.name"
                 type="text"
+                autocomplete="one-time-code"
                 :placeholder="typeConfig.namePlaceholder"
                 :class="inputCls"
                 autofocus
@@ -231,6 +234,7 @@ const selectCls = 'w-full rounded-xl border border-slate-200/80 bg-white px-4 py
               <input
                 v-model="form.api_key"
                 type="password"
+                autocomplete="new-password"
                 :placeholder="isEdit && editData?.api_key_set ? `已设置 (${editData.api_key_hint})，留空则不修改` : typeConfig.secretPlaceholder"
                 :class="inputCls"
               />
@@ -241,6 +245,7 @@ const selectCls = 'w-full rounded-xl border border-slate-200/80 bg-white px-4 py
               <input
                 v-model="form.base_url"
                 type="text"
+                autocomplete="one-time-code"
                 :placeholder="typeConfig.urlPlaceholder"
                 :class="inputCls"
               />

--- a/frontend/src/components/ProviderDialog.vue
+++ b/frontend/src/components/ProviderDialog.vue
@@ -1,5 +1,7 @@
 <script setup>
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, inject } from 'vue'
+
+const pushToast = inject('pushToast', (type, msg) => { console.warn(`[${type}] ${msg}`) })
 
 const props = defineProps({
   open: { type: Boolean, default: false },
@@ -14,9 +16,9 @@ const isEdit = computed(() => !!props.editData)
 const typeConfig = computed(() => ({
   openai: {
     title: isEdit.value ? '编辑 OpenAI 兼容供应商' : '添加 OpenAI 兼容供应商',
-    iconBg: 'bg-emerald-50 dark:bg-emerald-500/10',
-    iconCls: 'fa-bolt text-emerald-600 dark:text-emerald-400',
-    btnCls: 'bg-emerald-600 hover:bg-emerald-700 dark:bg-emerald-500 dark:hover:bg-emerald-600',
+    iconBg: 'bg-blue-50 dark:bg-blue-500/10',
+    iconCls: 'fa-bolt text-blue-600 dark:text-blue-400',
+    btnCls: 'bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600',
     namePlaceholder: '例如：DeepSeek / Qwen / Moonshot',
     urlPlaceholder: '留空使用 OpenAI 官方，或填入 https://api.deepseek.com 等',
     modelPlaceholder: 'gpt-4o-mini',
@@ -27,9 +29,9 @@ const typeConfig = computed(() => ({
   },
   anthropic: {
     title: isEdit.value ? '编辑 Anthropic 供应商' : '添加 Anthropic 供应商',
-    iconBg: 'bg-orange-50 dark:bg-orange-500/10',
-    iconCls: 'fa-brain text-orange-600 dark:text-orange-400',
-    btnCls: 'bg-orange-600 hover:bg-orange-700 dark:bg-orange-500 dark:hover:bg-orange-600',
+    iconBg: 'bg-blue-50 dark:bg-blue-500/10',
+    iconCls: 'fa-brain text-blue-600 dark:text-blue-400',
+    btnCls: 'bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600',
     namePlaceholder: '例如：Claude Official',
     urlPlaceholder: '留空使用 Anthropic 官方',
     modelPlaceholder: 'claude-sonnet-4-20250514',
@@ -103,17 +105,15 @@ const fetchModels = async () => {
     const data = await res.json()
     modelList.value = data.models || []
     if (modelList.value.length === 0) {
-      fetchModelError.value = '未获取到可用模型'
+      pushToast('error', '未获取到可用模型')
+    } else {
+      pushToast('success', `获取到 ${modelList.value.length} 个可用模型`)
     }
   } catch (e) {
-    fetchModelError.value = e.message || '获取失败'
+    pushToast('error', e.message || '获取模型列表失败')
   } finally {
     fetchingModels.value = false
   }
-}
-
-const selectModel = (field, modelId) => {
-  form.value[field] = modelId
 }
 
 // 每次打开时重置或回填表单
@@ -121,6 +121,7 @@ watch(() => props.open, (v) => {
   if (!v) return
   modelList.value = []
   fetchModelError.value = ''
+  openDropdown.value = null
   testResult.value = null
   if (props.editData) {
     form.value = {
@@ -185,18 +186,31 @@ const confirm = () => {
 }
 
 const inputCls = 'w-full rounded-xl border border-slate-200/80 bg-white px-4 py-2.5 text-sm text-slate-800 placeholder-slate-400 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-200 dark:placeholder-slate-500'
-const selectCls = 'w-full rounded-xl border border-slate-200/80 bg-white px-4 py-2.5 text-sm text-slate-800 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-200 appearance-none cursor-pointer bg-[url("data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'12\' height=\'12\' viewBox=\'0 0 12 12\'%3E%3Cpath fill=\'%2394a3b8\' d=\'M2 4l4 4 4-4\'/%3E%3C/svg%3E")] bg-[length:12px] bg-[right_12px_center] bg-no-repeat pr-10'
+
+// 自定义下拉
+const openDropdown = ref(null) // 'model_name' | 'light_model_name' | null
+const toggleDropdown = (field) => {
+  openDropdown.value = openDropdown.value === field ? null : field
+}
+const selectOption = (field, value) => {
+  form.value[field] = value
+  openDropdown.value = null
+}
 </script>
 
 <template>
   <Teleport to="body">
-    <Transition name="dialog-fade">
-      <div v-if="open" class="fixed inset-0 z-[100] flex items-center justify-center p-4" @click.self="emit('close')">
-        <!-- 背景遮罩 -->
-        <div class="absolute inset-0 bg-black/40 backdrop-blur-sm"></div>
+    <!-- 背景遮罩 -->
+    <div
+      class="fixed inset-0 z-[100] transition-[background-color,backdrop-filter] duration-200 md:left-64"
+      :class="open ? 'bg-black/40 backdrop-blur-sm pointer-events-auto' : 'bg-transparent backdrop-blur-none pointer-events-none'"
+      @click="emit('close')"
+    ></div>
 
+    <Transition name="dialog-fade">
+      <div v-if="open" class="fixed inset-0 z-[101] flex items-center justify-center p-4 md:left-64" @click.self="emit('close')">
         <!-- 弹窗主体 -->
-        <div class="relative w-full max-w-lg rounded-2xl border border-slate-200/60 bg-white/70 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-white/[0.03]">
+        <div class="relative w-full max-w-lg sm:w-[32rem] rounded-2xl border border-slate-200/60 bg-white shadow-2xl dark:border-white/10 dark:bg-[#0f0f17]">
           <!-- 头部 -->
           <div class="flex items-center justify-between border-b border-slate-100 px-6 py-4 dark:border-white/5">
             <div class="flex items-center gap-3">
@@ -216,7 +230,7 @@ const selectCls = 'w-full rounded-xl border border-slate-200/80 bg-white px-4 py
           </div>
 
           <!-- 表单 -->
-          <form autocomplete="off" class="space-y-4 px-6 py-5" @submit.prevent="confirm">
+          <form autocomplete="off" class="space-y-4 px-6 py-5" @submit.prevent="confirm" @click="openDropdown = null">
             <div>
               <label class="mb-1.5 block text-xs font-bold text-slate-600 dark:text-slate-400">{{ type === 'paddleocr' ? '服务名称' : '供应商名称' }}</label>
               <input
@@ -259,27 +273,48 @@ const selectCls = 'w-full rounded-xl border border-slate-200/80 bg-white px-4 py
                 class="inline-flex items-center gap-1.5 rounded-xl border border-slate-200/60 bg-white/60 px-3.5 py-2 text-xs font-bold text-slate-600 transition-all hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-white/10 dark:bg-white/5 dark:text-slate-300 dark:hover:bg-white/10"
               >
                 <i class="fa-solid text-[10px]" :class="fetchingModels ? 'fa-circle-notch fa-spin' : 'fa-arrows-rotate'"></i>
-                {{ fetchingModels ? '获取中...' : '获取模型列表' }}
+                <span class="inline-block w-[4.5rem] text-center">{{ fetchingModels ? '获取中...' : '获取模型列表' }}</span>
               </button>
-              <span v-if="fetchModelError" class="text-xs font-medium text-rose-500 dark:text-rose-400">{{ fetchModelError }}</span>
-              <span v-else-if="modelList.length > 0" class="text-xs font-medium text-emerald-600 dark:text-emerald-400">{{ modelList.length }} 个模型可用</span>
-              <span v-else-if="!canFetchModels" class="text-xs text-slate-400 dark:text-slate-500">请先填写 API Key</span>
+              <span v-if="!canFetchModels" class="text-xs text-slate-400 dark:text-slate-500">请先填写 API Key</span>
             </div>
 
             <div class="grid gap-4" :class="type === 'openai' ? 'sm:grid-cols-2' : ''">
               <div>
-                <label class="mb-1.5 block text-xs font-bold text-slate-600 dark:text-slate-400">
+                <label class="mb-1.5 flex items-center gap-1.5 text-xs font-bold text-slate-600 dark:text-slate-400">
                   {{ type === 'paddleocr' ? 'OCR 模型' : '默认模型' }}
+                  <span v-if="type !== 'paddleocr'" class="group relative">
+                    <i class="fa-solid fa-circle-info cursor-help text-slate-400 transition-colors hover:text-blue-500 dark:text-slate-500"></i>
+                    <span class="pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 -translate-x-1/2 whitespace-nowrap rounded-lg border border-slate-200/60 bg-white/90 px-3 py-1.5 text-xs font-normal text-slate-600 opacity-0 shadow-lg backdrop-blur-xl transition-opacity group-hover:opacity-100 dark:border-white/10 dark:bg-[#0A0A0F]/90 dark:text-slate-300">
+                      用于题目分割、纠错等核心任务
+                    </span>
+                  </span>
                 </label>
-                <!-- 有模型列表时用 select -->
-                <select
-                  v-if="modelList.length > 0 && type !== 'paddleocr'"
-                  v-model="form.model_name"
-                  :class="selectCls"
-                >
-                  <option value="" disabled>请选择模型</option>
-                  <option v-for="m in modelList" :key="m" :value="m">{{ m }}</option>
-                </select>
+                <!-- 有模型列表时用自定义下拉 -->
+                <div v-if="modelList.length > 0 && type !== 'paddleocr'" class="relative">
+                  <button
+                    type="button"
+                    @click.stop="toggleDropdown('model_name')"
+                    class="flex w-full items-center justify-between rounded-xl border border-slate-200/80 bg-white/70 px-4 py-2.5 text-left text-sm backdrop-blur-xl transition-colors dark:border-white/10 dark:bg-slate-800/60"
+                    :class="form.model_name ? 'text-slate-800 dark:text-slate-200' : 'text-slate-400 dark:text-slate-500'"
+                  >
+                    <span class="truncate">{{ form.model_name || '请选择模型' }}</span>
+                    <i class="fa-solid fa-chevron-down ml-2 text-[10px] text-slate-400 transition-transform" :class="openDropdown === 'model_name' ? 'rotate-180' : ''"></i>
+                  </button>
+                  <Transition name="dropdown">
+                    <div v-if="openDropdown === 'model_name'" class="absolute z-50 mt-1.5 max-h-48 w-full overflow-y-auto rounded-xl border border-slate-200/60 bg-white/80 py-1 shadow-xl backdrop-blur-xl dark:border-white/10 dark:bg-[#0A0A0F]/80">
+                      <button
+                        v-for="m in modelList" :key="m"
+                        type="button"
+                        @click.stop="selectOption('model_name', m)"
+                        class="flex w-full items-center gap-2 px-4 py-2 text-left text-sm transition-colors hover:bg-blue-50/80 dark:hover:bg-blue-500/10"
+                        :class="form.model_name === m ? 'font-bold text-blue-600 dark:text-blue-400' : 'text-slate-700 dark:text-slate-300'"
+                      >
+                        <i v-if="form.model_name === m" class="fa-solid fa-check text-[10px] text-blue-500"></i>
+                        <span :class="form.model_name !== m ? 'pl-[18px]' : ''">{{ m }}</span>
+                      </button>
+                    </div>
+                  </Transition>
+                </div>
                 <!-- 无模型列表时用 input -->
                 <input
                   v-else
@@ -290,15 +325,50 @@ const selectCls = 'w-full rounded-xl border border-slate-200/80 bg-white px-4 py
                 />
               </div>
               <div v-if="type === 'openai'">
-                <label class="mb-1.5 block text-xs font-bold text-slate-600 dark:text-slate-400">轻量模型 <span class="font-normal text-slate-400">（可选）</span></label>
-                <select
-                  v-if="modelList.length > 0"
-                  v-model="form.light_model_name"
-                  :class="selectCls"
-                >
-                  <option value="">不使用</option>
-                  <option v-for="m in modelList" :key="m" :value="m">{{ m }}</option>
-                </select>
+                <label class="mb-1.5 flex items-center gap-1.5 text-xs font-bold text-slate-600 dark:text-slate-400">
+                  辅助模型
+                  <span class="font-normal text-slate-400">（可选）</span>
+                  <span class="group relative">
+                    <i class="fa-solid fa-circle-info cursor-help text-slate-400 transition-colors hover:text-blue-500 dark:text-slate-500"></i>
+                    <span class="pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 -translate-x-1/2 whitespace-nowrap rounded-lg border border-slate-200/60 bg-white/90 px-3 py-1.5 text-xs font-normal text-slate-600 opacity-0 shadow-lg backdrop-blur-xl transition-opacity group-hover:opacity-100 dark:border-white/10 dark:bg-[#0A0A0F]/90 dark:text-slate-300">
+                      用于科目识别等简单任务，更快更省 Token
+                    </span>
+                  </span>
+                </label>
+                <div v-if="modelList.length > 0" class="relative">
+                  <button
+                    type="button"
+                    @click.stop="toggleDropdown('light_model_name')"
+                    class="flex w-full items-center justify-between rounded-xl border border-slate-200/80 bg-white/70 px-4 py-2.5 text-left text-sm backdrop-blur-xl transition-colors dark:border-white/10 dark:bg-slate-800/60"
+                    :class="form.light_model_name ? 'text-slate-800 dark:text-slate-200' : 'text-slate-400 dark:text-slate-500'"
+                  >
+                    <span class="truncate">{{ form.light_model_name || '不使用' }}</span>
+                    <i class="fa-solid fa-chevron-down ml-2 text-[10px] text-slate-400 transition-transform" :class="openDropdown === 'light_model_name' ? 'rotate-180' : ''"></i>
+                  </button>
+                  <Transition name="dropdown">
+                    <div v-if="openDropdown === 'light_model_name'" class="absolute z-50 mt-1.5 max-h-48 w-full overflow-y-auto rounded-xl border border-slate-200/60 bg-white/80 py-1 shadow-xl backdrop-blur-xl dark:border-white/10 dark:bg-[#0A0A0F]/80">
+                      <button
+                        type="button"
+                        @click.stop="selectOption('light_model_name', '')"
+                        class="flex w-full items-center gap-2 px-4 py-2 text-left text-sm transition-colors hover:bg-blue-50/80 dark:hover:bg-blue-500/10"
+                        :class="!form.light_model_name ? 'font-bold text-blue-600 dark:text-blue-400' : 'text-slate-700 dark:text-slate-300'"
+                      >
+                        <i v-if="!form.light_model_name" class="fa-solid fa-check text-[10px] text-blue-500"></i>
+                        <span :class="form.light_model_name ? 'pl-[18px]' : ''">不使用</span>
+                      </button>
+                      <button
+                        v-for="m in modelList" :key="m"
+                        type="button"
+                        @click.stop="selectOption('light_model_name', m)"
+                        class="flex w-full items-center gap-2 px-4 py-2 text-left text-sm transition-colors hover:bg-blue-50/80 dark:hover:bg-blue-500/10"
+                        :class="form.light_model_name === m ? 'font-bold text-blue-600 dark:text-blue-400' : 'text-slate-700 dark:text-slate-300'"
+                      >
+                        <i v-if="form.light_model_name === m" class="fa-solid fa-check text-[10px] text-blue-500"></i>
+                        <span :class="form.light_model_name !== m ? 'pl-[18px]' : ''">{{ m }}</span>
+                      </button>
+                    </div>
+                  </Transition>
+                </div>
                 <input
                   v-else
                   v-model="form.light_model_name"
@@ -403,12 +473,26 @@ const selectCls = 'w-full rounded-xl border border-slate-200/80 bg-white px-4 py
 </template>
 
 <style scoped>
-.dialog-fade-enter-active,
+.dialog-fade-enter-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
 .dialog-fade-leave-active {
-  transition: opacity 0.2s ease;
+  transition: opacity 0.15s ease, transform 0.15s ease;
 }
 .dialog-fade-enter-from,
 .dialog-fade-leave-to {
   opacity: 0;
+  transform: scale(0.96);
+}
+.dropdown-enter-active {
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+.dropdown-leave-active {
+  transition: opacity 0.1s ease, transform 0.1s ease;
+}
+.dropdown-enter-from,
+.dropdown-leave-to {
+  opacity: 0;
+  transform: translateY(-4px);
 }
 </style>

--- a/frontend/src/components/SettingsView.vue
+++ b/frontend/src/components/SettingsView.vue
@@ -19,7 +19,7 @@ const saving = ref(false)
 const makeOpenAIProvider = (data = {}) => ({
   id: data.id || crypto.randomUUID(),
   name: data.name || '',
-  api_key: '',
+  api_key: data.api_key || '',
   base_url: data.base_url || '',
   model_name: data.model_name || '',
   light_model_name: data.light_model_name || '',
@@ -31,7 +31,7 @@ const makeOpenAIProvider = (data = {}) => ({
 const makeAnthropicProvider = (data = {}) => ({
   id: data.id || crypto.randomUUID(),
   name: data.name || '',
-  api_key: '',
+  api_key: data.api_key || '',
   base_url: data.base_url || '',
   model_name: data.model_name || '',
   api_key_set: data.api_key_set || false,
@@ -41,7 +41,7 @@ const makeAnthropicProvider = (data = {}) => ({
 const makePaddleOCRProvider = (data = {}) => ({
   id: data.id || crypto.randomUUID(),
   name: data.name || '',
-  api_key: '',
+  api_key: data.api_key || '',
   base_url: data.base_url || data.api_url || '',
   model_name: data.model_name || data.model || '',
   use_doc_orientation: data.use_doc_orientation || false,
@@ -204,7 +204,7 @@ const onDialogConfirm = (formData) => {
       anthropicProviders.value.push(p)
       if (anthropicProviders.value.length === 1) activeAnthropicId.value = p.id
     } else {
-      const p = makePaddleOCRProvider({ name: formData.name, api_url: formData.base_url, model: formData.model_name, use_doc_orientation: formData.use_doc_orientation, use_doc_unwarping: formData.use_doc_unwarping, use_chart_recognition: formData.use_chart_recognition })
+      const p = makePaddleOCRProvider({ name: formData.name, api_key: formData.api_key, api_url: formData.base_url, model: formData.model_name, use_doc_orientation: formData.use_doc_orientation, use_doc_unwarping: formData.use_doc_unwarping, use_chart_recognition: formData.use_chart_recognition })
       paddleocrProviders.value.push(p)
       if (paddleocrProviders.value.length === 1) activePaddleocrId.value = p.id
     }

--- a/frontend/src/components/SettingsView.vue
+++ b/frontend/src/components/SettingsView.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, inject, onMounted, watch } from 'vue'
 import { fetchAppConfig, updateAppConfig } from '../api.js'
+import ProviderDialog from './ProviderDialog.vue'
 
 const props = defineProps({
   visible: { type: Boolean, default: false },
@@ -13,45 +14,91 @@ const pushToast = inject('pushToast', (type, msg) => { console.warn(`[${type}] $
 const loading = ref(true)
 const saving = ref(false)
 
-// 表单数据
-const form = ref({
-  openai: { api_key: '', base_url: '', model_name: '', light_model_name: '', supports_function_calling: true },
-  anthropic: { api_key: '', base_url: '', model_name: '' },
-  paddleocr: { api_url: '', api_token: '', model: '', use_doc_orientation: false, use_doc_unwarping: false, use_chart_recognition: false },
+// ---------- 多 Provider 数据结构 ----------
+
+const makeOpenAIProvider = (data = {}) => ({
+  id: data.id || crypto.randomUUID(),
+  name: data.name || '',
+  api_key: '',
+  base_url: data.base_url || '',
+  model_name: data.model_name || '',
+  light_model_name: data.light_model_name || '',
+  supports_function_calling: data.supports_function_calling ?? true,
+  api_key_set: data.api_key_set || false,
+  api_key_hint: data.api_key_hint || '',
 })
 
-// 用于显示占位提示
-const hints = ref({
-  openai: { api_key_set: false, api_key_hint: '' },
-  anthropic: { api_key_set: false, api_key_hint: '' },
-  paddleocr: { api_token_set: false, api_token_hint: '' },
+const makeAnthropicProvider = (data = {}) => ({
+  id: data.id || crypto.randomUUID(),
+  name: data.name || '',
+  api_key: '',
+  base_url: data.base_url || '',
+  model_name: data.model_name || '',
+  api_key_set: data.api_key_set || false,
+  api_key_hint: data.api_key_hint || '',
 })
+
+const makePaddleOCRProvider = (data = {}) => ({
+  id: data.id || crypto.randomUUID(),
+  name: data.name || '',
+  api_key: '',
+  base_url: data.base_url || data.api_url || '',
+  model_name: data.model_name || data.model || '',
+  use_doc_orientation: data.use_doc_orientation || false,
+  use_doc_unwarping: data.use_doc_unwarping || false,
+  use_chart_recognition: data.use_chart_recognition || false,
+  api_key_set: data.api_key_set || data.api_token_set || false,
+  api_key_hint: data.api_key_hint || data.api_token_hint || '',
+})
+
+const openaiProviders = ref([])
+const anthropicProviders = ref([])
+const paddleocrProviders = ref([])
+
+// 当前激活的 provider ID（每类只能激活一个）
+const activeOpenaiId = ref(null)
+const activeAnthropicId = ref(null)
+const activePaddleocrId = ref(null)
+
+const toggleActive = (type, id) => {
+  const refMap = { openai: activeOpenaiId, anthropic: activeAnthropicId, paddleocr: activePaddleocrId }
+  const target = refMap[type]
+  target.value = target.value === id ? null : id
+}
+
+// ---------- 加载 / 保存 ----------
 
 const loadConfig = async () => {
   loading.value = true
   try {
     const cfg = await fetchAppConfig()
-    // 填充表单（密钥字段留空，用户不修改则不提交）
-    form.value.openai.base_url = cfg.openai?.base_url || ''
-    form.value.openai.model_name = cfg.openai?.model_name || ''
-    form.value.openai.light_model_name = cfg.openai?.light_model_name || ''
-    form.value.openai.supports_function_calling = cfg.openai?.supports_function_calling ?? true
-    form.value.openai.api_key = ''
 
-    form.value.anthropic.base_url = cfg.anthropic?.base_url || ''
-    form.value.anthropic.model_name = cfg.anthropic?.model_name || ''
-    form.value.anthropic.api_key = ''
+    if (cfg.openai_providers && cfg.openai_providers.length > 0) {
+      openaiProviders.value = cfg.openai_providers.map(p => makeOpenAIProvider(p))
+    } else if (cfg.openai) {
+      openaiProviders.value = [makeOpenAIProvider({ name: 'Default', ...cfg.openai })]
+    } else {
+      openaiProviders.value = []
+    }
+    activeOpenaiId.value = cfg.active_openai_id || openaiProviders.value[0]?.id || null
 
-    form.value.paddleocr.api_url = cfg.paddleocr?.api_url || ''
-    form.value.paddleocr.model = cfg.paddleocr?.model || ''
-    form.value.paddleocr.api_token = ''
-    form.value.paddleocr.use_doc_orientation = cfg.paddleocr?.use_doc_orientation || false
-    form.value.paddleocr.use_doc_unwarping = cfg.paddleocr?.use_doc_unwarping || false
-    form.value.paddleocr.use_chart_recognition = cfg.paddleocr?.use_chart_recognition || false
+    if (cfg.anthropic_providers && cfg.anthropic_providers.length > 0) {
+      anthropicProviders.value = cfg.anthropic_providers.map(p => makeAnthropicProvider(p))
+    } else if (cfg.anthropic) {
+      anthropicProviders.value = [makeAnthropicProvider({ name: 'Default', ...cfg.anthropic })]
+    } else {
+      anthropicProviders.value = []
+    }
+    activeAnthropicId.value = cfg.active_anthropic_id || anthropicProviders.value[0]?.id || null
 
-    hints.value.openai = { api_key_set: cfg.openai?.api_key_set, api_key_hint: cfg.openai?.api_key_hint || '' }
-    hints.value.anthropic = { api_key_set: cfg.anthropic?.api_key_set, api_key_hint: cfg.anthropic?.api_key_hint || '' }
-    hints.value.paddleocr = { api_token_set: cfg.paddleocr?.api_token_set, api_token_hint: cfg.paddleocr?.api_token_hint || '' }
+    if (cfg.paddleocr_providers && cfg.paddleocr_providers.length > 0) {
+      paddleocrProviders.value = cfg.paddleocr_providers.map(p => makePaddleOCRProvider(p))
+    } else if (cfg.paddleocr) {
+      paddleocrProviders.value = [makePaddleOCRProvider({ name: 'Default', ...cfg.paddleocr })]
+    } else {
+      paddleocrProviders.value = []
+    }
+    activePaddleocrId.value = cfg.active_paddleocr_id || paddleocrProviders.value[0]?.id || null
   } catch (e) {
     pushToast('error', '加载配置失败: ' + (e instanceof Error ? e.message : String(e)))
   } finally {
@@ -65,42 +112,104 @@ const saveConfig = async () => {
   try {
     const payload = {}
 
-    // OpenAI
-    const oa = {}
-    if (form.value.openai.api_key) oa.api_key = form.value.openai.api_key
-    oa.base_url = form.value.openai.base_url
-    oa.model_name = form.value.openai.model_name
-    oa.light_model_name = form.value.openai.light_model_name
-    oa.supports_function_calling = form.value.openai.supports_function_calling
-    payload.openai = oa
+    payload.openai_providers = openaiProviders.value.map(p => {
+      const item = { id: p.id, name: p.name, base_url: p.base_url, model_name: p.model_name, light_model_name: p.light_model_name, supports_function_calling: p.supports_function_calling }
+      if (p.api_key) item.api_key = p.api_key
+      return item
+    })
 
-    // Anthropic
-    const an = {}
-    if (form.value.anthropic.api_key) an.api_key = form.value.anthropic.api_key
-    an.base_url = form.value.anthropic.base_url
-    an.model_name = form.value.anthropic.model_name
-    payload.anthropic = an
+    payload.anthropic_providers = anthropicProviders.value.map(p => {
+      const item = { id: p.id, name: p.name, base_url: p.base_url, model_name: p.model_name }
+      if (p.api_key) item.api_key = p.api_key
+      return item
+    })
 
-    // PaddleOCR
-    const po = {}
-    if (form.value.paddleocr.api_token) po.api_token = form.value.paddleocr.api_token
-    po.api_url = form.value.paddleocr.api_url
-    po.model = form.value.paddleocr.model
-    po.use_doc_orientation = form.value.paddleocr.use_doc_orientation
-    po.use_doc_unwarping = form.value.paddleocr.use_doc_unwarping
-    po.use_chart_recognition = form.value.paddleocr.use_chart_recognition
-    payload.paddleocr = po
+    payload.paddleocr_providers = paddleocrProviders.value.map(p => {
+      const item = { id: p.id, name: p.name, api_url: p.base_url, model: p.model_name, use_doc_orientation: p.use_doc_orientation, use_doc_unwarping: p.use_doc_unwarping, use_chart_recognition: p.use_chart_recognition }
+      if (p.api_key) item.api_token = p.api_key
+      return item
+    })
+
+    payload.active_openai_id = activeOpenaiId.value
+    payload.active_anthropic_id = activeAnthropicId.value
+    payload.active_paddleocr_id = activePaddleocrId.value
 
     await updateAppConfig(payload)
     pushToast('success', '配置已保存并生效')
     emit('saved')
-    // 重新加载以更新 hints
     await loadConfig()
   } catch (e) {
     pushToast('error', '保存失败: ' + (e instanceof Error ? e.message : String(e)))
   } finally {
     saving.value = false
   }
+}
+
+const removeOpenAIProvider = (idx) => {
+  if (openaiProviders.value[idx]?.id === activeOpenaiId.value) activeOpenaiId.value = null
+  openaiProviders.value.splice(idx, 1)
+}
+
+const removeAnthropicProvider = (idx) => {
+  if (anthropicProviders.value[idx]?.id === activeAnthropicId.value) activeAnthropicId.value = null
+  anthropicProviders.value.splice(idx, 1)
+}
+
+const removePaddleOCRProvider = (idx) => {
+  if (paddleocrProviders.value[idx]?.id === activePaddleocrId.value) activePaddleocrId.value = null
+  paddleocrProviders.value.splice(idx, 1)
+}
+
+// ---------- 弹窗控制 ----------
+const dialogOpen = ref(false)
+const dialogType = ref('openai')
+const dialogEditData = ref(null)  // null=新增, object=编辑
+const dialogEditIndex = ref(-1)
+
+const openAddDialog = (type) => {
+  dialogType.value = type
+  dialogEditData.value = null
+  dialogEditIndex.value = -1
+  dialogOpen.value = true
+}
+
+const openEditDialog = (type, provider, idx) => {
+  dialogType.value = type
+  dialogEditData.value = { ...provider }
+  dialogEditIndex.value = idx
+  dialogOpen.value = true
+}
+
+const onDialogConfirm = (formData) => {
+  if (dialogEditIndex.value >= 0) {
+    // 编辑模式：更新已有 provider
+    const listMap = { openai: openaiProviders, anthropic: anthropicProviders, paddleocr: paddleocrProviders }
+    const list = listMap[dialogType.value]
+    const existing = list.value[dialogEditIndex.value]
+    if (existing) {
+      Object.assign(existing, formData)
+      if (dialogType.value === 'paddleocr') {
+        existing.base_url = formData.base_url
+        existing.model_name = formData.model_name
+      }
+    }
+  } else {
+    // 新增模式
+    if (dialogType.value === 'openai') {
+      const p = makeOpenAIProvider(formData)
+      openaiProviders.value.push(p)
+      if (openaiProviders.value.length === 1) activeOpenaiId.value = p.id
+    } else if (dialogType.value === 'anthropic') {
+      const p = makeAnthropicProvider(formData)
+      anthropicProviders.value.push(p)
+      if (anthropicProviders.value.length === 1) activeAnthropicId.value = p.id
+    } else {
+      const p = makePaddleOCRProvider({ name: formData.name, api_url: formData.base_url, model: formData.model_name, use_doc_orientation: formData.use_doc_orientation, use_doc_unwarping: formData.use_doc_unwarping, use_chart_recognition: formData.use_chart_recognition })
+      paddleocrProviders.value.push(p)
+      if (paddleocrProviders.value.length === 1) activePaddleocrId.value = p.id
+    }
+  }
+  dialogOpen.value = false
 }
 
 onMounted(() => { if (props.visible) loadConfig() })
@@ -127,194 +236,214 @@ watch(() => props.visible, (v) => { if (v) loadConfig() })
       <div v-else class="space-y-6">
 
         <!-- ====== OpenAI 兼容 API ====== -->
-        <div class="rounded-2xl border border-slate-200/60 bg-white/70 p-6 shadow-sm backdrop-blur-xl dark:border-white/10 dark:bg-[#0A0A0F]/60">
-          <div class="mb-5 flex items-center gap-3">
-            <div class="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-50 dark:bg-emerald-500/10">
-              <i class="fa-solid fa-bolt text-lg text-emerald-600 dark:text-emerald-400"></i>
+        <div>
+          <div class="mb-3 flex items-center justify-between pl-1">
+            <div class="flex items-center gap-3">
+              <div class="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-50 dark:bg-emerald-500/10">
+                <i class="fa-solid fa-bolt text-lg text-emerald-600 dark:text-emerald-400"></i>
+              </div>
+              <div>
+                <h3 class="text-base font-bold text-slate-800 dark:text-slate-200">OpenAI 兼容 API</h3>
+                <p class="text-xs text-slate-500 dark:text-slate-400">支持 OpenAI / DeepSeek / Qwen / Moonshot 等</p>
+              </div>
             </div>
-            <div>
-              <h3 class="text-base font-bold text-slate-800 dark:text-slate-200">OpenAI 兼容 API</h3>
-              <p class="text-xs text-slate-500 dark:text-slate-400">支持 OpenAI / DeepSeek / Qwen / Moonshot 等，通过 Base URL 切换</p>
-            </div>
+            <button
+              @click="openAddDialog('openai')"
+              class="inline-flex items-center gap-1.5 rounded-xl border border-dashed border-slate-300 px-3 py-1.5 text-xs font-bold text-slate-500 transition-all hover:border-emerald-400 hover:bg-emerald-50 hover:text-emerald-600 dark:border-white/10 dark:text-slate-400 dark:hover:border-emerald-500/40 dark:hover:bg-emerald-500/10 dark:hover:text-emerald-400"
+            >
+              <i class="fa-solid fa-plus text-[10px]"></i>
+              添加
+            </button>
           </div>
-          <div class="grid gap-4 sm:grid-cols-2">
-            <div class="sm:col-span-2">
-              <label class="mb-1.5 block text-xs font-bold text-slate-600 dark:text-slate-400">API Key</label>
-              <input
-                v-model="form.openai.api_key"
-                type="password"
-                :placeholder="hints.openai.api_key_set ? `已设置 (${hints.openai.api_key_hint})` : '输入 API Key'"
-                class="w-full rounded-xl border border-slate-200/80 bg-white px-4 py-2.5 text-sm text-slate-800 placeholder-slate-400 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-200 dark:placeholder-slate-500"
-              />
-            </div>
-            <div class="sm:col-span-2">
-              <label class="mb-1.5 block text-xs font-bold text-slate-600 dark:text-slate-400">Base URL</label>
-              <input
-                v-model="form.openai.base_url"
-                type="text"
-                placeholder="留空使用 OpenAI 官方，或填入 https://api.deepseek.com 等"
-                class="w-full rounded-xl border border-slate-200/80 bg-white px-4 py-2.5 text-sm text-slate-800 placeholder-slate-400 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-200 dark:placeholder-slate-500"
-              />
-            </div>
-            <div>
-              <label class="mb-1.5 block text-xs font-bold text-slate-600 dark:text-slate-400">默认模型</label>
-              <input
-                v-model="form.openai.model_name"
-                type="text"
-                placeholder="gpt-4o-mini"
-                class="w-full rounded-xl border border-slate-200/80 bg-white px-4 py-2.5 text-sm text-slate-800 placeholder-slate-400 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-200 dark:placeholder-slate-500"
-              />
-            </div>
-            <div>
-              <label class="mb-1.5 block text-xs font-bold text-slate-600 dark:text-slate-400">轻量模型 <span class="font-normal text-slate-400">（可选）</span></label>
-              <input
-                v-model="form.openai.light_model_name"
-                type="text"
-                placeholder="科目识别等轻量任务使用"
-                class="w-full rounded-xl border border-slate-200/80 bg-white px-4 py-2.5 text-sm text-slate-800 placeholder-slate-400 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-200 dark:placeholder-slate-500"
-              />
-            </div>
+
+          <div v-if="openaiProviders.length === 0" class="rounded-2xl border border-dashed border-slate-200/60 py-10 text-center dark:border-white/10">
+            <i class="fa-solid fa-plug text-3xl text-slate-300 dark:text-slate-600"></i>
+            <p class="mt-3 text-sm font-medium text-slate-400 dark:text-slate-500">尚未配置，点击上方"添加"按钮</p>
           </div>
-          <!-- 能力开关 -->
-          <div class="mt-5 border-t border-slate-100 pt-5 dark:border-white/5">
-            <p class="mb-3 text-xs font-bold text-slate-600 dark:text-slate-400">能力开关</p>
-            <div class="space-y-3">
-              <label
-                v-for="toggle in [
-                  { key: 'supports_function_calling', label: '支持 Function Calling', description: '文心一言、通义千问等不支持时需关闭，否则会陷入无限循环' },
-                ]"
-                :key="toggle.key"
-                class="flex cursor-pointer items-center justify-between"
+
+          <div class="space-y-2">
+            <div
+              v-for="(provider, idx) in openaiProviders" :key="provider.id"
+              class="flex items-center gap-3 rounded-2xl border border-slate-200/60 bg-white/70 px-5 py-3.5 shadow-sm backdrop-blur-xl transition-all dark:border-white/10 dark:bg-white/[0.03]"
+            >
+              <!-- 激活单选 -->
+              <button
+                @click="toggleActive('openai', provider.id)"
+                class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-all"
+                :class="activeOpenaiId === provider.id
+                  ? 'border-emerald-500 bg-emerald-500 dark:border-emerald-400 dark:bg-emerald-400'
+                  : 'border-slate-300 hover:border-emerald-400 dark:border-slate-600 dark:hover:border-emerald-500'"
+                :title="activeOpenaiId === provider.id ? '当前已启用' : '点击启用'"
               >
-                <div>
-                  <span class="text-sm font-medium text-slate-700 dark:text-slate-300">{{ toggle.label }}</span>
-                  <p v-if="toggle.description" class="mt-0.5 text-xs text-slate-400 dark:text-slate-500">{{ toggle.description }}</p>
-                </div>
-                <button
-                  type="button"
-                  @click="form.openai[toggle.key] = !form.openai[toggle.key]"
-                  class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500/50"
-                  :class="form.openai[toggle.key] ? 'bg-blue-600 dark:bg-indigo-500' : 'bg-slate-200 dark:bg-slate-700'"
-                >
-                  <span
-                    class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
-                    :class="form.openai[toggle.key] ? 'translate-x-5' : 'translate-x-0'"
-                  ></span>
-                </button>
-              </label>
+                <i v-if="activeOpenaiId === provider.id" class="fa-solid fa-check text-[9px] text-white"></i>
+              </button>
+
+              <!-- 名称 + 状态 -->
+              <div class="flex min-w-0 flex-1 items-center gap-2">
+                <span class="truncate text-sm font-bold text-slate-800 dark:text-slate-200">{{ provider.name || '未命名' }}</span>
+                <span v-if="activeOpenaiId === provider.id" class="shrink-0 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-bold text-emerald-600 dark:bg-emerald-500/15 dark:text-emerald-400">
+                  使用中
+                </span>
+                <span v-else-if="provider.api_key_set" class="shrink-0 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-bold text-slate-500 dark:bg-white/5 dark:text-slate-400">
+                  已配置
+                </span>
+              </div>
+
+              <!-- 设置 + 删除 -->
+              <button
+                @click="openEditDialog('openai', provider, idx)"
+                class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-white/5 dark:hover:text-slate-300"
+                title="设置"
+              >
+                <i class="fa-solid fa-gear text-xs"></i>
+              </button>
+              <button
+                @click="removeOpenAIProvider(idx)"
+                class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-rose-50 hover:text-rose-500 dark:hover:bg-rose-500/10"
+                title="删除"
+              >
+                <i class="fa-solid fa-trash-can text-xs"></i>
+              </button>
             </div>
           </div>
         </div>
 
         <!-- ====== Anthropic API ====== -->
-        <div class="rounded-2xl border border-slate-200/60 bg-white/70 p-6 shadow-sm backdrop-blur-xl dark:border-white/10 dark:bg-[#0A0A0F]/60">
-          <div class="mb-5 flex items-center gap-3">
-            <div class="flex h-10 w-10 items-center justify-center rounded-xl bg-orange-50 dark:bg-orange-500/10">
-              <i class="fa-solid fa-brain text-lg text-orange-600 dark:text-orange-400"></i>
+        <div>
+          <div class="mb-3 flex items-center justify-between pl-1">
+            <div class="flex items-center gap-3">
+              <div class="flex h-10 w-10 items-center justify-center rounded-xl bg-orange-50 dark:bg-orange-500/10">
+                <i class="fa-solid fa-brain text-lg text-orange-600 dark:text-orange-400"></i>
+              </div>
+              <div>
+                <h3 class="text-base font-bold text-slate-800 dark:text-slate-200">Anthropic API</h3>
+                <p class="text-xs text-slate-500 dark:text-slate-400">Claude 系列模型</p>
+              </div>
             </div>
-            <div>
-              <h3 class="text-base font-bold text-slate-800 dark:text-slate-200">Anthropic API</h3>
-              <p class="text-xs text-slate-500 dark:text-slate-400">Claude 系列模型</p>
-            </div>
+            <button
+              @click="openAddDialog('anthropic')"
+              class="inline-flex items-center gap-1.5 rounded-xl border border-dashed border-slate-300 px-3 py-1.5 text-xs font-bold text-slate-500 transition-all hover:border-orange-400 hover:bg-orange-50 hover:text-orange-600 dark:border-white/10 dark:text-slate-400 dark:hover:border-orange-500/40 dark:hover:bg-orange-500/10 dark:hover:text-orange-400"
+            >
+              <i class="fa-solid fa-plus text-[10px]"></i>
+              添加
+            </button>
           </div>
-          <div class="grid gap-4 sm:grid-cols-2">
-            <div class="sm:col-span-2">
-              <label class="mb-1.5 block text-xs font-bold text-slate-600 dark:text-slate-400">API Key</label>
-              <input
-                v-model="form.anthropic.api_key"
-                type="password"
-                :placeholder="hints.anthropic.api_key_set ? `已设置 (${hints.anthropic.api_key_hint})` : '输入 API Key'"
-                class="w-full rounded-xl border border-slate-200/80 bg-white px-4 py-2.5 text-sm text-slate-800 placeholder-slate-400 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-200 dark:placeholder-slate-500"
-              />
-            </div>
-            <div class="sm:col-span-2">
-              <label class="mb-1.5 block text-xs font-bold text-slate-600 dark:text-slate-400">Base URL</label>
-              <input
-                v-model="form.anthropic.base_url"
-                type="text"
-                placeholder="留空使用 Anthropic 官方"
-                class="w-full rounded-xl border border-slate-200/80 bg-white px-4 py-2.5 text-sm text-slate-800 placeholder-slate-400 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-200 dark:placeholder-slate-500"
-              />
-            </div>
-            <div>
-              <label class="mb-1.5 block text-xs font-bold text-slate-600 dark:text-slate-400">默认模型</label>
-              <input
-                v-model="form.anthropic.model_name"
-                type="text"
-                placeholder="claude-sonnet-4-20250514"
-                class="w-full rounded-xl border border-slate-200/80 bg-white px-4 py-2.5 text-sm text-slate-800 placeholder-slate-400 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-200 dark:placeholder-slate-500"
-              />
+
+          <div v-if="anthropicProviders.length === 0" class="rounded-2xl border border-dashed border-slate-200/60 py-10 text-center dark:border-white/10">
+            <i class="fa-solid fa-plug text-3xl text-slate-300 dark:text-slate-600"></i>
+            <p class="mt-3 text-sm font-medium text-slate-400 dark:text-slate-500">尚未配置，点击上方"添加"按钮</p>
+          </div>
+
+          <div class="space-y-2">
+            <div
+              v-for="(provider, idx) in anthropicProviders" :key="provider.id"
+              class="flex items-center gap-3 rounded-2xl border border-slate-200/60 bg-white/70 px-5 py-3.5 shadow-sm backdrop-blur-xl transition-all dark:border-white/10 dark:bg-white/[0.03]"
+            >
+              <button
+                @click="toggleActive('anthropic', provider.id)"
+                class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-all"
+                :class="activeAnthropicId === provider.id
+                  ? 'border-orange-500 bg-orange-500 dark:border-orange-400 dark:bg-orange-400'
+                  : 'border-slate-300 hover:border-orange-400 dark:border-slate-600 dark:hover:border-orange-500'"
+                :title="activeAnthropicId === provider.id ? '当前已启用' : '点击启用'"
+              >
+                <i v-if="activeAnthropicId === provider.id" class="fa-solid fa-check text-[9px] text-white"></i>
+              </button>
+
+              <div class="flex min-w-0 flex-1 items-center gap-2">
+                <span class="truncate text-sm font-bold text-slate-800 dark:text-slate-200">{{ provider.name || '未命名' }}</span>
+                <span v-if="activeAnthropicId === provider.id" class="shrink-0 rounded-full bg-orange-100 px-2 py-0.5 text-[10px] font-bold text-orange-600 dark:bg-orange-500/15 dark:text-orange-400">
+                  使用中
+                </span>
+                <span v-else-if="provider.api_key_set" class="shrink-0 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-bold text-slate-500 dark:bg-white/5 dark:text-slate-400">
+                  已配置
+                </span>
+              </div>
+
+              <button
+                @click="openEditDialog('anthropic', provider, idx)"
+                class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-white/5 dark:hover:text-slate-300"
+                title="设置"
+              >
+                <i class="fa-solid fa-gear text-xs"></i>
+              </button>
+              <button
+                @click="removeAnthropicProvider(idx)"
+                class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-rose-50 hover:text-rose-500 dark:hover:bg-rose-500/10"
+                title="删除"
+              >
+                <i class="fa-solid fa-trash-can text-xs"></i>
+              </button>
             </div>
           </div>
         </div>
 
         <!-- ====== PaddleOCR ====== -->
-        <div class="rounded-2xl border border-slate-200/60 bg-white/70 p-6 shadow-sm backdrop-blur-xl dark:border-white/10 dark:bg-[#0A0A0F]/60">
-          <div class="mb-5 flex items-center gap-3">
-            <div class="flex h-10 w-10 items-center justify-center rounded-xl bg-blue-50 dark:bg-blue-500/10">
-              <i class="fa-solid fa-eye text-lg text-blue-600 dark:text-blue-400"></i>
+        <div>
+          <div class="mb-3 flex items-center justify-between pl-1">
+            <div class="flex items-center gap-3">
+              <div class="flex h-10 w-10 items-center justify-center rounded-xl bg-blue-50 dark:bg-blue-500/10">
+                <i class="fa-solid fa-eye text-lg text-blue-600 dark:text-blue-400"></i>
+              </div>
+              <div>
+                <h3 class="text-base font-bold text-slate-800 dark:text-slate-200">PaddleOCR</h3>
+                <p class="text-xs text-slate-500 dark:text-slate-400">文档 OCR 识别服务</p>
+              </div>
             </div>
-            <div>
-              <h3 class="text-base font-bold text-slate-800 dark:text-slate-200">PaddleOCR</h3>
-              <p class="text-xs text-slate-500 dark:text-slate-400">文档 OCR 识别服务</p>
-            </div>
-          </div>
-          <div class="grid gap-4 sm:grid-cols-2">
-            <div class="sm:col-span-2">
-              <label class="mb-1.5 block text-xs font-bold text-slate-600 dark:text-slate-400">API URL</label>
-              <input
-                v-model="form.paddleocr.api_url"
-                type="text"
-                placeholder="https://paddleocr.aistudio-app.com/api/v2/ocr/jobs"
-                class="w-full rounded-xl border border-slate-200/80 bg-white px-4 py-2.5 text-sm text-slate-800 placeholder-slate-400 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-200 dark:placeholder-slate-500"
-              />
-            </div>
-            <div class="sm:col-span-2">
-              <label class="mb-1.5 block text-xs font-bold text-slate-600 dark:text-slate-400">API Token</label>
-              <input
-                v-model="form.paddleocr.api_token"
-                type="password"
-                :placeholder="hints.paddleocr.api_token_set ? `已设置 (${hints.paddleocr.api_token_hint})` : '输入 API Token'"
-                class="w-full rounded-xl border border-slate-200/80 bg-white px-4 py-2.5 text-sm text-slate-800 placeholder-slate-400 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-200 dark:placeholder-slate-500"
-              />
-            </div>
-            <div>
-              <label class="mb-1.5 block text-xs font-bold text-slate-600 dark:text-slate-400">OCR 模型</label>
-              <input
-                v-model="form.paddleocr.model"
-                type="text"
-                placeholder="PaddleOCR-VL-1.5"
-                class="w-full rounded-xl border border-slate-200/80 bg-white px-4 py-2.5 text-sm text-slate-800 placeholder-slate-400 transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-200 dark:placeholder-slate-500"
-              />
-            </div>
+            <button
+              @click="openAddDialog('paddleocr')"
+              class="inline-flex items-center gap-1.5 rounded-xl border border-dashed border-slate-300 px-3 py-1.5 text-xs font-bold text-slate-500 transition-all hover:border-blue-400 hover:bg-blue-50 hover:text-blue-600 dark:border-white/10 dark:text-slate-400 dark:hover:border-blue-500/40 dark:hover:bg-blue-500/10 dark:hover:text-blue-400"
+            >
+              <i class="fa-solid fa-plus text-[10px]"></i>
+              添加
+            </button>
           </div>
 
-          <!-- PaddleOCR 开关 -->
-          <div class="mt-5 border-t border-slate-100 pt-5 dark:border-white/5">
-            <p class="mb-3 text-xs font-bold text-slate-600 dark:text-slate-400">功能开关</p>
-            <div class="space-y-3">
-              <label
-                v-for="toggle in [
-                  { key: 'use_doc_orientation', label: '文档方向检测' },
-                  { key: 'use_doc_unwarping', label: '文档去畸变' },
-                  { key: 'use_chart_recognition', label: '图表识别' },
-                ]"
-                :key="toggle.key"
-                class="flex cursor-pointer items-center justify-between"
+          <div v-if="paddleocrProviders.length === 0" class="rounded-2xl border border-dashed border-slate-200/60 py-10 text-center dark:border-white/10">
+            <i class="fa-solid fa-plug text-3xl text-slate-300 dark:text-slate-600"></i>
+            <p class="mt-3 text-sm font-medium text-slate-400 dark:text-slate-500">尚未配置，点击上方"添加"按钮</p>
+          </div>
+
+          <div class="space-y-2">
+            <div
+              v-for="(provider, idx) in paddleocrProviders" :key="provider.id"
+              class="flex items-center gap-3 rounded-2xl border border-slate-200/60 bg-white/70 px-5 py-3.5 shadow-sm backdrop-blur-xl transition-all dark:border-white/10 dark:bg-white/[0.03]"
+            >
+              <button
+                @click="toggleActive('paddleocr', provider.id)"
+                class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-all"
+                :class="activePaddleocrId === provider.id
+                  ? 'border-blue-500 bg-blue-500 dark:border-blue-400 dark:bg-blue-400'
+                  : 'border-slate-300 hover:border-blue-400 dark:border-slate-600 dark:hover:border-blue-500'"
+                :title="activePaddleocrId === provider.id ? '当前已启用' : '点击启用'"
               >
-                <span class="text-sm font-medium text-slate-700 dark:text-slate-300">{{ toggle.label }}</span>
-                <button
-                  type="button"
-                  @click="form.paddleocr[toggle.key] = !form.paddleocr[toggle.key]"
-                  class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500/50"
-                  :class="form.paddleocr[toggle.key] ? 'bg-blue-600 dark:bg-indigo-500' : 'bg-slate-200 dark:bg-slate-700'"
-                >
-                  <span
-                    class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
-                    :class="form.paddleocr[toggle.key] ? 'translate-x-5' : 'translate-x-0'"
-                  ></span>
-                </button>
-              </label>
+                <i v-if="activePaddleocrId === provider.id" class="fa-solid fa-check text-[9px] text-white"></i>
+              </button>
+
+              <div class="flex min-w-0 flex-1 items-center gap-2">
+                <span class="truncate text-sm font-bold text-slate-800 dark:text-slate-200">{{ provider.name || '未命名' }}</span>
+                <span v-if="activePaddleocrId === provider.id" class="shrink-0 rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-bold text-blue-600 dark:bg-blue-500/15 dark:text-blue-400">
+                  使用中
+                </span>
+                <span v-else-if="provider.api_key_set" class="shrink-0 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-bold text-slate-500 dark:bg-white/5 dark:text-slate-400">
+                  已配置
+                </span>
+              </div>
+
+              <button
+                @click="openEditDialog('paddleocr', provider, idx)"
+                class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-white/5 dark:hover:text-slate-300"
+                title="设置"
+              >
+                <i class="fa-solid fa-gear text-xs"></i>
+              </button>
+              <button
+                @click="removePaddleOCRProvider(idx)"
+                class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-rose-50 hover:text-rose-500 dark:hover:bg-rose-500/10"
+                title="删除"
+              >
+                <i class="fa-solid fa-trash-can text-xs"></i>
+              </button>
             </div>
           </div>
         </div>
@@ -340,5 +469,14 @@ watch(() => props.visible, (v) => { if (v) loadConfig() })
         </div>
       </div>
     </div>
+
+    <!-- 添加/编辑供应商弹窗 -->
+    <ProviderDialog
+      :open="dialogOpen"
+      :type="dialogType"
+      :edit-data="dialogEditData"
+      @close="dialogOpen = false"
+      @confirm="onDialogConfirm"
+    />
   </div>
 </template>

--- a/frontend/src/components/SettingsView.vue
+++ b/frontend/src/components/SettingsView.vue
@@ -69,6 +69,7 @@ const toggleActive = (type, id) => {
 // ---------- 加载 / 保存 ----------
 
 const loadConfig = async () => {
+  configLoaded.value = false
   loading.value = true
   try {
     const cfg = await fetchAppConfig()
@@ -103,6 +104,8 @@ const loadConfig = async () => {
     pushToast('error', '加载配置失败: ' + (e instanceof Error ? e.message : String(e)))
   } finally {
     loading.value = false
+    // nextTick 后再启用自动保存，避免赋值触发 watcher
+    setTimeout(() => { configLoaded.value = true }, 0)
   }
 }
 
@@ -135,9 +138,7 @@ const saveConfig = async () => {
     payload.active_paddleocr_id = activePaddleocrId.value
 
     await updateAppConfig(payload)
-    pushToast('success', '配置已保存并生效')
     emit('saved')
-    await loadConfig()
   } catch (e) {
     pushToast('error', '保存失败: ' + (e instanceof Error ? e.message : String(e)))
   } finally {
@@ -145,19 +146,31 @@ const saveConfig = async () => {
   }
 }
 
-const removeOpenAIProvider = (idx) => {
-  if (openaiProviders.value[idx]?.id === activeOpenaiId.value) activeOpenaiId.value = null
-  openaiProviders.value.splice(idx, 1)
-}
+// ---------- 自动保存（防抖） ----------
+let autoSaveTimer = null
+const configLoaded = ref(false)  // 防止 loadConfig 触发自动保存
 
-const removeAnthropicProvider = (idx) => {
-  if (anthropicProviders.value[idx]?.id === activeAnthropicId.value) activeAnthropicId.value = null
-  anthropicProviders.value.splice(idx, 1)
-}
+watch(
+  [openaiProviders, anthropicProviders, paddleocrProviders, activeOpenaiId, activeAnthropicId, activePaddleocrId],
+  () => {
+    if (!configLoaded.value) return
+    clearTimeout(autoSaveTimer)
+    autoSaveTimer = setTimeout(() => saveConfig(), 600)
+  },
+  { deep: true },
+)
 
-const removePaddleOCRProvider = (idx) => {
-  if (paddleocrProviders.value[idx]?.id === activePaddleocrId.value) activePaddleocrId.value = null
-  paddleocrProviders.value.splice(idx, 1)
+const removeProvider = async (type, idx) => {
+  const listMap = { openai: openaiProviders, anthropic: anthropicProviders, paddleocr: paddleocrProviders }
+  const activeMap = { openai: activeOpenaiId, anthropic: activeAnthropicId, paddleocr: activePaddleocrId }
+  const list = listMap[type]
+  if (list.value[idx]?.id === activeMap[type].value) activeMap[type].value = null
+  list.value.splice(idx, 1)
+  clearTimeout(autoSaveTimer)
+  try {
+    await saveConfig()
+    pushToast('success', '已删除')
+  } catch { /* saveConfig 内部已 toast error */ }
 }
 
 // ---------- 弹窗控制 ----------
@@ -180,7 +193,7 @@ const openEditDialog = (type, provider, idx) => {
   dialogOpen.value = true
 }
 
-const onDialogConfirm = (formData) => {
+const onDialogConfirm = async (formData) => {
   if (dialogEditIndex.value >= 0) {
     // 编辑模式：更新已有 provider
     const listMap = { openai: openaiProviders, anthropic: anthropicProviders, paddleocr: paddleocrProviders }
@@ -209,7 +222,15 @@ const onDialogConfirm = (formData) => {
       if (paddleocrProviders.value.length === 1) activePaddleocrId.value = p.id
     }
   }
+  const isEdit = dialogEditIndex.value >= 0
   dialogOpen.value = false
+
+  // 立即保存并提示
+  clearTimeout(autoSaveTimer)
+  try {
+    await saveConfig()
+    pushToast('success', isEdit ? '配置已更新' : '供应商已添加')
+  } catch { /* saveConfig 内部已 toast error */ }
 }
 
 onMounted(() => { if (props.visible) loadConfig() })
@@ -239,8 +260,8 @@ watch(() => props.visible, (v) => { if (v) loadConfig() })
         <div>
           <div class="mb-3 flex items-center justify-between pl-1">
             <div class="flex items-center gap-3">
-              <div class="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-50 dark:bg-emerald-500/10">
-                <i class="fa-solid fa-bolt text-lg text-emerald-600 dark:text-emerald-400"></i>
+              <div class="flex h-10 w-10 items-center justify-center rounded-xl bg-blue-50 dark:bg-blue-500/10">
+                <i class="fa-solid fa-bolt text-lg text-blue-600 dark:text-blue-400"></i>
               </div>
               <div>
                 <h3 class="text-base font-bold text-slate-800 dark:text-slate-200">OpenAI 兼容 API</h3>
@@ -249,7 +270,7 @@ watch(() => props.visible, (v) => { if (v) loadConfig() })
             </div>
             <button
               @click="openAddDialog('openai')"
-              class="inline-flex items-center gap-1.5 rounded-xl border border-dashed border-slate-300 px-3 py-1.5 text-xs font-bold text-slate-500 transition-all hover:border-emerald-400 hover:bg-emerald-50 hover:text-emerald-600 dark:border-white/10 dark:text-slate-400 dark:hover:border-emerald-500/40 dark:hover:bg-emerald-500/10 dark:hover:text-emerald-400"
+              class="inline-flex items-center gap-1.5 rounded-xl border border-dashed border-slate-300 px-3 py-1.5 text-xs font-bold text-slate-500 transition-all hover:border-blue-400 hover:bg-blue-50 hover:text-blue-600 dark:border-white/10 dark:text-slate-400 dark:hover:border-blue-500/40 dark:hover:bg-blue-500/10 dark:hover:text-blue-400"
             >
               <i class="fa-solid fa-plus text-[10px]"></i>
               添加
@@ -264,19 +285,18 @@ watch(() => props.visible, (v) => { if (v) loadConfig() })
           <div class="space-y-2">
             <div
               v-for="(provider, idx) in openaiProviders" :key="provider.id"
-              class="flex items-center gap-3 rounded-2xl border border-slate-200/60 bg-white/70 px-5 py-3.5 shadow-sm backdrop-blur-xl transition-all dark:border-white/10 dark:bg-white/[0.03]"
+              class="flex cursor-pointer items-center gap-3 rounded-2xl border border-slate-200/60 bg-white/70 px-5 py-3.5 shadow-sm backdrop-blur-xl transition-all hover:border-blue-300 dark:border-white/10 dark:bg-white/[0.03] dark:hover:border-blue-500/30"
+              @click="toggleActive('openai', provider.id)"
             >
               <!-- 激活单选 -->
-              <button
-                @click="toggleActive('openai', provider.id)"
+              <div
                 class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-all"
                 :class="activeOpenaiId === provider.id
                   ? 'border-emerald-500 bg-emerald-500 dark:border-emerald-400 dark:bg-emerald-400'
-                  : 'border-slate-300 hover:border-emerald-400 dark:border-slate-600 dark:hover:border-emerald-500'"
-                :title="activeOpenaiId === provider.id ? '当前已启用' : '点击启用'"
+                  : 'border-slate-300 dark:border-slate-600'"
               >
                 <i v-if="activeOpenaiId === provider.id" class="fa-solid fa-check text-[9px] text-white"></i>
-              </button>
+              </div>
 
               <!-- 名称 + 状态 -->
               <div class="flex min-w-0 flex-1 items-center gap-2">
@@ -291,14 +311,14 @@ watch(() => props.visible, (v) => { if (v) loadConfig() })
 
               <!-- 设置 + 删除 -->
               <button
-                @click="openEditDialog('openai', provider, idx)"
+                @click.stop="openEditDialog('openai', provider, idx)"
                 class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-white/5 dark:hover:text-slate-300"
                 title="设置"
               >
                 <i class="fa-solid fa-gear text-xs"></i>
               </button>
               <button
-                @click="removeOpenAIProvider(idx)"
+                @click.stop="removeProvider('openai', idx)"
                 class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-rose-50 hover:text-rose-500 dark:hover:bg-rose-500/10"
                 title="删除"
               >
@@ -312,8 +332,8 @@ watch(() => props.visible, (v) => { if (v) loadConfig() })
         <div>
           <div class="mb-3 flex items-center justify-between pl-1">
             <div class="flex items-center gap-3">
-              <div class="flex h-10 w-10 items-center justify-center rounded-xl bg-orange-50 dark:bg-orange-500/10">
-                <i class="fa-solid fa-brain text-lg text-orange-600 dark:text-orange-400"></i>
+              <div class="flex h-10 w-10 items-center justify-center rounded-xl bg-blue-50 dark:bg-blue-500/10">
+                <i class="fa-solid fa-brain text-lg text-blue-600 dark:text-blue-400"></i>
               </div>
               <div>
                 <h3 class="text-base font-bold text-slate-800 dark:text-slate-200">Anthropic API</h3>
@@ -322,7 +342,7 @@ watch(() => props.visible, (v) => { if (v) loadConfig() })
             </div>
             <button
               @click="openAddDialog('anthropic')"
-              class="inline-flex items-center gap-1.5 rounded-xl border border-dashed border-slate-300 px-3 py-1.5 text-xs font-bold text-slate-500 transition-all hover:border-orange-400 hover:bg-orange-50 hover:text-orange-600 dark:border-white/10 dark:text-slate-400 dark:hover:border-orange-500/40 dark:hover:bg-orange-500/10 dark:hover:text-orange-400"
+              class="inline-flex items-center gap-1.5 rounded-xl border border-dashed border-slate-300 px-3 py-1.5 text-xs font-bold text-slate-500 transition-all hover:border-blue-400 hover:bg-blue-50 hover:text-blue-600 dark:border-white/10 dark:text-slate-400 dark:hover:border-blue-500/40 dark:hover:bg-blue-500/10 dark:hover:text-blue-400"
             >
               <i class="fa-solid fa-plus text-[10px]"></i>
               添加
@@ -337,22 +357,21 @@ watch(() => props.visible, (v) => { if (v) loadConfig() })
           <div class="space-y-2">
             <div
               v-for="(provider, idx) in anthropicProviders" :key="provider.id"
-              class="flex items-center gap-3 rounded-2xl border border-slate-200/60 bg-white/70 px-5 py-3.5 shadow-sm backdrop-blur-xl transition-all dark:border-white/10 dark:bg-white/[0.03]"
+              class="flex cursor-pointer items-center gap-3 rounded-2xl border border-slate-200/60 bg-white/70 px-5 py-3.5 shadow-sm backdrop-blur-xl transition-all hover:border-blue-300 dark:border-white/10 dark:bg-white/[0.03] dark:hover:border-blue-500/30"
+              @click="toggleActive('anthropic', provider.id)"
             >
-              <button
-                @click="toggleActive('anthropic', provider.id)"
+              <div
                 class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-all"
                 :class="activeAnthropicId === provider.id
-                  ? 'border-orange-500 bg-orange-500 dark:border-orange-400 dark:bg-orange-400'
-                  : 'border-slate-300 hover:border-orange-400 dark:border-slate-600 dark:hover:border-orange-500'"
-                :title="activeAnthropicId === provider.id ? '当前已启用' : '点击启用'"
+                  ? 'border-emerald-500 bg-emerald-500 dark:border-emerald-400 dark:bg-emerald-400'
+                  : 'border-slate-300 dark:border-slate-600'"
               >
                 <i v-if="activeAnthropicId === provider.id" class="fa-solid fa-check text-[9px] text-white"></i>
-              </button>
+              </div>
 
               <div class="flex min-w-0 flex-1 items-center gap-2">
                 <span class="truncate text-sm font-bold text-slate-800 dark:text-slate-200">{{ provider.name || '未命名' }}</span>
-                <span v-if="activeAnthropicId === provider.id" class="shrink-0 rounded-full bg-orange-100 px-2 py-0.5 text-[10px] font-bold text-orange-600 dark:bg-orange-500/15 dark:text-orange-400">
+                <span v-if="activeAnthropicId === provider.id" class="shrink-0 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-bold text-emerald-600 dark:bg-emerald-500/15 dark:text-emerald-400">
                   使用中
                 </span>
                 <span v-else-if="provider.api_key_set" class="shrink-0 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-bold text-slate-500 dark:bg-white/5 dark:text-slate-400">
@@ -361,14 +380,14 @@ watch(() => props.visible, (v) => { if (v) loadConfig() })
               </div>
 
               <button
-                @click="openEditDialog('anthropic', provider, idx)"
+                @click.stop="openEditDialog('anthropic', provider, idx)"
                 class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-white/5 dark:hover:text-slate-300"
                 title="设置"
               >
                 <i class="fa-solid fa-gear text-xs"></i>
               </button>
               <button
-                @click="removeAnthropicProvider(idx)"
+                @click.stop="removeProvider('anthropic', idx)"
                 class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-rose-50 hover:text-rose-500 dark:hover:bg-rose-500/10"
                 title="删除"
               >
@@ -407,22 +426,21 @@ watch(() => props.visible, (v) => { if (v) loadConfig() })
           <div class="space-y-2">
             <div
               v-for="(provider, idx) in paddleocrProviders" :key="provider.id"
-              class="flex items-center gap-3 rounded-2xl border border-slate-200/60 bg-white/70 px-5 py-3.5 shadow-sm backdrop-blur-xl transition-all dark:border-white/10 dark:bg-white/[0.03]"
+              class="flex cursor-pointer items-center gap-3 rounded-2xl border border-slate-200/60 bg-white/70 px-5 py-3.5 shadow-sm backdrop-blur-xl transition-all hover:border-blue-300 dark:border-white/10 dark:bg-white/[0.03] dark:hover:border-blue-500/30"
+              @click="toggleActive('paddleocr', provider.id)"
             >
-              <button
-                @click="toggleActive('paddleocr', provider.id)"
+              <div
                 class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-all"
                 :class="activePaddleocrId === provider.id
-                  ? 'border-blue-500 bg-blue-500 dark:border-blue-400 dark:bg-blue-400'
-                  : 'border-slate-300 hover:border-blue-400 dark:border-slate-600 dark:hover:border-blue-500'"
-                :title="activePaddleocrId === provider.id ? '当前已启用' : '点击启用'"
+                  ? 'border-emerald-500 bg-emerald-500 dark:border-emerald-400 dark:bg-emerald-400'
+                  : 'border-slate-300 dark:border-slate-600'"
               >
                 <i v-if="activePaddleocrId === provider.id" class="fa-solid fa-check text-[9px] text-white"></i>
-              </button>
+              </div>
 
               <div class="flex min-w-0 flex-1 items-center gap-2">
                 <span class="truncate text-sm font-bold text-slate-800 dark:text-slate-200">{{ provider.name || '未命名' }}</span>
-                <span v-if="activePaddleocrId === provider.id" class="shrink-0 rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-bold text-blue-600 dark:bg-blue-500/15 dark:text-blue-400">
+                <span v-if="activePaddleocrId === provider.id" class="shrink-0 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-bold text-emerald-600 dark:bg-emerald-500/15 dark:text-emerald-400">
                   使用中
                 </span>
                 <span v-else-if="provider.api_key_set" class="shrink-0 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-bold text-slate-500 dark:bg-white/5 dark:text-slate-400">
@@ -431,14 +449,14 @@ watch(() => props.visible, (v) => { if (v) loadConfig() })
               </div>
 
               <button
-                @click="openEditDialog('paddleocr', provider, idx)"
+                @click.stop="openEditDialog('paddleocr', provider, idx)"
                 class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-white/5 dark:hover:text-slate-300"
                 title="设置"
               >
                 <i class="fa-solid fa-gear text-xs"></i>
               </button>
               <button
-                @click="removePaddleOCRProvider(idx)"
+                @click.stop="removeProvider('paddleocr', idx)"
                 class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-rose-50 hover:text-rose-500 dark:hover:bg-rose-500/10"
                 title="删除"
               >
@@ -448,25 +466,6 @@ watch(() => props.visible, (v) => { if (v) loadConfig() })
           </div>
         </div>
 
-        <!-- 操作栏 -->
-        <div class="flex items-center justify-end gap-3 pb-8">
-          <button
-            @click="loadConfig"
-            :disabled="saving"
-            class="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200/60 bg-white/60 px-5 py-2.5 text-sm font-bold text-slate-700 transition-all hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/10 dark:bg-slate-800/60 dark:text-slate-300 dark:hover:bg-slate-700"
-          >
-            <i class="fa-solid fa-rotate-right"></i>
-            重置
-          </button>
-          <button
-            @click="saveConfig"
-            :disabled="saving"
-            class="inline-flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-6 py-2.5 text-sm font-bold text-white shadow-md transition-all hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-600"
-          >
-            <i class="fa-solid" :class="saving ? 'fa-circle-notch fa-spin' : 'fa-check'"></i>
-            {{ saving ? '保存中...' : '保存配置' }}
-          </button>
-        </div>
       </div>
     </div>
 

--- a/frontend/src/components/StatusBar.vue
+++ b/frontend/src/components/StatusBar.vue
@@ -19,6 +19,7 @@ const props = defineProps({
   providerOptions: { type: Array, default: () => [] },
   selectedModel: { type: String, default: '' },
   disabled: { type: Boolean, default: false },
+  noModels: { type: Boolean, default: false },
 })
 
 const modelLogos = { openai: deepseekLogo, anthropic: ernieLogo }
@@ -43,7 +44,7 @@ const modelOptions = computed(() => {
   return items
 })
 
-const selectedLabel = computed(() => props.selectedModel || '选择模型')
+const selectedLabel = computed(() => props.noModels ? '暂无模型' : (props.selectedModel || '选择模型'))
 
 // 反查当前选中模型所属的 provider
 const currentProvider = computed(() => {
@@ -143,7 +144,7 @@ const modelStatusError = computed(() => {
 
     <!-- 模型下拉选择器 (按 provider 分组) -->
     <div v-if="!statusError" class="ml-auto flex items-center gap-2">
-      <Listbox :model-value="selectedModel" @update:model-value="(v) => emit('update:selectedModel', v)" :disabled="disabled">
+      <Listbox :model-value="selectedModel" @update:model-value="(v) => emit('update:selectedModel', v)" :disabled="disabled || noModels">
         <div class="relative w-48">
           <ListboxButton
             class="group relative flex h-9 w-full cursor-pointer items-center justify-between gap-4 rounded-xl border border-slate-300 bg-white pl-3 pr-2 text-left shadow-sm backdrop-blur-sm hover:border-blue-400 hover:bg-slate-50 dark:border-white/5 dark:bg-white/5 dark:hover:border-indigo-500/20 dark:hover:bg-white/10"

--- a/frontend/src/components/ToastContainer.vue
+++ b/frontend/src/components/ToastContainer.vue
@@ -19,7 +19,7 @@ const onLeave = (el) => {
 </script>
 
 <template>
-  <div class="pointer-events-none fixed left-0 right-0 top-6 z-[100] flex flex-col items-center gap-3 px-4 md:left-64">
+  <div class="pointer-events-none fixed left-0 right-0 top-6 z-[200] flex flex-col items-center gap-3 px-4 md:left-64">
     <TransitionGroup
       enter-active-class="transition duration-500 cubic-bezier(0.34, 1.56, 0.64, 1)"
       enter-from-class="opacity-0 -translate-y-8 scale-90"

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -580,9 +580,9 @@ onBeforeUnmount(() => {
     </Transition>
     <!-- ================== 全局固定背景光晕 (支持长页面滚动) ================== -->
     <div class="pointer-events-none fixed inset-0 z-0 overflow-hidden">
-      <div class="animate-blob absolute -top-[10%] left-[-10%] h-[50vw] w-[50vw] rounded-full bg-blue-400/[0.12] mix-blend-multiply blur-[120px] dark:bg-indigo-600/20 dark:mix-blend-screen"></div>
-      <div class="animate-blob animation-delay-4000 absolute -bottom-[10%] right-[-10%] h-[45vw] w-[45vw] rounded-full bg-indigo-300/[0.15] mix-blend-multiply blur-[100px] dark:bg-fuchsia-600/20 dark:mix-blend-screen"></div>
-      <div class="animate-blob animation-delay-2000 absolute left-[15%] top-[25%] h-[35vw] w-[35vw] rounded-full bg-cyan-200/[0.12] mix-blend-multiply blur-[110px] dark:bg-blue-500/10 dark:mix-blend-screen"></div>
+      <div class="animate-blob absolute -top-[10%] left-[-10%] h-[50vw] w-[50vw] rounded-full bg-blue-400/[0.12] mix-blend-multiply blur-[120px] dark:bg-indigo-500/[0.15] dark:mix-blend-screen"></div>
+      <div class="animate-blob animation-delay-4000 absolute -bottom-[10%] right-[-10%] h-[45vw] w-[45vw] rounded-full bg-indigo-300/[0.15] mix-blend-multiply blur-[100px] dark:bg-fuchsia-500/[0.12] dark:mix-blend-screen"></div>
+      <div class="animate-blob animation-delay-2000 absolute left-[15%] top-[25%] h-[35vw] w-[35vw] rounded-full bg-cyan-200/[0.12] mix-blend-multiply blur-[110px] dark:bg-blue-500/[0.10] dark:mix-blend-screen"></div>
     </div>
 
     <!-- ================== PC端：左侧边栏导航 ================== -->
@@ -968,15 +968,15 @@ onBeforeUnmount(() => {
 <style>
 /* 自定义背景光晕动画 - 极致性能优化版 */
 @keyframes blob {
-  0% { transform: translate3d(0, 0, 0) scale(1); opacity: 0.6; }
-  33% { transform: translate3d(80px, -120px, 0) scale(1.2); opacity: 0.8; }
-  66% { transform: translate3d(-60px, 60px, 0) scale(0.8); opacity: 0.3; }
-  100% { transform: translate3d(0, 0, 0) scale(1); opacity: 0.6; }
+  0% { transform: translate3d(0, 0, 0) scale(1); }
+  33% { transform: translate3d(80px, -120px, 0) scale(1.15); }
+  66% { transform: translate3d(-60px, 60px, 0) scale(0.9); }
+  100% { transform: translate3d(0, 0, 0) scale(1); }
 }
 
 .animate-blob {
   animation: blob 30s infinite alternate ease-in-out;
-  will-change: transform, opacity;
+  will-change: transform;
 }
 
 .animation-delay-2000 {

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -118,6 +118,9 @@ const providerOptions = computed(() => {
   return s && s.available_models ? s.available_models : []
 })
 
+// 是否有可用模型
+const hasConfiguredModel = computed(() => providerOptions.value.some(p => p.configured))
+
 // 从 selectedModel 反查 provider
 const selectedProvider = computed(() => {
   for (const p of providerOptions.value) {
@@ -273,7 +276,7 @@ let activeXhr = null
 let fakeProgressTimer = null
 let fakeProgressKeys = []
 
-const splitEnabled = computed(() => !splitting.value && !splitCompleted.value && uploadReady.value && !uploadBusy.value)
+const splitEnabled = computed(() => !splitting.value && !splitCompleted.value && uploadReady.value && !uploadBusy.value && hasConfiguredModel.value)
 const exportEnabled = computed(() => splitCompleted.value && selectedIds.size > 0)
 
 const stopFakeProgress = () => {
@@ -750,6 +753,7 @@ onBeforeUnmount(() => {
                   :provider-options="providerOptions"
                   :selected-model="selectedModel"
                   :disabled="splitting || splitCompleted"
+                  :no-models="!hasConfiguredModel"
                   @update:selected-model="(v) => selectedModel = v"
                 />
 
@@ -778,6 +782,7 @@ onBeforeUnmount(() => {
                     :splitting="splitting"
                     :split-completed="splitCompleted"
                     :expand="questions.length === 0"
+                    :disabled="!hasConfiguredModel"
                     @upload="enqueueUpload"
                     @remove-file="removePendingFile"
                   />


### PR DESCRIPTION
## Summary

- 将 LLM（OpenAI/Anthropic）和 PaddleOCR 的 API 凭据从 `.env` 环境变量迁移到数据库 `provider_configs` 表，每个用户独立管理
- 新增 ProviderDialog 弹窗组件，支持多供应商新增/编辑/删除/激活，配置自动保存
- 核心工作流（分割、对话）从数据库读取用户凭据，彻底移除环境变量回退逻辑

## 主要改动

### 后端
- **ProviderConfig 模型**：支持 openai/anthropic/paddleocr 三类，每类可配多个并激活一个（`is_active`）
- **config.py**：移除 `env_prefix`/`env_file` 自动读取，新增 `load_providers_from_db()` 从数据库注入凭据；删除 `get_config_for_ui`、`get_available_models`、`update_env_file` 等死代码
- **llm.py**：`init_model()` 支持直接传入 `api_key`/`base_url` 参数
- **paddleocr_client.py**：`__init__` 改为参数传入凭据，移除 `os.getenv` 和 `load_dotenv`
- **web_app.py**：`/api/split`、`/api/chat/stream` 路由入口注入用户 DB 凭据；`/api/status` 从数据库读取配置状态；`/api/config` GET/PUT 要求登录；`/api/models/list`、`/api/paddleocr/test` 支持 `provider_id` 从数据库读取已存 key

### 前端
- **ProviderDialog**：玻璃态弹窗，自定义下拉替代原生 select，模型字段带 info tooltip，`autocomplete` 防浏览器自动填充
- **SettingsView**：统一蓝色调，Item 点击整行切换激活，自动保存（600ms 防抖），删除重置/保存按钮；新增/编辑/删除操作 toast 提示
- **WorkspaceView**：无可用模型时禁用上传和分割，显示"请先在系统设置中配置 API 模型"引导
- **StatusBar**：无模型时显示"暂无模型"并禁用下拉
- **ToastContainer**：z-index 提升至 200，避免被 dialog 遮挡
- **.env.example**：精简为仅保留 Flask 密钥和 LangSmith 配置，注释翻译为中文

## Test plan

- [x] 新用户注册后进入设置页，添加 OpenAI/PaddleOCR 供应商配置并保存
- [x] 切换激活不同供应商，刷新页面验证激活状态持久化
- [x] 编辑已有配置，验证 API Key 不丢失（不输入新 key 时保留旧值）
- [x] 删除供应商配置，验证 toast 提示和数据库清理
- [x] 工作台验证：无模型时上传和分割按钮禁用；配置模型后上传 → 分割流程正常
- [x] 编辑 dialog 中点击"获取模型列表"，验证从数据库读取 key 而非要求重新输入
- [x] PaddleOCR 编辑 dialog 中点击"测试连接"，验证使用已存凭据