### PR TITLE
refactor(workspace): 精简核对页头部，将选择控件上移至页面标题栏

### DIFF
--- a/frontend/src/components/QuestionList.vue
+++ b/frontend/src/components/QuestionList.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, nextTick, watch, onMounted } from 'vue'
+import { ref, nextTick, watch, onMounted } from 'vue'
 import QuestionCard from './QuestionCard.vue'
 import { typesetMath } from '../utils.js'
 
@@ -13,8 +13,6 @@ const emit = defineEmits(['toggle-select', 'select-all', 'deselect-all', 'open-i
 const questionListEl = ref(null)
 const questionsBoxEl = ref(null)
 let sortable = null
-
-const selectedCountLabel = computed(() => `已选 ${props.selectedIds.size} 项`)
 
 const triggerTypeset = async () => {
   await nextTick()
@@ -61,48 +59,7 @@ defineExpose({ initSortable, questionsBoxEl, triggerTypeset })
 </script>
 
 <template>
-  <div v-if="questions.length" ref="questionsBoxEl" class="mt-8 relative z-10">
-    <div class="flex flex-col gap-4 border-b border-slate-100/80 pb-6 sm:flex-row sm:items-end sm:justify-between dark:border-white/5">
-        <div>
-          <div class="mb-1 flex items-center gap-2">
-            <div class="flex h-5 w-5 items-center justify-center rounded-lg bg-blue-100 text-blue-600 dark:bg-indigo-500/20 dark:text-indigo-400">
-              <i class="fa-solid fa-layer-group text-[9px]"></i>
-            </div>
-            <span class="text-[9px] font-black uppercase tracking-[0.2em] text-slate-400 dark:text-slate-500">解析结果</span>
-          </div>
-          <h3 class="text-2xl font-black tracking-tight text-slate-900 dark:text-white">
-            题目数据核对
-          </h3>
-          <p class="mt-1 text-[11px] font-bold text-slate-500 dark:text-slate-400">
-            拖拽调整排序，点击卡片选择导出
-          </p>
-        </div>
-        
-        <div class="flex flex-wrap items-center gap-3">
-          <div class="flex items-center gap-1 rounded-xl border border-slate-100 bg-white/50 p-1 shadow-sm backdrop-blur-md dark:border-white/5 dark:bg-slate-800/50">
-            <button 
-              type="button" 
-              class="flex items-center gap-2 rounded-lg px-4 py-1.5 text-[10px] font-black text-slate-600 hover:bg-white hover:text-blue-600 hover:shadow-sm dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-indigo-300" 
-              @click="emit('select-all')"
-            >
-              全选
-            </button>
-            <button 
-              type="button" 
-              class="flex items-center gap-2 rounded-lg px-4 py-1.5 text-[10px] font-black text-slate-600 hover:bg-white hover:text-rose-500 hover:shadow-sm dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-rose-400" 
-              @click="emit('deselect-all')"
-            >
-              清空
-            </button>
-          </div>
-          
-          <div class="flex h-9 items-center gap-2 rounded-xl bg-slate-900 px-4 text-[10px] font-black text-white shadow-xl shadow-slate-900/20 dark:bg-white dark:text-slate-900 dark:shadow-none">
-            <i class="fa-solid fa-square-check text-blue-400"></i>
-            <span class="tracking-widest">{{ selectedCountLabel }}</span>
-          </div>
-        </div>
-      </div>
-
+  <div v-if="questions.length" ref="questionsBoxEl" class="relative z-10">
       <!-- 题目列表 -->
       <div ref="questionListEl" class="relative z-10 mt-6 grid gap-5" id="questionList">
         <QuestionCard

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -817,10 +817,27 @@ onBeforeUnmount(() => {
                     <p class="text-xs font-bold text-slate-400 dark:text-slate-500 mt-0.5">请确认解析结果的准确性并进行导出或存档</p>
                   </div>
                 </div>
-                <div class="flex items-center gap-2">
-                  <span class="rounded-full bg-blue-100 px-3 py-1 text-[10px] font-black text-blue-700 dark:bg-indigo-500/20 dark:text-indigo-300">
-                    {{ questions.length }} 道题目已解析
-                  </span>
+                <div class="flex items-center gap-3">
+                  <div class="flex items-center gap-1 rounded-xl border border-slate-100 bg-white/50 p-1 shadow-sm backdrop-blur-md dark:border-white/5 dark:bg-slate-800/50">
+                    <button
+                      type="button"
+                      class="flex items-center gap-2 rounded-lg px-4 py-1.5 text-[10px] font-black text-slate-600 hover:bg-white hover:text-blue-600 hover:shadow-sm dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-indigo-300"
+                      @click="selectAll"
+                    >
+                      全选
+                    </button>
+                    <button
+                      type="button"
+                      class="flex items-center gap-2 rounded-lg px-4 py-1.5 text-[10px] font-black text-slate-600 hover:bg-white hover:text-rose-500 hover:shadow-sm dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-rose-400"
+                      @click="deselectAll"
+                    >
+                      清空
+                    </button>
+                  </div>
+                  <div class="flex h-9 items-center gap-2 rounded-xl bg-slate-900 px-4 text-[10px] font-black text-white shadow-xl shadow-slate-900/20 dark:bg-white dark:text-slate-900 dark:shadow-none">
+                    <i class="fa-solid fa-square-check text-blue-400"></i>
+                    <span class="tracking-widest">已选 {{ selectedIds.size }} 项</span>
+                  </div>
                 </div>
               </div>
 


### PR DESCRIPTION
## 变更概述

### 🖥️ 工作台 - 题目核对页

**头部布局精简**

- 移除 `QuestionList` 组件内重复的「解析结果 / 题目数据核对 / 拖拽调整排序」标题区块
- 移除 `QuestionList` 内的「全选 / 清空」按钮和「已选 X 项」计数徽标
- 将上述选择控件上移至 `WorkspaceView` 核对页顶部标题栏右侧，替换原有的「X 道题目已解析」徽标
- 清理 `QuestionList` 中未使用的 `computed` 导入和 `selectedCountLabel`

**效果**：减少一层视觉层级冗余，选择操作与页面标题同行展示，信息层次更清晰