### PR TITLE
Feature/classify model

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -171,6 +171,10 @@ class Settings(BaseSettings):
     pages_dir: Path | None = None
     struct_dir: Path | None = None
     results_dir: Path | None = None
+    erased_dir: Path | None = None
+
+    # 文字擦除模型权重路径，可通过 APP_MODEL_PATH 覆盖
+    model_path: Path | None = None
 
     # 上传 & 请求限制
     max_file_size_mb: int = 50
@@ -191,6 +195,10 @@ class Settings(BaseSettings):
             self.struct_dir = self.runtime_dir / "struct"
         if self.results_dir is None:
             self.results_dir = self.runtime_dir / "results"
+        if self.erased_dir is None:
+            self.erased_dir = self.runtime_dir / "erased"
+        if self.model_path is None:
+            self.model_path = self.runtime_dir / "models" / "latest.pth"
 
         # 初始化 LLM 供应商注册表
         if self.llm_providers is None:
@@ -202,7 +210,7 @@ class Settings(BaseSettings):
 
     def ensure_dirs(self):
         """确保必要目录存在（应在应用启动入口显式调用）"""
-        for d in [self.upload_dir, self.pages_dir, self.struct_dir, self.results_dir]:
+        for d in [self.upload_dir, self.pages_dir, self.struct_dir, self.results_dir, self.erased_dir]:
             d.mkdir(parents=True, exist_ok=True)
 
     # ----- LLM 供应商查询方法 -----

--- a/backend/models/config.py
+++ b/backend/models/config.py
@@ -1,0 +1,59 @@
+import os
+import yaml
+from pathlib import Path
+
+
+class Config:
+    _instance = None
+    _config = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        if self._config is None:
+            self._load_config()
+
+    def _load_config(self, config_path=None):
+        if config_path is None:
+            config_path = os.path.join(
+                os.path.dirname(__file__),
+                'config.yaml'
+            )
+
+        if not os.path.exists(config_path):
+            raise FileNotFoundError(f"配置文件不存在: {config_path}")
+
+        with open(config_path, 'r', encoding='utf-8') as f:
+            self._config = yaml.safe_load(f)
+
+    @property
+    def train(self):
+        return self._config.get('train', {})
+
+    @property
+    def loss(self):
+        return self._config.get('loss', {})
+
+    @property
+    def inference(self):
+        return self._config.get('inference', {})
+
+    @property
+    def wandb(self):
+        return self._config.get('wandb', {})
+
+    def get(self, key, default=None):
+        keys = key.split('.')
+        value = self._config
+        for k in keys:
+            if isinstance(value, dict):
+                value = value.get(k, default)
+            else:
+                return default
+        return value
+
+
+config = Config()

--- a/backend/models/config.yaml
+++ b/backend/models/config.yaml
@@ -1,0 +1,51 @@
+# EnsExam 配置文件
+
+# ====================== 训练参数 ======================
+train:
+  epochs: 100           # 训练轮数
+  batch_size: 4         # 批次大小
+  lr: 0.0001            # 学习率
+  device: "cuda"        # 训练设备 ("cuda" 或 "cpu")
+  num_workers: 4       # 数据加载线程数
+
+  # 路径配置
+  data_root: "D:\\PythonProject1\\LLM\\adcj\\src\\adcj\\EnsExam\\SCUT-EnsExam\\SCUT-EnsExam"
+  save_dir: "./ensexam_checkpoints"
+  resume_path: "./ensexam_checkpoints/latest.pth"
+
+# ====================== 损失权重 ======================
+loss:
+  # LR Loss 多尺度权重 [Ic4, Ic2, Ic1, Ire]
+  lambda_n: [5, 6, 8, 10]
+  beta_n: [0.8, 0.8, 0.8, 2]
+
+  # 各损失总权重
+  lambda_lr: 1.0       # LR损失权重
+  lambda_p: 0.05       # 感知损失权重
+  lambda_style: 120    # 风格损失权重
+  lambda_sn: 1         # SN损失权重
+  lambda_b: 0.4        # 块损失权重
+
+# ====================== 推理参数 ======================
+inference:
+  model_path: "D:\\PythonProject1\\LLM\\adcj\\src\\adcj\\EnsExam\\ensexam_checkpoints\\ensexam_epoch_5.pth"
+  img_size: 512         # 必须和训练时一致
+
+  # 单张图片推理
+  input_image_path: "D:\\PythonProject1\\LLM\\adcj\\src\\adcj\\EnsExam\\SCUT-EnsExam\\SCUT-EnsExam\\test\\all_images\\15.jpg"
+  output_image_path: "./test_output.jpg"
+
+  # 批量目录推理
+  input_dir: "D:\\PythonProject1\\LLM\\adcj\\src\\adcj\\EnsExam\\SCUT-EnsExam\\SCUT-EnsExam\\test\\all_images"
+  output_dir: "./output"
+  patch_size: 512       # 滑动窗口尺寸
+  overlap: 32           # 重叠像素
+
+# ====================== WandB 配置 ======================
+wandb:
+  enabled: true         # 是否启用 wandb
+  project: "ensexam"    # 项目名称
+  name: null           # 实验名称 (null 则自动生成)
+  entity: null         # 团队/用户名
+  offline: true        # 离线模式 (true 使用 offline wandb)
+  dir: "./wandb"       # wandb 日志目录

--- a/backend/models/inference.py
+++ b/backend/models/inference.py
@@ -1,0 +1,184 @@
+"""
+GAN 文字擦除模型推理引擎
+
+职责：
+- 懒加载 Generator 权重（进程内单例，首次调用时初始化）
+- 图像预处理（归一化到 [-1,1]，padding 到 512 的整数倍）
+- 大图滑动窗口推理（patch_size=512，overlap 可配置）
+- 后处理（还原 [0,255]，裁剪掉 padding）
+"""
+import io
+import logging
+import threading
+
+import numpy as np
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+_PATCH_SIZE = 512
+_OVERLAP = 32
+
+
+class InferenceEngine:
+    """单例推理引擎，线程安全懒加载"""
+
+    _instance = None
+    _class_lock = threading.Lock()
+
+    def __new__(cls):
+        if cls._instance is None:
+            with cls._class_lock:
+                if cls._instance is None:
+                    inst = super().__new__(cls)
+                    inst._model = None
+                    inst._device = None
+                    inst._model_lock = threading.Lock()
+                    cls._instance = inst
+        return cls._instance
+
+    # ------------------------------------------------------------------
+    # 模型加载
+    # ------------------------------------------------------------------
+
+    def _load_model(self):
+        """首次调用时从磁盘加载权重，后续调用直接复用"""
+        if self._model is not None:
+            return
+
+        with self._model_lock:
+            if self._model is not None:
+                return
+
+            import torch
+            from models.model import Generator
+            from config import settings
+
+            model_path = settings.model_path
+            if not model_path.exists():
+                raise FileNotFoundError(
+                    f"模型权重不存在，请将 latest.pth 放到: {model_path}"
+                )
+
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            generator = Generator().to(device)
+
+            ckpt = torch.load(model_path, map_location=device, weights_only=False)
+            # train.py 保存格式：{'G_state_dict': ..., 'D_state_dict': ..., ...}
+            state_dict = (
+                ckpt.get("G_state_dict")
+                or ckpt.get("generator_state_dict")
+                or ckpt
+            )
+            generator.load_state_dict(state_dict)
+            generator.eval()
+
+            self._model = generator
+            self._device = device
+            logger.info("推理引擎初始化完成，设备: %s，权重: %s", device, model_path)
+
+    # ------------------------------------------------------------------
+    # 图像预处理 / 后处理
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _preprocess(pil_img: Image.Image):
+        """PIL → float Tensor [-1, 1]，并 padding 到 512 的整数倍
+
+        Returns:
+            arr_padded (np.ndarray): shape (H_pad, W_pad, 3)，float32 in [-1,1]
+            orig_w, orig_h: 原始尺寸，用于最终裁剪
+        """
+        img = pil_img.convert("RGB")
+        orig_w, orig_h = img.size
+
+        pad_w = (_PATCH_SIZE - orig_w % _PATCH_SIZE) % _PATCH_SIZE
+        pad_h = (_PATCH_SIZE - orig_h % _PATCH_SIZE) % _PATCH_SIZE
+
+        if pad_w or pad_h:
+            canvas = Image.new("RGB", (orig_w + pad_w, orig_h + pad_h), (255, 255, 255))
+            canvas.paste(img, (0, 0))
+            img = canvas
+
+        arr = np.array(img, dtype=np.float32) / 127.5 - 1.0
+        return arr, orig_w, orig_h
+
+    @staticmethod
+    def _to_tensor(arr: np.ndarray, device):
+        """(H, W, 3) ndarray → (1, 3, H, W) Tensor on device"""
+        import torch
+        return torch.from_numpy(arr).permute(2, 0, 1).unsqueeze(0).to(device)
+
+    @staticmethod
+    def _to_numpy(tensor) -> np.ndarray:
+        """(1, 3, H, W) Tensor → (H, W, 3) uint8 ndarray"""
+        arr = tensor.squeeze(0).permute(1, 2, 0).cpu().numpy()
+        return np.clip((arr + 1.0) * 127.5, 0, 255).astype(np.uint8)
+
+    # ------------------------------------------------------------------
+    # 推理
+    # ------------------------------------------------------------------
+
+    def _infer_single(self, arr: np.ndarray) -> np.ndarray:
+        """整图推理（适用于恰好 512×512 的 patch）"""
+        import torch
+        tensor = self._to_tensor(arr, self._device)
+        with torch.no_grad():
+            *_, Icomp = self._model(tensor)
+        return self._to_numpy(Icomp)
+
+    def _infer_sliding_window(self, arr: np.ndarray) -> np.ndarray:
+        """滑动窗口推理，patch 重叠区域做加权平均以消除接缝"""
+        import torch
+
+        h, w, _ = arr.shape
+        result = np.zeros((h, w, 3), dtype=np.float64)
+        weight = np.zeros((h, w, 1), dtype=np.float64)
+
+        stride = _PATCH_SIZE - _OVERLAP
+
+        def _ticks(total):
+            pts = list(range(0, total - _PATCH_SIZE + 1, stride))
+            if not pts or pts[-1] + _PATCH_SIZE < total:
+                pts.append(total - _PATCH_SIZE)
+            return pts
+
+        for y in _ticks(h):
+            for x in _ticks(w):
+                patch = arr[y:y + _PATCH_SIZE, x:x + _PATCH_SIZE]
+                tensor = self._to_tensor(patch, self._device)
+                with torch.no_grad():
+                    *_, Icomp = self._model(tensor)
+                out = self._to_numpy(Icomp).astype(np.float64)
+                result[y:y + _PATCH_SIZE, x:x + _PATCH_SIZE] += out
+                weight[y:y + _PATCH_SIZE, x:x + _PATCH_SIZE] += 1.0
+
+        return np.clip(result / weight, 0, 255).astype(np.uint8)
+
+    # ------------------------------------------------------------------
+    # 公开接口
+    # ------------------------------------------------------------------
+
+    def run(self, image_bytes: bytes) -> Image.Image:
+        """推理主入口
+
+        Args:
+            image_bytes: 原始图片字节（支持 JPEG/PNG/BMP 等 PIL 可读格式）
+
+        Returns:
+            擦除文字后的 PIL 图像（RGB）
+        """
+        self._load_model()
+
+        pil_img = Image.open(io.BytesIO(image_bytes))
+        arr, orig_w, orig_h = self._preprocess(pil_img)
+        h, w, _ = arr.shape
+
+        if h == _PATCH_SIZE and w == _PATCH_SIZE:
+            result_arr = self._infer_single(arr)
+        else:
+            result_arr = self._infer_sliding_window(arr)
+
+        # 裁剪掉 padding，还原到原始尺寸
+        result_arr = result_arr[:orig_h, :orig_w]
+        return Image.fromarray(result_arr)

--- a/backend/models/inference.py
+++ b/backend/models/inference.py
@@ -119,21 +119,13 @@ class InferenceEngine:
     # 推理
     # ------------------------------------------------------------------
 
-    def _infer_single(self, arr: np.ndarray) -> np.ndarray:
-        """整图推理（适用于恰好 512×512 的 patch）"""
-        import torch
-        tensor = self._to_tensor(arr, self._device)
-        with torch.no_grad():
-            *_, Icomp = self._model(tensor)
-        return self._to_numpy(Icomp)
-
     def _infer_sliding_window(self, arr: np.ndarray) -> np.ndarray:
         """滑动窗口推理，patch 重叠区域做加权平均以消除接缝"""
         import torch
 
         h, w, _ = arr.shape
-        result = np.zeros((h, w, 3), dtype=np.float64)
-        weight = np.zeros((h, w, 1), dtype=np.float64)
+        result = np.zeros((h, w, 3), dtype=np.float32)
+        weight = np.zeros((h, w, 1), dtype=np.float32)
 
         stride = _PATCH_SIZE - _OVERLAP
 
@@ -143,15 +135,16 @@ class InferenceEngine:
                 pts.append(total - _PATCH_SIZE)
             return pts
 
-        for y in _ticks(h):
-            for x in _ticks(w):
-                patch = arr[y:y + _PATCH_SIZE, x:x + _PATCH_SIZE]
-                tensor = self._to_tensor(patch, self._device)
-                with torch.no_grad():
+        with torch.no_grad():
+            for y in _ticks(h):
+                for x in _ticks(w):
+                    patch = arr[y:y + _PATCH_SIZE, x:x + _PATCH_SIZE]
+                    tensor = self._to_tensor(patch, self._device)
                     *_, Icomp = self._model(tensor)
-                out = self._to_numpy(Icomp).astype(np.float64)
-                result[y:y + _PATCH_SIZE, x:x + _PATCH_SIZE] += out
-                weight[y:y + _PATCH_SIZE, x:x + _PATCH_SIZE] += 1.0
+                    # 直接从 tensor 提取 float32，避免 uint8 截断精度损失
+                    out = (Icomp.squeeze(0).permute(1, 2, 0).cpu().numpy() + 1.0) * 127.5
+                    result[y:y + _PATCH_SIZE, x:x + _PATCH_SIZE] += out
+                    weight[y:y + _PATCH_SIZE, x:x + _PATCH_SIZE] += 1.0
 
         return np.clip(result / weight, 0, 255).astype(np.uint8)
 
@@ -174,10 +167,7 @@ class InferenceEngine:
         arr, orig_w, orig_h = self._preprocess(pil_img)
         h, w, _ = arr.shape
 
-        if h == _PATCH_SIZE and w == _PATCH_SIZE:
-            result_arr = self._infer_single(arr)
-        else:
-            result_arr = self._infer_sliding_window(arr)
+        result_arr = self._infer_sliding_window(arr)
 
         # 裁剪掉 padding，还原到原始尺寸
         result_arr = result_arr[:orig_h, :orig_w]

--- a/backend/models/model.py
+++ b/backend/models/model.py
@@ -126,17 +126,11 @@ class CoarseNet(nn.Module):
         self.up4 = UpSample(256, 64, use_cbam=True)  # 1/2 → Ic2
         self.up5 = UpSample(128, 64, use_cbam=True)  # 1/1 → Ic1
         # 输出层：Ms(笔画掩码), Mb(文本块掩码), 多尺度Ic
-        self.up1_ms = UpSample(512, 512, use_cbam=True)
-        self.up2_ms = UpSample(1024, 256, use_cbam=True)
-        self.up3_ms = UpSample(512, 128, use_cbam=True)
-        self.up4_ms = UpSample(256, 64, use_cbam=True)
-        self.up5_ms = UpSample(128, 64, use_cbam=True)
-
-        self.up1_mb = UpSample(512, 512, use_cbam=True)
-        self.up2_mb = UpSample(1024, 256, use_cbam=True)
-        self.up3_mb = UpSample(512, 128, use_cbam=True)
-        self.up4_mb = UpSample(256, 64, use_cbam=True)
-        self.up5_mb = UpSample(128, 64, use_cbam=True)
+        self.up1_seg = UpSample(512, 512, use_cbam=True)
+        self.up2_seg = UpSample(1024, 256, use_cbam=True)
+        self.up3_seg = UpSample(512, 128, use_cbam=True)
+        self.up4_seg = UpSample(256, 64, use_cbam=True)
+        self.up5_seg = UpSample(128, 64, use_cbam=True)
 
         self.out_ms = nn.Conv2d(64, 1, 3, 1, 1, bias=True)
         self.out_mb = nn.Conv2d(64, 1, 3, 1, 1, bias=True)
@@ -170,27 +164,17 @@ class CoarseNet(nn.Module):
         u5 = self.up5(u4)  # H → 输出 Ic1, Mb, Ms
         Ic1 = torch.tanh(self.out_ic1(u5))
 
-        u1_mb = self.up1_mb(d5)
-        u1_mb = torch.cat([u1_mb, d4], dim=1)
-        u2_mb = self.up2_mb(u1_mb)
-        u2_mb = torch.cat([u2_mb, d3], dim=1)
-        u3_mb = self.up3_mb(u2_mb)
-        u3_mb = torch.cat([u3_mb, d2], dim=1)
-        u4_mb = self.up4_mb(u3_mb)
-        u4_mb = torch.cat([u4_mb, d1], dim=1)
-        u5_mb = self.up5_mb(u4_mb)
-        Mb = torch.sigmoid(self.out_mb(u5_mb))
-
-        u1_ms = self.up1_ms(d5)
-        u1_ms = torch.cat([u1_ms, d4], dim=1)
-        u2_ms = self.up2_ms(u1_ms)
-        u2_ms = torch.cat([u2_ms, d3], dim=1)
-        u3_ms = self.up3_ms(u2_ms)
-        u3_ms = torch.cat([u3_ms, d2], dim=1)
-        u4_ms = self.up4_ms(u3_ms)
-        u4_ms = torch.cat([u4_ms, d1], dim=1)
-        u5_ms = self.up5_ms(u4_ms)
-        Ms = torch.sigmoid(self.out_ms(u5_ms))
+        u1_seg = self.up1_seg(d5)
+        u1_seg = torch.cat([u1_seg, d4], dim=1)
+        u2_seg = self.up2_seg(u1_seg)
+        u2_seg = torch.cat([u2_seg, d3], dim=1)
+        u3_seg = self.up3_seg(u2_seg)
+        u3_seg = torch.cat([u3_seg, d2], dim=1)
+        u4_seg = self.up4_seg(u3_seg)
+        u4_seg = torch.cat([u4_seg, d1], dim=1)
+        u5_seg = self.up5_seg(u4_seg)
+        Mb = torch.sigmoid(self.out_mb(u5_seg))
+        Ms = torch.sigmoid(self.out_ms(u5_seg))
 
         return Ms, Mb, Ic4, Ic2, Ic1
 

--- a/backend/models/model.py
+++ b/backend/models/model.py
@@ -1,0 +1,399 @@
+import math
+
+import cv2
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torchvision.models import vgg16
+
+
+def generate_soft_stroke_mask(Iin, Igt, alpha=3, L=5, threshold=20):
+    """
+    生成软笔画掩码
+    :param Iin: 原始图像
+    :param Igt: 擦除GT图像
+    :param alpha: SAF函数参数
+    :param L: 最大距离
+    :param threshold: 粗掩码阈值
+    :return: 软笔画掩码Ms [H, W] 0-1
+    """
+    diff = np.abs(Igt - Iin).mean(axis=-1)
+    coarse_mask = (diff > threshold).astype(np.uint8) * 255
+
+    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (3,3))
+    denoised_mask = cv2.morphologyEx(coarse_mask, cv2.MORPH_CLOSE, kernel)
+
+    skeleton = cv2.erode(denoised_mask, kernel, iterations=1)
+    outer = cv2.dilate(denoised_mask, kernel, iterations=1)
+
+    dist = cv2.distanceTransform(255-outer, cv2.DIST_L2, 5)
+    dist = np.clip(dist, 0, L)
+
+    C = (1 + math.exp(-alpha)) / (1 - math.exp(-alpha))
+    saf = C * (2 / (1 + np.exp(-alpha * dist / L)) - 1)
+    saf = np.clip(saf, 0, 1)
+
+    saf[skeleton > 0] = 1.0
+    return saf
+
+# CBAM注意力模块（轻量版，适配U-Net）
+class CBAM(nn.Module):
+    def __init__(self, in_channels, reduction=16):
+        super().__init__()
+        # 通道注意力
+        self.avg_pool = nn.AdaptiveAvgPool2d(1)
+        self.max_pool = nn.AdaptiveMaxPool2d(1)
+        self.fc = nn.Sequential(
+            nn.Linear(in_channels, in_channels//reduction),
+            nn.ReLU(inplace=True),
+            nn.Linear(in_channels//reduction, in_channels)
+        )
+        # 空间注意力
+        self.spatial = nn.Sequential(
+            nn.Conv2d(2, 1, 3, padding=1, bias=False),
+            nn.Sigmoid()
+        )
+        self.sigmoid = nn.Sigmoid()
+
+    def forward(self, x):
+        b, c, h, w = x.shape
+        # 通道注意力
+        avg_out = self.fc(self.avg_pool(x).view(b,c)).view(b,c,1,1)
+        max_out = self.fc(self.max_pool(x).view(b,c)).view(b,c,1,1)
+        channel_att = self.sigmoid(avg_out + max_out)
+        x = x * channel_att
+        # 空间注意力
+        avg_out = torch.mean(x, dim=1, keepdim=True)
+        max_out, _ = torch.max(x, dim=1, keepdim=True)
+        spatial_att = self.spatial(torch.cat([avg_out, max_out], dim=1))
+        x = x * spatial_att
+        return x
+
+# 空洞卷积块（Refine网络用）
+class DilatedConvBlock(nn.Module):
+    def __init__(self, in_channels, out_channels, dilation=2):
+        super().__init__()
+        self.block = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, 3, padding=dilation, dilation=dilation, bias=False),
+            nn.BatchNorm2d(out_channels),
+            nn.ReLU(inplace=True)
+        )
+    def forward(self, x):
+        return self.block(x)
+
+# U-Net下采样块（Coarse/Refine网络编码器）
+class DownSample(nn.Module):
+    def __init__(self, in_channels, out_channels, use_cbam=False):
+        super().__init__()
+        self.conv = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, 4, 2, 1, bias=False),
+            nn.BatchNorm2d(out_channels),
+            nn.LeakyReLU(0.2, inplace=True)
+        )
+        self.cbam = CBAM(out_channels) if use_cbam else nn.Identity()
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.cbam(x)
+        return x
+
+# U-Net上采样块（Coarse网络解码器）
+class UpSample(nn.Module):
+    def __init__(self, in_channels, out_channels):
+        super().__init__()
+        self.conv = nn.Sequential(
+            nn.ConvTranspose2d(in_channels, out_channels, 4, 2, 1, bias=False),
+            nn.BatchNorm2d(out_channels),
+            nn.ReLU(inplace=True)
+        )
+    def forward(self, x):
+        return self.conv(x)
+
+# 带空洞卷积的上采样块（Refine网络解码器）
+class DilatedUpSample(nn.Module):
+    def __init__(self, in_channels, out_channels, dilation=2):
+        super().__init__()
+        self.conv = nn.Sequential(
+            nn.ConvTranspose2d(in_channels, out_channels, 4, 2, 1, bias=False),
+            nn.BatchNorm2d(out_channels),
+            nn.ReLU(inplace=True)
+        )
+        self.dilated = DilatedConvBlock(out_channels, out_channels, dilation)
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.dilated(x)
+        return x
+
+# Coarse网络
+class CoarseNet(nn.Module):
+    def __init__(self, in_channels=3):
+        super().__init__()
+        # 编码器：下采样+CBAM
+        self.down1 = DownSample(in_channels, 64, use_cbam=False)  # 1/2
+        self.down2 = DownSample(64, 128, use_cbam=True)          # 1/4
+        self.down3 = DownSample(128, 256, use_cbam=True)         # 1/8
+        self.down4 = DownSample(256, 512, use_cbam=True)         # 1/16
+        self.down5 = DownSample(512, 512, use_cbam=True)         # 1/32
+        # 解码器：上采样
+        self.up1 = UpSample(512, 512)    # 1/16
+        self.up2 = UpSample(1024, 256)   # 1/8
+        self.up3 = UpSample(512, 128)    # 1/4 → Ic4
+        self.up4 = UpSample(256, 64)     # 1/2 → Ic2
+        self.up5 = UpSample(128, 64)     # 1/1 → Ic1
+        # 输出层：Ms(笔画掩码), Mb(文本块掩码), 多尺度Ic
+        self.out_ms = nn.Conv2d(64, 1, 3, 1, 1)
+        self.out_mb = nn.Conv2d(64, 1, 3, 1, 1)
+        self.out_ic4 = nn.Conv2d(128, 3, 3, 1, 1)
+        self.out_ic2 = nn.Conv2d(64, 3, 3, 1, 1)
+        self.out_ic1 = nn.Conv2d(64, 3, 3, 1, 1)
+
+    def forward(self, x):
+        # 编码器
+        d1 = self.down1(x)
+        d2 = self.down2(d1)
+        d3 = self.down3(d2)
+        d4 = self.down4(d3)
+        d5 = self.down5(d4)
+        # 解码器
+        u1 = self.up1(d5)
+        u2 = self.up2(torch.cat([u1, d4], dim=1))
+        u3 = self.up3(torch.cat([u2, d3], dim=1))  # 1/4
+        u4 = self.up4(torch.cat([u3, d2], dim=1))  # 1/2
+        u5 = self.up5(torch.cat([u4, d1], dim=1))  # 1/1
+        # 输出
+        Ic4 = self.out_ic4(u3)
+        Ic2 = self.out_ic2(u4)
+        Ic1 = self.out_ic1(u5)
+        Ms = self.out_ms(u5)
+        Mb = self.out_mb(u5)
+        return Ms, Mb, Ic4, Ic2, Ic1
+
+# Refine网络
+class RefineNet(nn.Module):
+    def __init__(self, in_channels=7):  # 3(Iin)+1(Ms)+3(Ic1) =7
+        super().__init__()
+        # 编码器：下采样
+        self.down1 = DownSample(in_channels, 64, use_cbam=False)  # 1/2
+        self.down2 = DownSample(64, 128, use_cbam=False)          # 1/4
+        self.down3 = DownSample(128, 256, use_cbam=False)         # 1/8
+        self.down4 = DownSample(256, 512, use_cbam=False)         # 1/16
+        # 解码器：带空洞卷积的上采样
+        self.up1 = DilatedUpSample(512, 256)    # 1/8
+        self.up2 = DilatedUpSample(512, 128)     # 1/4
+        self.up3 = DilatedUpSample(256, 64)      # 1/2
+        self.up4 = DilatedUpSample(128, 64)      # 1/1
+        # 输出层：精细化擦除结果Ire
+        self.out_ire = nn.Conv2d(64, 3, 3, 1, 1)
+
+    def forward(self, x):
+        # 编码器
+        d1 = self.down1(x)
+        d2 = self.down2(d1)
+        d3 = self.down3(d2)
+        d4 = self.down4(d3)
+        # 解码器
+        u1 = self.up1(d4)
+        u2 = self.up2(torch.cat([u1, d3], dim=1))
+        u3 = self.up3(torch.cat([u2, d2], dim=1))
+        u4 = self.up4(torch.cat([u3, d1], dim=1))
+        # 输出
+        Ire = self.out_ire(u4)
+        return Ire
+
+# 生成器整体
+class Generator(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.coarse = CoarseNet()
+        self.refine = RefineNet()
+
+    def forward(self, Iin):
+        # Coarse网络输出
+        Ms, Mb, Ic4, Ic2, Ic1 = self.coarse(Iin)
+        # 拼接输入：Iin + Ms + Ic1（通道维度）
+        refine_in = torch.cat([Iin, Ms, Ic1], dim=1)
+        # Refine网络输出
+        Ire = self.refine(refine_in)
+        # 融合得到最终结果Icomp
+        Icomp = Ire * Mb + Iin * (1 - Mb)
+        return Ms, Mb, Ic4, Ic2, Ic1, Ire, Icomp
+
+
+
+# 基础判别器块
+class DiscBlock(nn.Module):
+    def __init__(self, in_channels, out_channels, stride=2):
+        super().__init__()
+        self.block = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, 4, stride, 1, bias=False),
+            nn.BatchNorm2d(out_channels),
+            nn.LeakyReLU(0.2, inplace=True)
+        )
+    def forward(self, x):
+        return self.block(x)
+
+# Local-Global判别器
+class Discriminator(nn.Module):
+    def __init__(self, in_channels=3):
+        super().__init__()
+        # 全局判别器：判整图
+        self.global_disc = nn.Sequential(
+            DiscBlock(in_channels, 64),
+            DiscBlock(64, 128),
+            DiscBlock(128, 256),
+            DiscBlock(256, 512),
+            nn.Conv2d(512, 1, 4, 1, 0, bias=False)
+        )
+        # 局部判别器：仅判文本区域（结构同全局）
+        self.local_disc = nn.Sequential(
+            DiscBlock(in_channels, 64),
+            DiscBlock(64, 128),
+            DiscBlock(128, 256),
+            DiscBlock(256, 512),
+            nn.Conv2d(512, 1, 4, 1, 0, bias=False)
+        )
+
+    def forward(self, x, local_mask=None):
+        """
+        :param x: 输入图像 [B,3,H,W]
+        :param local_mask: 文本区域掩码GT [B,1,H,W] 用于提取局部区域
+        :return: global_score, local_score
+        """
+        # 全局判别分数
+        global_score = self.global_disc(x)
+        # 局部判别分数：仅对文本区域做判别
+        local_score = 0
+        if local_mask is not None:
+            # 提取文本区域的特征
+            local_x = x * local_mask
+            local_score = self.local_disc(local_x)
+        return global_score, local_score
+
+
+# 加载预训练VGG16（用于感知/风格损失）
+class VGG16Feature(nn.Module):
+    def __init__(self):
+        super().__init__()
+        vgg = vgg16(pretrained=True).features
+        self.feat1 = nn.Sequential(*vgg[:5])   # 第1个池化层前
+        self.feat2 = nn.Sequential(*vgg[5:10]) # 第2个池化层前
+        self.feat3 = nn.Sequential(*vgg[10:17])# 第3个池化层前
+        # 冻结参数
+        for param in self.parameters():
+            param.requires_grad = False
+
+    def forward(self, x):
+        # x: [B,3,H,W] 归一化到ImageNet标准
+        x = F.interpolate(x, size=(224,224), mode='bilinear', align_corners=False)
+        f1 = self.feat1(x)
+        f2 = self.feat2(f1)
+        f3 = self.feat3(f2)
+        return [f1, f2, f3]
+
+# Gram矩阵计算
+def gram_matrix(x):
+    b, c, h, w = x.shape
+    x = x.view(b, c, h*w)
+    return torch.bmm(x, x.transpose(1,2)) / (c*h*w)
+
+# 全量Loss计算类
+class EnsExamLoss(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.vgg_feat = VGG16Feature().cuda()
+        # LR Loss权重：Ic4, Ic2, Ic1, Ire
+        self.lambda_n = [0.5, 0.6, 0.8, 1.0]  # 原[5,6,8,10] → 缩小10倍
+        self.beta_n = [0.08, 0.08, 0.08, 0.2]  # 原[0.8,0.8,0.8,2] → 缩小10倍
+        # 总损失权重
+        self.lambda_lr = 1.0
+        self.lambda_p = 0.005  # 感知损失权重降低（原0.05）
+        self.lambda_style = 12.0  # 风格损失权重降低（原120）
+        self.lambda_sn = 0.1  # SN损失权重降低（原1.0）
+        self.lambda_b = 0.04  # Block损失权重降低（原0.4）
+
+    def sn_loss(self, Ms, Ms_gt):
+        """SN损失"""
+        l1 = F.l1_loss(Ms, Ms_gt, reduction='sum')
+        sum_ms = Ms.sum()
+        sum_ms_gt = Ms_gt.sum()
+        min_sum = torch.min(sum_ms, sum_ms_gt) + 1e-8  # 避免除0
+        return l1 / min_sum
+
+    def block_loss(self, Mb, Mb_gt):
+        """Block损失（Dice Loss）"""
+        intersection = (Mb * Mb_gt).sum()
+        union = (Mb**2).sum() + (Mb_gt**2).sum() + 1e-8
+        dice = 2 * intersection / union
+        return 1 - dice
+
+    def lr_loss(self, Iouts, Igt_list, Mb_gt):
+        """LR损失（修复多尺度掩码维度匹配问题）"""
+        lr_loss = 0.0
+        for i, (Iout, Igt) in enumerate(zip(Iouts, Igt_list)):
+            # 关键修复：将Mb_gt下采样到当前Iout/Igt的尺度
+            # 获取当前Iout的高/宽
+            _, _, h, w = Iout.shape
+            # 下采样Mb_gt到(h, w)，保持通道数不变
+            Mb_gt_scaled = F.interpolate(Mb_gt, size=(h, w), mode='bilinear', align_corners=False)
+
+            # 文本区域损失（使用下采样后的掩码）
+            loss_text = F.l1_loss(Iout * Mb_gt_scaled, Igt * Mb_gt_scaled, reduction='mean')
+            # 非文本区域损失（使用下采样后的掩码）
+            loss_nontext = F.l1_loss(Iout * (1 - Mb_gt_scaled), Igt * (1 - Mb_gt_scaled), reduction='mean')
+            # 加权求和
+            lr_loss += self.lambda_n[i] * loss_text + self.beta_n[i] * loss_nontext
+        return lr_loss
+
+    def perceptual_loss(self, I_list, Igt):
+        """感知损失"""
+        per_loss = 0.0
+        gt_feats = self.vgg_feat(Igt)
+        for I in I_list:
+            I_feats = self.vgg_feat(I)
+            for f1, f2 in zip(I_feats, gt_feats):
+                per_loss += F.l1_loss(f1, f2, reduction='sum')
+        return per_loss
+
+    def style_loss(self, I_list, Igt):
+        """风格损失"""
+        style_loss = 0.0
+        gt_feats = self.vgg_feat(Igt)
+        gt_grams = [gram_matrix(f) for f in gt_feats]
+        for I in I_list:
+            I_feats = self.vgg_feat(I)
+            I_grams = [gram_matrix(f) for f in I_feats]
+            for g1, g2 in zip(I_grams, gt_grams):
+                style_loss += F.l1_loss(g1, g2, reduction='sum')
+        return style_loss
+
+    def adversarial_loss(self, score, is_real):
+        """Hinge对抗损失"""
+        if is_real:
+            loss = torch.mean(F.relu(1 - score))
+        else:
+            loss = torch.mean(F.relu(1 + score))
+        return loss
+
+    def forward(self, gen_out, gt, disc_score):
+        """
+        总损失计算
+        :param gen_out: 生成器输出 (Ms, Mb, Ic4, Ic2, Ic1, Ire, Icomp)
+        :param gt: 标签 (Ms_gt, Mb_gt, Igt4, Igt2, Igt1, Igt)
+        :param disc_score: 判别器分数 (global_score, local_score)
+        :return: 总损失，各分项损失
+        """
+        Ms, Mb, Ic4, Ic2, Ic1, Ire, Icomp = gen_out
+        Ms_gt, Mb_gt, Igt4, Igt2, Igt1, Igt = gt
+        global_score, local_score = disc_score
+
+        # 各分项损失
+        L_sn = self.sn_loss(Ms, Ms_gt) * self.lambda_sn
+        L_block = self.block_loss(Mb, Mb_gt) * self.lambda_b
+        L_lr = self.lr_loss([Ic4, Ic2, Ic1, Ire], [Igt4, Igt2, Igt1, Igt], Mb_gt) * self.lambda_lr
+        L_per = self.perceptual_loss([Ire, Icomp], Igt) * self.lambda_p
+        L_style = self.style_loss([Ire, Icomp], Igt) * self.lambda_style
+        L_adv = (self.adversarial_loss(global_score, False) + self.adversarial_loss(local_score, False)) / 2
+
+        # 总损失
+        L_total = L_adv + L_lr + L_per + L_style + L_sn + L_block
+        return L_total, [L_adv, L_lr, L_per, L_style, L_sn, L_block]

--- a/backend/models/model.py
+++ b/backend/models/model.py
@@ -334,25 +334,53 @@ def gram_matrix(x):
 
 # 全量Loss计算类
 class EnsExamLoss(nn.Module):
-    def __init__(self):
+    def __init__(self, loss_config=None):
         super().__init__()
+        if loss_config is None:
+            loss_config = {}
         self.vgg_feat = VGG16Feature()
-        # LR Loss权重：Ic4, Ic2, Ic1, Ire
-        self.lambda_n = [5, 6, 8, 10]  # 原[5,6,8,10] → 缩小10倍
-        self.beta_n = [0.8, 0.8, 0.8, 2]  # 原[0.8,0.8,0.8,2] → 缩小10倍
-        # 总损失权重
-        self.lambda_lr = 1.0
-        self.lambda_p = 0.05  # 感知损失权重降低（原0.05）
-        self.lambda_style = 120  # 风格损失权重降低（原120）
-        self.lambda_sn = 1  # SN损失权重降低（原1.0）
-        self.lambda_b = 0.4  # Block损失权重降低（原0.4）
+        self.lambda_n = loss_config.get('lambda_n', [5, 6, 8, 10])
+        self.beta_n = loss_config.get('beta_n', [0.8, 0.8, 0.8, 2])
+        self.lambda_lr = loss_config.get('lambda_lr', 1.0)
+        self.lambda_p = loss_config.get('lambda_p', 0.05)
+        self.lambda_style = loss_config.get('lambda_style', 120)
+        self.lambda_sn = loss_config.get('lambda_sn', 1)
+        self.lambda_b = loss_config.get('lambda_b', 0.4)
 
     def sn_loss(self, Ms, Ms_gt):
         """SN损失"""
-        l1_sum = torch.sum(torch.abs(Ms - Ms_gt), dim=[1, 2, 3])
-        # 这里的归一化是为了解决笔迹稀疏问题
-        normalization = torch.min(torch.sum(Ms, dim=[1, 2, 3]), torch.sum(Ms_gt, dim=[1, 2, 3]))
-        return (l1_sum / (normalization + 1e-6)).mean()
+        Ms = Ms.float()
+        Ms_gt = Ms_gt.float()
+
+        # 1. 计算每个样本的 GT 字迹总面积 (Batch 维度)
+        # shape: [B]
+        sum_gt = torch.sum(Ms_gt, dim=tuple(range(1, Ms.dim())))
+
+        # 2. 创建掩码：只选择 GT 中有字迹的样本 (阈值设为 1，避免浮点误差)
+        # 如果 sum_gt > 0，则 valid_mask 为 1，否则为 0
+        valid_mask = (sum_gt > 1.0).float()
+
+        # 如果整个 Batch 都没有字迹，直接返回 0，避免除零或无效计算
+        if valid_mask.sum() == 0:
+            # 返回与输入无关的零梯度，但保持可训练
+            return Ms.sum() * 0  # 利用输入创建，保持计算图连接
+
+        # 3. 计算 L1 误差总和 [B]
+        l1_sum = torch.sum(torch.abs(Ms - Ms_gt), dim=tuple(range(1, Ms.dim())))
+
+        # 4. 计算归一化分母 [B]
+        sum_pred = torch.sum(Ms, dim=tuple(range(1, Ms.dim())))
+        normalization = torch.min(sum_pred, sum_gt)
+
+        # 5. 计算单样本 Loss
+        # 注意：这里 epsilon 可以改回 1e-6，因为 valid_mask 已经保证了 sum_gt 不为 0
+        loss_batch = l1_sum / (normalization + 1e-6)
+
+        # 6. 只对有字迹的样本求平均
+        # 乘以 valid_mask 将无字样本 loss 置零，除以 valid_mask.sum() 保证梯度尺度稳定
+        L_sn = (loss_batch * valid_mask).sum() / (valid_mask.sum() + 1e-6)
+
+        return L_sn
 
     def block_loss(self, Mb, Mb_gt):
         # 逐样本计算

--- a/backend/models/model.py
+++ b/backend/models/model.py
@@ -8,106 +8,89 @@ from torch import nn
 from torchvision.models import vgg16
 
 
-def generate_soft_stroke_mask(Iin, Igt, alpha=3, L=5, threshold=20):
-    """
-    生成软笔画掩码
-    :param Iin: 原始图像
-    :param Igt: 擦除GT图像
-    :param alpha: SAF函数参数
-    :param L: 最大距离
-    :param threshold: 粗掩码阈值
-    :return: 软笔画掩码Ms [H, W] 0-1
-    """
-    diff = np.abs(Igt - Iin).mean(axis=-1)
-    coarse_mask = (diff > threshold).astype(np.uint8) * 255
-
-    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (3,3))
-    denoised_mask = cv2.morphologyEx(coarse_mask, cv2.MORPH_CLOSE, kernel)
-
-    skeleton = cv2.erode(denoised_mask, kernel, iterations=1)
-    outer = cv2.dilate(denoised_mask, kernel, iterations=1)
-
-    dist = cv2.distanceTransform(255-outer, cv2.DIST_L2, 5)
-    dist = np.clip(dist, 0, L)
-
-    C = (1 + math.exp(-alpha)) / (1 - math.exp(-alpha))
-    saf = C * (2 / (1 + np.exp(-alpha * dist / L)) - 1)
-    saf = np.clip(saf, 0, 1)
-
-    saf[skeleton > 0] = 1.0
-    return saf
-
-# CBAM注意力模块（轻量版，适配U-Net）
 class CBAM(nn.Module):
     def __init__(self, in_channels, reduction=16):
         super().__init__()
-        # 通道注意力
+        # 通道注意力（标准实现）
         self.avg_pool = nn.AdaptiveAvgPool2d(1)
         self.max_pool = nn.AdaptiveMaxPool2d(1)
-        self.fc = nn.Sequential(
-            nn.Linear(in_channels, in_channels//reduction),
+        self.mlp = nn.Sequential(
+            nn.Linear(in_channels, in_channels // reduction, bias=False),
             nn.ReLU(inplace=True),
-            nn.Linear(in_channels//reduction, in_channels)
-        )
-        # 空间注意力
-        self.spatial = nn.Sequential(
-            nn.Conv2d(2, 1, 3, padding=1, bias=False),
-            nn.Sigmoid()
+            nn.Linear(in_channels // reduction, in_channels, bias=False)
         )
         self.sigmoid = nn.Sigmoid()
 
+        # 空间注意力（关键修正：7×7卷积 + 无BatchNorm）
+        self.spatial = nn.Sequential(
+            nn.Conv2d(2, 1, kernel_size=7, padding=3, bias=False),  # ✅ 7×7
+            nn.Sigmoid()  # ✅ 无BatchNorm
+        )
+
     def forward(self, x):
         b, c, h, w = x.shape
-        # 通道注意力
-        avg_out = self.fc(self.avg_pool(x).view(b,c)).view(b,c,1,1)
-        max_out = self.fc(self.max_pool(x).view(b,c)).view(b,c,1,1)
+
+        # ========== 通道注意力 ==========
+        avg_out = self.mlp(self.avg_pool(x).view(b, c)).view(b, c, 1, 1)
+        max_out = self.mlp(self.max_pool(x).view(b, c)).view(b, c, 1, 1)
         channel_att = self.sigmoid(avg_out + max_out)
-        x = x * channel_att
-        # 空间注意力
-        avg_out = torch.mean(x, dim=1, keepdim=True)
-        max_out, _ = torch.max(x, dim=1, keepdim=True)
-        spatial_att = self.spatial(torch.cat([avg_out, max_out], dim=1))
-        x = x * spatial_att
+        x = x * channel_att  # 广播相乘 [B,C,H,W] * [B,C,1,1]
+
+        # ========== 空间注意力 ==========
+        avg_out = torch.mean(x, dim=1, keepdim=True)  # [B,1,H,W]
+        max_out, _ = torch.max(x, dim=1, keepdim=True)  # [B,1,H,W]
+        spatial_att = self.spatial(torch.cat([avg_out, max_out], dim=1))  # [B,1,H,W]
+        x = x * spatial_att  # 广播相乘 [B,C,H,W] * [B,1,H,W]
+
         return x
+
 
 # 空洞卷积块（Refine网络用）
 class DilatedConvBlock(nn.Module):
     def __init__(self, in_channels, out_channels, dilation=2):
         super().__init__()
+        padding = dilation * (3 - 1) // 2
         self.block = nn.Sequential(
-            nn.Conv2d(in_channels, out_channels, 3, padding=dilation, dilation=dilation, bias=False),
+            nn.Conv2d(in_channels, out_channels, 3, padding=padding, dilation=dilation, bias=False),
             nn.BatchNorm2d(out_channels),
             nn.ReLU(inplace=True)
         )
+
     def forward(self, x):
         return self.block(x)
 
+
 # U-Net下采样块（Coarse/Refine网络编码器）
 class DownSample(nn.Module):
-    def __init__(self, in_channels, out_channels, use_cbam=False):
+    def __init__(self, in_channels, out_channels):
         super().__init__()
         self.conv = nn.Sequential(
             nn.Conv2d(in_channels, out_channels, 4, 2, 1, bias=False),
             nn.BatchNorm2d(out_channels),
             nn.LeakyReLU(0.2, inplace=True)
         )
-        self.cbam = CBAM(out_channels) if use_cbam else nn.Identity()
+
     def forward(self, x):
         x = self.conv(x)
-        x = self.cbam(x)
         return x
+
 
 # U-Net上采样块（Coarse网络解码器）
 class UpSample(nn.Module):
-    def __init__(self, in_channels, out_channels):
+    def __init__(self, in_channels, out_channels, use_cbam=False):
         super().__init__()
         self.conv = nn.Sequential(
             nn.ConvTranspose2d(in_channels, out_channels, 4, 2, 1, bias=False),
             nn.BatchNorm2d(out_channels),
             nn.ReLU(inplace=True)
         )
+        self.cbam = CBAM(out_channels) if use_cbam else nn.modules.Identity()
+
     def forward(self, x):
-        return self.conv(x)
+        x = self.conv(x)
+        x = self.cbam(x)
+        return x
+
 
 # 带空洞卷积的上采样块（Refine网络解码器）
 class DilatedUpSample(nn.Module):
@@ -119,69 +102,113 @@ class DilatedUpSample(nn.Module):
             nn.ReLU(inplace=True)
         )
         self.dilated = DilatedConvBlock(out_channels, out_channels, dilation)
+
     def forward(self, x):
         x = self.conv(x)
         x = self.dilated(x)
         return x
+
 
 # Coarse网络
 class CoarseNet(nn.Module):
     def __init__(self, in_channels=3):
         super().__init__()
         # 编码器：下采样+CBAM
-        self.down1 = DownSample(in_channels, 64, use_cbam=False)  # 1/2
-        self.down2 = DownSample(64, 128, use_cbam=True)          # 1/4
-        self.down3 = DownSample(128, 256, use_cbam=True)         # 1/8
-        self.down4 = DownSample(256, 512, use_cbam=True)         # 1/16
-        self.down5 = DownSample(512, 512, use_cbam=True)         # 1/32
+        self.down1 = DownSample(in_channels, 64)  # 1/2
+        self.down2 = DownSample(64, 128)  # 1/4
+        self.down3 = DownSample(128, 256)  # 1/8
+        self.down4 = DownSample(256, 512)  # 1/16
+        self.down5 = DownSample(512, 512)  # 1/32
         # 解码器：上采样
-        self.up1 = UpSample(512, 512)    # 1/16
-        self.up2 = UpSample(1024, 256)   # 1/8
-        self.up3 = UpSample(512, 128)    # 1/4 → Ic4
-        self.up4 = UpSample(256, 64)     # 1/2 → Ic2
-        self.up5 = UpSample(128, 64)     # 1/1 → Ic1
+        self.up1 = UpSample(512, 512, use_cbam=True)  # 1/16
+        self.up2 = UpSample(1024, 256, use_cbam=True)  # 1/8
+        self.up3 = UpSample(512, 128, use_cbam=True)  # 1/4 → Ic4
+        self.up4 = UpSample(256, 64, use_cbam=True)  # 1/2 → Ic2
+        self.up5 = UpSample(128, 64, use_cbam=True)  # 1/1 → Ic1
         # 输出层：Ms(笔画掩码), Mb(文本块掩码), 多尺度Ic
-        self.out_ms = nn.Conv2d(64, 1, 3, 1, 1)
-        self.out_mb = nn.Conv2d(64, 1, 3, 1, 1)
-        self.out_ic4 = nn.Conv2d(128, 3, 3, 1, 1)
-        self.out_ic2 = nn.Conv2d(64, 3, 3, 1, 1)
-        self.out_ic1 = nn.Conv2d(64, 3, 3, 1, 1)
+        self.up1_ms = UpSample(512, 512, use_cbam=True)
+        self.up2_ms = UpSample(1024, 256, use_cbam=True)
+        self.up3_ms = UpSample(512, 128, use_cbam=True)
+        self.up4_ms = UpSample(256, 64, use_cbam=True)
+        self.up5_ms = UpSample(128, 64, use_cbam=True)
+
+        self.up1_mb = UpSample(512, 512, use_cbam=True)
+        self.up2_mb = UpSample(1024, 256, use_cbam=True)
+        self.up3_mb = UpSample(512, 128, use_cbam=True)
+        self.up4_mb = UpSample(256, 64, use_cbam=True)
+        self.up5_mb = UpSample(128, 64, use_cbam=True)
+
+        self.out_ms = nn.Conv2d(64, 1, 3, 1, 1, bias=True)
+        self.out_mb = nn.Conv2d(64, 1, 3, 1, 1, bias=True)
+        self.out_ic4 = nn.Conv2d(128, 3, 3, 1, 1, bias=False)
+        self.out_ic2 = nn.Conv2d(64, 3, 3, 1, 1, bias=False)
+        self.out_ic1 = nn.Conv2d(64, 3, 3, 1, 1, bias=False)
 
     def forward(self, x):
-        # 编码器
-        d1 = self.down1(x)
-        d2 = self.down2(d1)
-        d3 = self.down3(d2)
-        d4 = self.down4(d3)
-        d5 = self.down5(d4)
-        # 解码器
+        # 编码器（下采样）
+        d1 = self.down1(x)  # H/2
+        d2 = self.down2(d1)  # H/4
+        d3 = self.down3(d2)  # H/8
+        d4 = self.down4(d3)  # H/16
+        d5 = self.down5(d4)  # H/32
+
+        # 解码器（上采样 + 跳跃连接）
         u1 = self.up1(d5)
-        u2 = self.up2(torch.cat([u1, d4], dim=1))
-        u3 = self.up3(torch.cat([u2, d3], dim=1))  # 1/4
-        u4 = self.up4(torch.cat([u3, d2], dim=1))  # 1/2
-        u5 = self.up5(torch.cat([u4, d1], dim=1))  # 1/1
-        # 输出
-        Ic4 = self.out_ic4(u3)
-        Ic2 = self.out_ic2(u4)
-        Ic1 = self.out_ic1(u5)
-        Ms = self.out_ms(u5)
-        Mb = self.out_mb(u5)
+        u1 = torch.cat([u1, d4], dim=1)  # 拼接H/16特征
+
+        u2 = self.up2(u1)
+        u2 = torch.cat([u2, d3], dim=1)  # 拼接H/8特征
+
+        u3 = self.up3(u2)  # H/4 → 输出 Ic4
+        Ic4 = torch.tanh(self.out_ic4(u3))
+        u3 = torch.cat([u3, d2], dim=1)  # 拼接H/4特征
+
+        u4 = self.up4(u3)  # H/2 → 输出 Ic2
+        Ic2 = torch.tanh(self.out_ic2(u4))
+        u4 = torch.cat([u4, d1], dim=1)  # 拼接H/2特征
+
+        u5 = self.up5(u4)  # H → 输出 Ic1, Mb, Ms
+        Ic1 = torch.tanh(self.out_ic1(u5))
+
+        u1_mb = self.up1_mb(d5)
+        u1_mb = torch.cat([u1_mb, d4], dim=1)
+        u2_mb = self.up2_mb(u1_mb)
+        u2_mb = torch.cat([u2_mb, d3], dim=1)
+        u3_mb = self.up3_mb(u2_mb)
+        u3_mb = torch.cat([u3_mb, d2], dim=1)
+        u4_mb = self.up4_mb(u3_mb)
+        u4_mb = torch.cat([u4_mb, d1], dim=1)
+        u5_mb = self.up5_mb(u4_mb)
+        Mb = torch.sigmoid(self.out_mb(u5_mb))
+
+        u1_ms = self.up1_ms(d5)
+        u1_ms = torch.cat([u1_ms, d4], dim=1)
+        u2_ms = self.up2_ms(u1_ms)
+        u2_ms = torch.cat([u2_ms, d3], dim=1)
+        u3_ms = self.up3_ms(u2_ms)
+        u3_ms = torch.cat([u3_ms, d2], dim=1)
+        u4_ms = self.up4_ms(u3_ms)
+        u4_ms = torch.cat([u4_ms, d1], dim=1)
+        u5_ms = self.up5_ms(u4_ms)
+        Ms = torch.sigmoid(self.out_ms(u5_ms))
+
         return Ms, Mb, Ic4, Ic2, Ic1
+
 
 # Refine网络
 class RefineNet(nn.Module):
     def __init__(self, in_channels=7):  # 3(Iin)+1(Ms)+3(Ic1) =7
         super().__init__()
         # 编码器：下采样
-        self.down1 = DownSample(in_channels, 64, use_cbam=False)  # 1/2
-        self.down2 = DownSample(64, 128, use_cbam=False)          # 1/4
-        self.down3 = DownSample(128, 256, use_cbam=False)         # 1/8
-        self.down4 = DownSample(256, 512, use_cbam=False)         # 1/16
+        self.down1 = DownSample(in_channels, 64)  # 1/2
+        self.down2 = DownSample(64, 128)  # 1/4
+        self.down3 = DownSample(128, 256)  # 1/8
+        self.down4 = DownSample(256, 512)  # 1/16
         # 解码器：带空洞卷积的上采样
-        self.up1 = DilatedUpSample(512, 256)    # 1/8
-        self.up2 = DilatedUpSample(512, 128)     # 1/4
-        self.up3 = DilatedUpSample(256, 64)      # 1/2
-        self.up4 = DilatedUpSample(128, 64)      # 1/1
+        self.up1 = DilatedUpSample(512, 256)  # 1/8
+        self.up2 = DilatedUpSample(512, 128)  # 1/4
+        self.up3 = DilatedUpSample(256, 64)  # 1/2
+        self.up4 = DilatedUpSample(128, 64)  # 1/1
         # 输出层：精细化擦除结果Ire
         self.out_ire = nn.Conv2d(64, 3, 3, 1, 1)
 
@@ -193,12 +220,19 @@ class RefineNet(nn.Module):
         d4 = self.down4(d3)
         # 解码器
         u1 = self.up1(d4)
-        u2 = self.up2(torch.cat([u1, d3], dim=1))
-        u3 = self.up3(torch.cat([u2, d2], dim=1))
-        u4 = self.up4(torch.cat([u3, d1], dim=1))
+        u1 = torch.cat([u1, d3], dim=1)
+
+        u2 = self.up2(u1)
+        u2 = torch.cat([u2, d2], dim=1)
+
+        u3 = self.up3(u2)
+        u3 = torch.cat([u3, d1], dim=1)
+
+        u4 = self.up4(u3)
         # 输出
-        Ire = self.out_ire(u4)
+        Ire = torch.tanh(self.out_ire(u4))
         return Ire
+
 
 # 生成器整体
 class Generator(nn.Module):
@@ -219,7 +253,6 @@ class Generator(nn.Module):
         return Ms, Mb, Ic4, Ic2, Ic1, Ire, Icomp
 
 
-
 # 基础判别器块
 class DiscBlock(nn.Module):
     def __init__(self, in_channels, out_channels, stride=2):
@@ -229,44 +262,52 @@ class DiscBlock(nn.Module):
             nn.BatchNorm2d(out_channels),
             nn.LeakyReLU(0.2, inplace=True)
         )
+
     def forward(self, x):
         return self.block(x)
+
 
 # Local-Global判别器
 class Discriminator(nn.Module):
     def __init__(self, in_channels=3):
         super().__init__()
-        # 全局判别器：判整图
+        # 全局判别器：输出标量（适配任意尺寸）
         self.global_disc = nn.Sequential(
             DiscBlock(in_channels, 64),
             DiscBlock(64, 128),
             DiscBlock(128, 256),
             DiscBlock(256, 512),
-            nn.Conv2d(512, 1, 4, 1, 0, bias=False)
+            nn.Conv2d(512, 1, 4, 1, 0, bias=False)  # [B,1,1,1]
         )
-        # 局部判别器：仅判文本区域（结构同全局）
+        # 局部判别器：输出特征图（用于掩码加权）
         self.local_disc = nn.Sequential(
             DiscBlock(in_channels, 64),
             DiscBlock(64, 128),
             DiscBlock(128, 256),
             DiscBlock(256, 512),
-            nn.Conv2d(512, 1, 4, 1, 0, bias=False)
+            nn.Conv2d(512, 1, 1, 1, 0, bias=False)  # [B,1,H',W']
         )
 
     def forward(self, x, local_mask=None):
         """
-        :param x: 输入图像 [B,3,H,W]
-        :param local_mask: 文本区域掩码GT [B,1,H,W] 用于提取局部区域
-        :return: global_score, local_score
+        :param x: [B,3,H,W] 归一化到[-1,1]的图像
+        :param local_mask: [B,1,H,W] 真实文本掩码（训练时必需）
+        :return:
+            global_score: [B,1,1,1] 全局判别logits
+            local_score: [B,1,H',W'] 掩码加权后的局部判别logits
         """
-        # 全局判别分数
         global_score = self.global_disc(x)
-        # 局部判别分数：仅对文本区域做判别
         local_score = 0
+
         if local_mask is not None:
-            # 提取文本区域的特征
-            local_x = x * local_mask
-            local_score = self.local_disc(local_x)
+            # 1. 计算局部判别特征图
+            local_feat = self.local_disc(x)  # [B,1,H',W']
+            # 2. 将local_mask下采样到local_feat的尺寸
+            _, _, h_feat, w_feat = local_feat.shape
+            local_mask_scaled = F.interpolate(local_mask, size=(h_feat, w_feat), mode='nearest')
+            # 3. 关键修复：用掩码加权局部特征（仅关注文本区域）
+            local_score = local_feat * local_mask_scaled
+
         return global_score, local_score
 
 
@@ -275,56 +316,68 @@ class VGG16Feature(nn.Module):
     def __init__(self):
         super().__init__()
         vgg = vgg16(pretrained=True).features
-        self.feat1 = nn.Sequential(*vgg[:5])   # 第1个池化层前
-        self.feat2 = nn.Sequential(*vgg[5:10]) # 第2个池化层前
-        self.feat3 = nn.Sequential(*vgg[10:17])# 第3个池化层前
+        self.feat1 = nn.Sequential(*vgg[:5])  # 第1个池化层前
+        self.feat2 = nn.Sequential(*vgg[5:10])  # 第2个池化层前
+        self.feat3 = nn.Sequential(*vgg[10:17])  # 第3个池化层前
         # 冻结参数
         for param in self.parameters():
             param.requires_grad = False
 
+            # 【关键修正】ImageNet归一化参数
+        # self.mean = torch.tensor([0.485, 0.456, 0.406]).view(1, 3, 1, 1).cuda()
+        # self.std = torch.tensor([0.229, 0.224, 0.225]).view(1, 3, 1, 1).cuda()
+        self.register_buffer('mean', torch.tensor([0.485, 0.456, 0.406]).view(1, 3, 1, 1))
+        self.register_buffer('std', torch.tensor([0.229, 0.224, 0.225]).view(1, 3, 1, 1))
+
     def forward(self, x):
         # x: [B,3,H,W] 归一化到ImageNet标准
-        x = F.interpolate(x, size=(224,224), mode='bilinear', align_corners=False)
+        # x: [-1,1] → [0,1] → ImageNet归一化
+        x = (x + 1) / 2.0  # [-1,1] → [0,1]
+        x = F.interpolate(x, size=(224, 224), mode='bilinear', align_corners=False)
+        x = (x - self.mean) / self.std
         f1 = self.feat1(x)
         f2 = self.feat2(f1)
         f3 = self.feat3(f2)
         return [f1, f2, f3]
 
+
 # Gram矩阵计算
 def gram_matrix(x):
     b, c, h, w = x.shape
-    x = x.view(b, c, h*w)
-    return torch.bmm(x, x.transpose(1,2)) / (c*h*w)
+    x = x.view(b, c, h * w)
+    return torch.bmm(x, x.transpose(1, 2)) / (c * h * w)
+
 
 # 全量Loss计算类
 class EnsExamLoss(nn.Module):
     def __init__(self):
         super().__init__()
-        self.vgg_feat = VGG16Feature().cuda()
+        self.vgg_feat = VGG16Feature()
         # LR Loss权重：Ic4, Ic2, Ic1, Ire
-        self.lambda_n = [0.5, 0.6, 0.8, 1.0]  # 原[5,6,8,10] → 缩小10倍
-        self.beta_n = [0.08, 0.08, 0.08, 0.2]  # 原[0.8,0.8,0.8,2] → 缩小10倍
+        self.lambda_n = [5, 6, 8, 10]  # 原[5,6,8,10] → 缩小10倍
+        self.beta_n = [0.8, 0.8, 0.8, 2]  # 原[0.8,0.8,0.8,2] → 缩小10倍
         # 总损失权重
         self.lambda_lr = 1.0
-        self.lambda_p = 0.005  # 感知损失权重降低（原0.05）
-        self.lambda_style = 12.0  # 风格损失权重降低（原120）
-        self.lambda_sn = 0.1  # SN损失权重降低（原1.0）
-        self.lambda_b = 0.04  # Block损失权重降低（原0.4）
+        self.lambda_p = 0.05  # 感知损失权重降低（原0.05）
+        self.lambda_style = 120  # 风格损失权重降低（原120）
+        self.lambda_sn = 1  # SN损失权重降低（原1.0）
+        self.lambda_b = 0.4  # Block损失权重降低（原0.4）
 
     def sn_loss(self, Ms, Ms_gt):
         """SN损失"""
-        l1 = F.l1_loss(Ms, Ms_gt, reduction='sum')
-        sum_ms = Ms.sum()
-        sum_ms_gt = Ms_gt.sum()
-        min_sum = torch.min(sum_ms, sum_ms_gt) + 1e-8  # 避免除0
-        return l1 / min_sum
+        l1_sum = torch.sum(torch.abs(Ms - Ms_gt), dim=[1, 2, 3])
+        # 这里的归一化是为了解决笔迹稀疏问题
+        normalization = torch.min(torch.sum(Ms, dim=[1, 2, 3]), torch.sum(Ms_gt, dim=[1, 2, 3]))
+        return (l1_sum / (normalization + 1e-6)).mean()
 
     def block_loss(self, Mb, Mb_gt):
-        """Block损失（Dice Loss）"""
-        intersection = (Mb * Mb_gt).sum()
-        union = (Mb**2).sum() + (Mb_gt**2).sum() + 1e-8
-        dice = 2 * intersection / union
-        return 1 - dice
+        # 逐样本计算
+        intersection = (Mb * Mb_gt).sum(dim=[1, 2, 3])  # [B]
+        mb_sq = (Mb ** 2).sum(dim=[1, 2, 3])  # [B]
+        mbgt_sq = (Mb_gt ** 2).sum(dim=[1, 2, 3])  # [B]
+
+        dice = (2 * intersection) / (mb_sq + mbgt_sq + 1e-8)  # [B]
+        return (1 - dice).mean()  # 平均所有样本
 
     def lr_loss(self, Iouts, Igt_list, Mb_gt):
         """LR损失（修复多尺度掩码维度匹配问题）"""
@@ -334,7 +387,7 @@ class EnsExamLoss(nn.Module):
             # 获取当前Iout的高/宽
             _, _, h, w = Iout.shape
             # 下采样Mb_gt到(h, w)，保持通道数不变
-            Mb_gt_scaled = F.interpolate(Mb_gt, size=(h, w), mode='bilinear', align_corners=False)
+            Mb_gt_scaled = F.interpolate(Mb_gt, size=(h, w), mode='nearest')
 
             # 文本区域损失（使用下采样后的掩码）
             loss_text = F.l1_loss(Iout * Mb_gt_scaled, Igt * Mb_gt_scaled, reduction='mean')
@@ -351,28 +404,34 @@ class EnsExamLoss(nn.Module):
         for I in I_list:
             I_feats = self.vgg_feat(I)
             for f1, f2 in zip(I_feats, gt_feats):
-                per_loss += F.l1_loss(f1, f2, reduction='sum')
+                per_loss += F.l1_loss(f1, f2, reduction='mean')
         return per_loss
 
     def style_loss(self, I_list, Igt):
-        """风格损失"""
         style_loss = 0.0
         gt_feats = self.vgg_feat(Igt)
-        gt_grams = [gram_matrix(f) for f in gt_feats]
         for I in I_list:
             I_feats = self.vgg_feat(I)
-            I_grams = [gram_matrix(f) for f in I_feats]
-            for g1, g2 in zip(I_grams, gt_grams):
-                style_loss += F.l1_loss(g1, g2, reduction='sum')
+            for f1, f2 in zip(I_feats, gt_feats):
+                b, c, h, w = f1.shape
+                gram1 = gram_matrix(f1)  # [B, C, C]
+                gram2 = gram_matrix(f2)  # [B, C, C]
+                # 关键：除以 H*W*C 归一化
+                norm = h * w * c
+                style_loss += F.l1_loss(gram1, gram2, reduction='mean') / norm
         return style_loss
 
-    def adversarial_loss(self, score, is_real):
-        """Hinge对抗损失"""
-        if is_real:
-            loss = torch.mean(F.relu(1 - score))
-        else:
-            loss = torch.mean(F.relu(1 + score))
-        return loss
+    # 判别器损失（训练D时用）
+    @staticmethod
+    def hinge_loss_D(real_score, fake_score):
+        loss_real = torch.mean(F.relu(1.0 - real_score))
+        loss_fake = torch.mean(F.relu(1.0 + fake_score))
+        return loss_real + loss_fake
+
+    # 生成器损失（训练G时用）
+    @staticmethod
+    def hinge_loss_G(fake_score):
+        return -torch.mean(F.relu(1.0 + fake_score))  # 注意：ReLU(1+score)
 
     def forward(self, gen_out, gt, disc_score):
         """
@@ -392,7 +451,10 @@ class EnsExamLoss(nn.Module):
         L_lr = self.lr_loss([Ic4, Ic2, Ic1, Ire], [Igt4, Igt2, Igt1, Igt], Mb_gt) * self.lambda_lr
         L_per = self.perceptual_loss([Ire, Icomp], Igt) * self.lambda_p
         L_style = self.style_loss([Ire, Icomp], Igt) * self.lambda_style
-        L_adv = (self.adversarial_loss(global_score, False) + self.adversarial_loss(local_score, False)) / 2
+
+        L_adv_global = self.hinge_loss_G(global_score)
+        L_adv_local = self.hinge_loss_G(local_score)
+        L_adv = (L_adv_global + L_adv_local) / 2
 
         # 总损失
         L_total = L_adv + L_lr + L_per + L_style + L_sn + L_block

--- a/backend/models/test_erase.py
+++ b/backend/models/test_erase.py
@@ -1,0 +1,122 @@
+"""
+文字擦除推理测试脚本
+运行方式：cd backend/models && python test_erase.py <图片路径>
+示例：python test_erase.py E:/code/python/error_correction/dataset/初中数学/图片/xxx.jpg
+"""
+import sys
+import os
+# backend/models/ → backend/
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import torch
+from pathlib import Path
+from PIL import Image
+import numpy as np
+
+# ── 命令行参数 ────────────────────────────────────────
+if len(sys.argv) < 2:
+    print("用法: python test_erase.py <图片路径>")
+    print("示例: python test_erase.py E:/xxx/photo.jpg")
+    sys.exit(1)
+
+test_img_path = Path(sys.argv[1])
+if not test_img_path.exists():
+    print(f"错误: 图片不存在 -> {test_img_path}")
+    sys.exit(1)
+
+# ── 路径配置 ──────────────────────────────────────────
+MODEL_PATH = Path(__file__).parent.parent / "runtime_data" / "models" / "latest.pth"
+OUTPUT_DIR = Path(__file__).parent.parent / "runtime_data" / "erased"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+# ── GPU 信息 ──────────────────────────────────────────
+print("=" * 50)
+print(f"PyTorch   : {torch.__version__}")
+print(f"CUDA 可用 : {torch.cuda.is_available()}")
+if torch.cuda.is_available():
+    print(f"GPU       : {torch.cuda.get_device_name(0)}")
+    print(f"VRAM      : {torch.cuda.get_device_properties(0).total_memory / 1024**3:.1f} GB")
+print("=" * 50)
+
+# ── 加载模型 ──────────────────────────────────────────
+print(f"\n[1] 加载权重: {MODEL_PATH}")
+assert MODEL_PATH.exists(), f"找不到权重文件: {MODEL_PATH}"
+
+from models.model import Generator
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+G = Generator().to(device)
+ckpt = torch.load(MODEL_PATH, map_location=device, weights_only=False)
+state_dict = ckpt.get("G_state_dict") or ckpt.get("generator_state_dict") or ckpt
+G.load_state_dict(state_dict)
+G.eval()
+print(f"    权重加载成功，运行设备: {device}")
+
+# ── 推理 ──────────────────────────────────────────────
+PATCH = 512
+OVERLAP = 32
+
+def preprocess(pil_img):
+    img = pil_img.convert("RGB")
+    w, h = img.size
+    pw = (PATCH - w % PATCH) % PATCH
+    ph = (PATCH - h % PATCH) % PATCH
+    if pw or ph:
+        canvas = Image.new("RGB", (w + pw, h + ph), (255, 255, 255))
+        canvas.paste(img, (0, 0))
+        img = canvas
+    arr = np.array(img, dtype=np.float32) / 127.5 - 1.0
+    return arr, w, h
+
+def to_tensor(arr):
+    return torch.from_numpy(arr).permute(2, 0, 1).unsqueeze(0).to(device)
+
+def to_numpy(t):
+    arr = t.squeeze(0).permute(1, 2, 0).cpu().numpy()
+    return np.clip((arr + 1.0) * 127.5, 0, 255).astype(np.uint8)
+
+def infer(arr):
+    h, w, _ = arr.shape
+    stride = PATCH - OVERLAP
+    result = np.zeros((h, w, 3), dtype=np.float64)
+    weight = np.zeros((h, w, 1), dtype=np.float64)
+
+    def ticks(total):
+        pts = list(range(0, total - PATCH + 1, stride))
+        if not pts or pts[-1] + PATCH < total:
+            pts.append(total - PATCH)
+        return pts
+
+    ys, xs = ticks(h), ticks(w)
+    total = len(ys) * len(xs)
+    done = 0
+    with torch.no_grad():
+        for y in ys:
+            for x in xs:
+                patch = to_tensor(arr[y:y+PATCH, x:x+PATCH])
+                *_, Icomp = G(patch)
+                out = to_numpy(Icomp).astype(np.float64)
+                result[y:y+PATCH, x:x+PATCH] += out
+                weight[y:y+PATCH, x:x+PATCH] += 1.0
+                done += 1
+                print(f"    patch {done}/{total}", end="\r")
+
+    print()
+    return np.clip(result / weight, 0, 255).astype(np.uint8)
+
+print(f"\n[2] 测试图片: {test_img_path.name}")
+pil_orig = Image.open(test_img_path)
+print(f"    原图尺寸: {pil_orig.size[0]}x{pil_orig.size[1]}")
+arr, orig_w, orig_h = preprocess(pil_orig)
+print(f"    Padding 后: {arr.shape[1]}x{arr.shape[0]}")
+
+print("\n[3] 开始推理...")
+result_arr = infer(arr)
+result_arr = result_arr[:orig_h, :orig_w]
+result_img = Image.fromarray(result_arr)
+
+# ── 保存结果 ──────────────────────────────────────────
+out_name = "erased_" + test_img_path.stem + ".png"
+out_path = OUTPUT_DIR / out_name
+result_img.save(out_path)
+print(f"\n[4] 结果已保存: {out_path}")
+print("    完成！")

--- a/backend/models/train.py
+++ b/backend/models/train.py
@@ -1,4 +1,5 @@
 # 设备
+import math
 import os
 
 import numpy as np
@@ -20,122 +21,302 @@ from torchvision import transforms
 import torch.nn.functional as F
 
 
-# -------------------------- 核心工具函数：自动生成掩码 --------------------------
-def generate_mask_from_pair(Iin, Igt, threshold=20):
+def generate_mask_from_pair(Iin, Igt, threshold=20, debug=False):
     """
-    从已resize的原始图(Iin)和擦除GT图(Igt)生成掩码：
-    ✅ 修复：移除函数内的resize，改用外部统一resize后的图像
-    :param Iin: 已resize的原始图像（H,W,3），0-255，RGB格式
-    :param Igt: 已resize的擦除GT图像（H,W,3），0-255，RGB格式
-    :param threshold: 像素差异阈值（适配手写文本）
-    :return: Ms_gt (H,W)、Mb_gt (H,W)，均为0-1的numpy数组
+    单块（512x512）软笔画掩码生成 - 修正版本
+    :param Iin: 单块图像 (H,W,3) RGB 0-255
+    :param Igt: 单块GT图 (H,W,3) RGB 0-255
+    :param threshold: 差异阈值，默认20
+    :param debug: 是否返回中间结果用于调试
+    :return: Ms_gt(软掩码), Mb_gt(基础掩码), [debug_dict]
     """
-    # 1. 生成粗笔画掩码（像素差异法）
-    diff = np.abs(Iin - Igt).mean(axis=-1)  # 灰度化相减，计算像素差异
-    coarse_mask = (diff > threshold).astype(np.uint8) * 255  # 二值化
+    H, W = Iin.shape[:2]
 
-    # 2. 生成Mb_gt（文本块掩码：膨胀+闭运算，扩大文本区域）
-    kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (5, 5))
-    Mb_gt = cv2.dilate(coarse_mask, kernel, iterations=2)  # 膨胀扩大文本块
-    Mb_gt = cv2.morphologyEx(Mb_gt, cv2.MORPH_CLOSE, kernel)  # 闭运算填充孔洞
-    Mb_gt = Mb_gt / 255.0  # 归一化到0-1
+    # ========== 1. 生成粗笔画掩码 ==========
+    # 使用int16避免溢出，计算RGB三通道的平均差异
+    diff = np.abs(Iin.astype(np.int16) - Igt.astype(np.int16)).mean(axis=-1)
+    # print(f"Diff统计: min={diff.min()}, max={diff.max()}, 90%={np.percentile(diff, 90)}")
+    coarse_mask = (diff > threshold).astype(np.uint8)
 
-    # 3. 生成Ms_gt（软笔画掩码：细化+渐变）
-    # 步骤1：去噪（腐蚀+膨胀）
-    denoised_mask = cv2.morphologyEx(coarse_mask, cv2.MORPH_CLOSE, cv2.getStructuringElement(cv2.MORPH_RECT, (3, 3)))
-    # 步骤2：提取骨架（细化笔画）
-    skeleton = np.zeros_like(denoised_mask)
-    temp_mask = denoised_mask.copy()
-    while True:
-        eroded = cv2.erode(temp_mask, kernel)
-        temp = cv2.dilate(eroded, kernel)
-        temp = cv2.subtract(temp_mask, temp)
-        skeleton = cv2.bitwise_or(skeleton, temp)
-        temp_mask = eroded.copy()
-        if cv2.countNonZero(temp_mask) == 0:
-            break
-    # 步骤3：生成软掩码（骨架=1，边界渐变）
-    dist = cv2.distanceTransform(255 - denoised_mask, cv2.DIST_L2, 5)
-    dist = np.clip(dist, 0, 5)
-    alpha = 3
-    L = 5
-    C = (1 + np.exp(-alpha)) / (1 - np.exp(-alpha))
-    saf = C * (2 / (1 + np.exp(-alpha * dist / L)) - 1)
-    saf = np.clip(saf, 0, 1)
-    saf[skeleton > 0] = 1.0  # 骨架区域强制为1
-    Ms_gt = saf
+    # ========== 2. 形态学去噪 ==========
+    kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (3, 3))
+    # 开运算去除散点噪声 + 闭运算连接断裂笔画
+    denoised_mask = cv2.morphologyEx(coarse_mask, cv2.MORPH_OPEN, kernel)
+    denoised_mask = cv2.morphologyEx(denoised_mask, cv2.MORPH_CLOSE, kernel)
+
+    # ========== 3. 生成 Mb_gt（基础文本块掩码） ==========
+    # 对去噪后的掩码适度膨胀，作为文本区域指导
+    Mb_gt = cv2.dilate(denoised_mask, kernel, iterations=2).astype(np.float32)
+
+    # ========== 4. 生成软笔画掩码 Ms_gt ==========
+    # 4.1 骨架：笔画收缩1像素（论文明确要求）
+    skeleton = cv2.erode(denoised_mask, kernel, iterations=1)
+
+    # 4.2 外边界区域：原始笔画扩张5像素
+    kernel_large = cv2.getStructuringElement(cv2.MORPH_RECT, (5, 5))
+    outer_region = cv2.dilate(denoised_mask, kernel_large, iterations=5)
+
+    # 4.3 距离变换：计算outer_region内每个像素到边缘的最短距离
+    # 输入要求：uint8, 0=背景, >0=前景；输出：float32，单位像素
+    dist_map = cv2.distanceTransform(outer_region, cv2.DIST_L2, cv2.DIST_MASK_PRECISE)
+
+    # 4.4 SAF 参数 (论文明确值)
+    alpha = 3.0
+    L = 5.0
+    exp_neg_alpha = np.exp(-alpha)
+    C = (1 + exp_neg_alpha) / (1 - exp_neg_alpha + 1e-8)  # +eps防除零
+
+    # 4.5 向量化计算软掩码（避免循环，提速100x）
+    Ms_gt = np.zeros((H, W), dtype=np.float32)
+
+    # 区域划分mask
+    mask_skeleton = skeleton > 0  # 骨架区域 → 值=1
+    mask_outer = outer_region > 0  # 扩张区域（含骨架）
+    mask_middle = mask_outer & (~mask_skeleton)  # 中间环形区域 → 用SAF
+
+    # (a) 骨架区域强制=1
+    Ms_gt[mask_skeleton] = 1.0
+
+    # (b) 中间区域应用SAF衰减
+    if np.any(mask_middle):
+        D = np.clip(dist_map[mask_middle], 0, L)  # 距离截断到[0, L]
+        # SAF公式: C * (2/(1+exp(-α*D/L)) - 1)
+        exp_term = np.exp(-alpha * D / L)
+        saf_vals = C * (2.0 / (1.0 + exp_term + 1e-8) - 1.0)
+        Ms_gt[mask_middle] = np.clip(saf_vals, 0.0, 1.0)
+
+    # (c) 外边界及以外区域保持=0（已初始化为0）
+
+    # ========== 5. 调试信息（可选） ==========
+    if debug:
+        debug_info = {
+            'coarse_mask': coarse_mask,
+            'denoised_mask': denoised_mask,
+            'skeleton': skeleton,
+            'outer_region': outer_region,
+            'dist_map': dist_map,
+            'mask_middle': mask_middle.astype(np.uint8) * 255
+        }
+        return Ms_gt, Mb_gt, debug_info
 
     return Ms_gt, Mb_gt
 
 
 # -------------------------- 真实数据集加载类（核心修复：统一图像尺寸） --------------------------
+# class EnsExamRealDataset(Dataset):
+#     """
+#     适配“仅含原始图+擦除GT图”的数据集加载类
+#     ✅ 修复：所有图像读取后先resize到img_size，保证批量尺寸一致
+#     """
+#
+#     def __init__(self, data_root, img_size=512, is_train=True):
+#         self.data_root = data_root
+#         self.img_size = img_size  # 统一目标尺寸（512×512）
+#         self.is_train = is_train
+#
+#         # 1. 定义图像预处理：归一化到[-1,1]（匹配GAN训练）
+#         self.img_transform = transforms.Compose([
+#             transforms.ToTensor(),  # HWC→CHW，0-255→0-1
+#             transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])  # 0-1→[-1,1]
+#         ])
+#
+#         # 2. 加载文件列表（保证images和gt目录下文件同名）
+#         split = "train" if is_train else "test"
+#         self.img_dir = os.path.join(data_root, split, "all_images")
+#         self.gt_dir = os.path.join(data_root, split, "all_labels")
+#
+#         # 过滤有效文件（仅保留png/jpg/jpeg）
+#         self.file_names = [
+#             f for f in os.listdir(self.img_dir)
+#             if f.endswith((".png", ".jpg", ".jpeg")) and os.path.exists(os.path.join(self.gt_dir, f))
+#         ]
+#         assert len(self.file_names) > 0, f"未找到匹配的图像文件！检查{self.img_dir}和{self.gt_dir}目录"
+#
+#     def __len__(self):
+#         return len(self.file_names)
+#
+#     def __getitem__(self, idx):
+#         # 1. 加载原始图和擦除GT图
+#         file_name = self.file_names[idx]
+#         img_path = os.path.join(self.img_dir, file_name)
+#         gt_path = os.path.join(self.gt_dir, file_name)
+#
+#         # 读取图像（BGR→RGB，避免OpenCV默认BGR格式问题）
+#         Iin = cv2.imread(img_path)[:, :, ::-1]  # (H,W,3)，0-255，RGB
+#         Igt = cv2.imread(gt_path)[:, :, ::-1]  # (H,W,3)，0-255，RGB
+#
+#         # ✅ 核心修复1：先统一resize到img_size×img_size（所有样本尺寸一致）
+#         Iin = cv2.resize(Iin, (self.img_size, self.img_size), interpolation=cv2.INTER_LINEAR)
+#         Igt = cv2.resize(Igt, (self.img_size, self.img_size), interpolation=cv2.INTER_LINEAR)
+#
+#         # 2. 自动生成Ms_gt（软笔画掩码）、Mb_gt（文本块掩码）
+#         # ✅ 核心修复2：传入已resize的图像，函数内不再重复resize
+#         Ms_gt_np, Mb_gt_np = generate_mask_from_pair(Iin, Igt, threshold=20)
+#
+#         # 3. 图像预处理（归一化到[-1,1]）
+#         Iin = self.img_transform(Iin)  # (3,512,512)，[-1,1]
+#         Igt = self.img_transform(Igt)  # (3,512,512)，[-1,1]
+#
+#         # 4. 掩码预处理（归一化到[0,1]，扩展通道维度）
+#         Ms_gt = torch.from_numpy(Ms_gt_np).unsqueeze(0).float()  # (1,512,512)，[0,1]
+#         Mb_gt = torch.from_numpy(Mb_gt_np).unsqueeze(0).float()  # (1,512,512)，[0,1]
+#
+#         # 5. 生成多尺度擦除GT（1/4, 1/2, 1/1）
+#         # Igt4：512→128，Igt2：512→256，Igt1：原尺寸
+#         Igt4 = F.interpolate(Igt.unsqueeze(0), size=(self.img_size // 4, self.img_size // 4), mode='bilinear',
+#                              align_corners=False).squeeze(0)
+#         Igt2 = F.interpolate(Igt.unsqueeze(0), size=(self.img_size // 2, self.img_size // 2), mode='bilinear',
+#                              align_corners=False).squeeze(0)
+#         Igt1 = Igt  # 1:1尺度
+#
+#         # 返回顺序：Iin, Ms_gt, Mb_gt, Igt4, Igt2, Igt1, Igt
+#         return Iin, Ms_gt, Mb_gt, Igt4, Igt2, Igt1, Igt
+
 class EnsExamRealDataset(Dataset):
     """
-    适配“仅含原始图+擦除GT图”的数据集加载类
-    ✅ 修复：所有图像读取后先resize到img_size，保证批量尺寸一致
+    适配“仅含原始图 + 擦除 GT 图”的数据集加载类
+    ✅ 修改：不再 resize 原图，而是将大图裁剪为多个 512x512 的样本块
     """
 
-    def __init__(self, data_root, img_size=512, is_train=True):
+    def __init__(self, data_root, img_size=512, is_train=True, overlap=0):
+        """
+        :param data_root: 数据集根目录
+        :param img_size: 裁剪块尺寸 (默认 512)
+        :param is_train: 是否训练模式
+        :param overlap: 裁剪重叠像素 (默认 0，即不重叠；训练时可设为 128 增加数据量)
+        """
         self.data_root = data_root
-        self.img_size = img_size  # 统一目标尺寸（512×512）
+        self.img_size = img_size
         self.is_train = is_train
+        self.overlap = overlap
 
-        # 1. 定义图像预处理：归一化到[-1,1]（匹配GAN训练）
+        # 1. 定义图像预处理：归一化到 [-1,1]
         self.img_transform = transforms.Compose([
-            transforms.ToTensor(),  # HWC→CHW，0-255→0-1
-            transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])  # 0-1→[-1,1]
+            transforms.ToTensor(),  # HWC→CHW, 0-255→0-1
+            transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])
         ])
 
-        # 2. 加载文件列表（保证images和gt目录下文件同名）
+        # 2. 获取文件路径
         split = "train" if is_train else "test"
         self.img_dir = os.path.join(data_root, split, "all_images")
         self.gt_dir = os.path.join(data_root, split, "all_labels")
 
-        # 过滤有效文件（仅保留png/jpg/jpeg）
-        self.file_names = [
-            f for f in os.listdir(self.img_dir)
-            if f.endswith((".png", ".jpg", ".jpeg")) and os.path.exists(os.path.join(self.gt_dir, f))
-        ]
-        assert len(self.file_names) > 0, f"未找到匹配的图像文件！检查{self.img_dir}和{self.gt_dir}目录"
+        # 3. ✅ 核心修改：构建“样本索引列表”
+        # 不再是一对一 (1 图=1 样本)，而是一对多 (1 图=N 个样本块)
+        self.patch_index_map = []
+
+        valid_extensions = (".png", ".jpg", ".jpeg")
+        all_files = [f for f in os.listdir(self.img_dir) if f.endswith(valid_extensions)]
+
+        print(f"🔍 正在扫描数据集并构建裁剪索引 (Overlap={overlap})...")
+        for fname in all_files:
+            if not os.path.exists(os.path.join(self.gt_dir, fname)):
+                continue
+
+            img_path = os.path.join(self.img_dir, fname)
+            gt_path = os.path.join(self.gt_dir, fname)
+
+            # 读取尺寸 (仅读取头信息，不加载像素，速度快)
+            # 如果 cv2.imread 太慢，可用 imageio 或 PIL 获取 size，这里为了兼容直接用 cv2
+            # 注意：这里必须加载一次获取 H,W，或者用 cv2.imread + IMREAD_UNCHANGED
+            img_temp = cv2.imread(img_path)
+            if img_temp is None: continue
+            H, W = img_temp.shape[:2]
+            del img_temp  # 释放内存
+
+            # 计算步长
+            step = self.img_size - self.overlap
+            if step <= 0: step = 1  # 防止 overlap 过大导致步长为 0
+
+            # 计算该图能切多少块 (覆盖全图，边缘不足补黑)
+            # 使用 math.ceil 确保覆盖整张图
+            num_h = math.ceil((H - self.overlap) / step) if H > self.img_size else 1
+            num_w = math.ceil((W - self.overlap) / step) if W > self.img_size else 1
+
+            # 如果原图小于 512，也作为一个样本 (后续会 padding)
+            if H <= self.img_size and W <= self.img_size:
+                num_h, num_w = 1, 1
+
+            for i in range(num_h):
+                for j in range(num_w):
+                    # 计算裁剪坐标
+                    y1 = i * step
+                    x1 = j * step
+
+                    # 如果是最后一块，确保覆盖到边缘
+                    y2 = min(y1 + self.img_size, H)
+                    x2 = min(x1 + self.img_size, W)
+
+                    # 如果是第一块且图很小，直接取全图
+                    if H <= self.img_size: y1, y2 = 0, H
+                    if W <= self.img_size: x1, x2 = 0, W
+
+                    # 记录样本信息：(图路径，GT 路径，裁剪坐标，是否需要 padding)
+                    need_pad_h = (y2 - y1) < self.img_size
+                    need_pad_w = (x2 - x1) < self.img_size
+
+                    self.patch_index_map.append({
+                        'img_path': img_path,
+                        'gt_path': gt_path,
+                        'y1': y1, 'y2': y2,
+                        'x1': x1, 'x2': x2,
+                        'pad_h': need_pad_h,
+                        'pad_w': need_pad_w
+                    })
+
+        print(f"✅ 索引构建完成：共 {len(self.patch_index_map)} 个样本块 (来自 {len(all_files)} 张图)")
+        assert len(self.patch_index_map) > 0, "未找到有效样本！"
 
     def __len__(self):
-        return len(self.file_names)
+        return len(self.patch_index_map)
 
     def __getitem__(self, idx):
-        # 1. 加载原始图和擦除GT图
-        file_name = self.file_names[idx]
-        img_path = os.path.join(self.img_dir, file_name)
-        gt_path = os.path.join(self.gt_dir, file_name)
+        # 1. 获取当前样本的裁剪信息
+        info = self.patch_index_map[idx]
 
-        # 读取图像（BGR→RGB，避免OpenCV默认BGR格式问题）
-        Iin = cv2.imread(img_path)[:, :, ::-1]  # (H,W,3)，0-255，RGB
-        Igt = cv2.imread(gt_path)[:, :, ::-1]  # (H,W,3)，0-255，RGB
+        # print(f"🔎 Loading: {info['img_path']}")
+        # print(f"   Exists: {os.path.exists(info['img_path'])}")
 
-        # ✅ 核心修复1：先统一resize到img_size×img_size（所有样本尺寸一致）
-        Iin = cv2.resize(Iin, (self.img_size, self.img_size), interpolation=cv2.INTER_LINEAR)
-        Igt = cv2.resize(Igt, (self.img_size, self.img_size), interpolation=cv2.INTER_LINEAR)
+        # 2. 加载完整原图 (RGB)
+        Iin_full = cv2.imread(info['img_path'])[:, :, ::-1]
+        Igt_full = cv2.imread(info['gt_path'])[:, :, ::-1]
 
-        # 2. 自动生成Ms_gt（软笔画掩码）、Mb_gt（文本块掩码）
-        # ✅ 核心修复2：传入已resize的图像，函数内不再重复resize
+        # 3. ✅ 核心修改：根据坐标裁剪
+        Iin = Iin_full[info['y1']:info['y2'], info['x1']:info['x2']]
+        Igt = Igt_full[info['y1']:info['y2'], info['x1']:info['x2']]
+
+        Iin = np.ascontiguousarray(Iin)
+        Igt = np.ascontiguousarray(Igt)
+
+        # 4. ✅ 边缘填充 (确保输入模型的都是 512x512)
+        if info['pad_h'] or info['pad_w']:
+            pad_h = self.img_size - Iin.shape[0]
+            pad_w = self.img_size - Iin.shape[1]
+            # 使用 REPLICATE 填充比 CONSTANT(黑边) 更好，减少边界伪影
+            Iin = cv2.copyMakeBorder(Iin, 0, pad_h, 0, pad_w, cv2.BORDER_REPLICATE)
+            Igt = cv2.copyMakeBorder(Igt, 0, pad_h, 0, pad_w, cv2.BORDER_REPLICATE)
+
+        # 5. 生成掩码 (输入已经是 512x512)
+        # 注意：这里调用的是单块生成函数，不是滑动拼接函数
         Ms_gt_np, Mb_gt_np = generate_mask_from_pair(Iin, Igt, threshold=20)
 
-        # 3. 图像预处理（归一化到[-1,1]）
-        Iin = self.img_transform(Iin)  # (3,512,512)，[-1,1]
-        Igt = self.img_transform(Igt)  # (3,512,512)，[-1,1]
+        # 6. 图像预处理 (归一化)
+        Iin = self.img_transform(Iin)  # (3, 512, 512)
+        Igt = self.img_transform(Igt)  # (3, 512, 512)
 
-        # 4. 掩码预处理（归一化到[0,1]，扩展通道维度）
-        Ms_gt = torch.from_numpy(Ms_gt_np).unsqueeze(0).float()  # (1,512,512)，[0,1]
-        Mb_gt = torch.from_numpy(Mb_gt_np).unsqueeze(0).float()  # (1,512,512)，[0,1]
+        # 7. 掩码转 Tensor
+        Ms_gt = torch.from_numpy(Ms_gt_np).unsqueeze(0).float()
+        Mb_gt = torch.from_numpy(Mb_gt_np).unsqueeze(0).float()
 
-        # 5. 生成多尺度擦除GT（1/4, 1/2, 1/1）
-        # Igt4：512→128，Igt2：512→256，Igt1：原尺寸
-        Igt4 = F.interpolate(Igt.unsqueeze(0), size=(self.img_size // 4, self.img_size // 4), mode='bilinear',
-                             align_corners=False).squeeze(0)
-        Igt2 = F.interpolate(Igt.unsqueeze(0), size=(self.img_size // 2, self.img_size // 2), mode='bilinear',
-                             align_corners=False).squeeze(0)
-        Igt1 = Igt  # 1:1尺度
+        # 8. 生成多尺度 GT (1/4, 1/2, 1/1)
+        Igt_unsqueeze = Igt.unsqueeze(0)
+        Igt4 = F.interpolate(Igt_unsqueeze, size=(self.img_size // 4, self.img_size // 4),
+                             mode='bilinear', align_corners=False).squeeze(0)
+        Igt2 = F.interpolate(Igt_unsqueeze, size=(self.img_size // 2, self.img_size // 2),
+                             mode='bilinear', align_corners=False).squeeze(0)
+        Igt1 = Igt
 
-        # 返回顺序：Iin, Ms_gt, Mb_gt, Igt4, Igt2, Igt1, Igt
+        # 返回：Iin, Ms_gt, Mb_gt, Igt4, Igt2, Igt1, Igt
         return Iin, Ms_gt, Mb_gt, Igt4, Igt2, Igt1, Igt
 
 # ====================== 3. 核心训练函数 ======================

--- a/backend/models/train.py
+++ b/backend/models/train.py
@@ -1,6 +1,7 @@
 # 设备
 import math
 import os
+import argparse
 
 import numpy as np
 import torch
@@ -11,6 +12,7 @@ import torch.nn.functional as F
 from tqdm import tqdm
 
 from src.adcj.EnsExam.model import Generator, Discriminator, EnsExamLoss
+from src.adcj.EnsExam.config import config
 
 import os
 import torch
@@ -319,19 +321,62 @@ class EnsExamRealDataset(Dataset):
         # 返回：Iin, Ms_gt, Mb_gt, Igt4, Igt2, Igt1, Igt
         return Iin, Ms_gt, Mb_gt, Igt4, Igt2, Igt1, Igt
 
+
 # ====================== 3. 核心训练函数 ======================
 def train_ensexam(
-        epochs=100,
-        batch_size=4,
-        lr=0.0001,
-        device='cuda',
-        save_dir='./checkpoints',
-        resume=False,  # 是否断点续训
-        resume_path='./checkpoints/latest.pth',
-        data_root='./data',
-):
+        epochs=None,
+        batch_size=None,
+        lr=None,
+        data_root=None,
+        img_size=512,
+        save_dir=None,
+        resume_path=None,
+        resume=False,
+        num_workers=None,
+        device=None,
+        use_wandb=None):
+    train_cfg = config.train
+    loss_cfg = config.loss
+    wandb_cfg = config.wandb
+
+    epochs = epochs if epochs is not None else train_cfg.get('epochs', 100)
+    batch_size = batch_size if batch_size is not None else train_cfg.get('batch_size', 4)
+    lr = lr if lr is not None else train_cfg.get('lr', 0.0001)
+    data_root = data_root if data_root is not None else train_cfg.get('data_root', './data')
+    save_dir = save_dir if save_dir is not None else train_cfg.get('save_dir', './ensexam_checkpoints')
+    resume_path = resume_path if resume_path is not None else train_cfg.get('resume_path',
+                                                                            './ensexam_checkpoints/latest.pth')
+    num_workers = num_workers if num_workers is not None else train_cfg.get('num_workers', 4)
+    device = device if device is not None else train_cfg.get('device', 'cuda' if torch.cuda.is_available() else 'cpu')
+    use_wandb = use_wandb if use_wandb is not None else wandb_cfg.get('enabled', True)
     # 0. 初始化目录
     os.makedirs(save_dir, exist_ok=True)
+
+    wandb_run = None
+    if use_wandb:
+        try:
+            import wandb
+            wandb_cfg = config.wandb
+            if wandb_cfg.get('offline', True):
+                os.environ['WANDB_MODE'] = 'offline'
+                wandb_dir = wandb_cfg.get('dir', './wandb')
+                os.makedirs(wandb_dir, exist_ok=True)
+
+            wandb_run = wandb.init(
+                project=wandb_cfg.get('project', 'ensexam'),
+                name=wandb_cfg.get('name'),
+                entity=wandb_cfg.get('entity'),
+                dir=wandb_cfg.get('dir', './wandb'),
+                config={
+                    'train': train_cfg,
+                    'loss': loss_cfg
+                }
+            )
+            print(f"WandB 初始化成功 (离线模式: {wandb_cfg.get('offline', True)})")
+        except ImportError:
+            print("Warning: wandb 未安装，跳过 wandb 记录")
+        except Exception as e:
+            print(f"Warning: wandb 初始化失败: {e}")
 
     # 1. 数据加载
     train_dataset = EnsExamRealDataset(data_root=data_root)
@@ -346,7 +391,7 @@ def train_ensexam(
     # 2. 模型初始化
     G = Generator().to(device)
     D = Discriminator().to(device)
-    criterion = EnsExamLoss().to(device)
+    criterion = EnsExamLoss(loss_cfg).to(device)
 
     # 3. 优化器
     optimizer_G = optim.Adam(G.parameters(), lr=lr, betas=(0.5, 0.9))
@@ -369,6 +414,14 @@ def train_ensexam(
     for epoch in range(start_epoch, epochs):
         epoch_loss_G = 0.0  # 生成器总损失
         epoch_loss_D = 0.0  # 判别器总损失
+        epoch_loss_parts = {
+            'adv': 0.0,
+            'lr': 0.0,
+            'per': 0.0,
+            'style': 0.0,
+            'sn': 0.0,
+            'block': 0.0
+        }
         pbar = tqdm(train_loader, desc=f"Epoch {epoch + 1}/{epochs}")
 
         for batch_idx, (Iin, Ms_gt, Mb_gt, Igt4, Igt2, Igt1, Igt) in enumerate(pbar):
@@ -414,6 +467,12 @@ def train_ensexam(
             # ---------------------- 步骤3：日志记录 ----------------------
             epoch_loss_G += loss_G.item()
             epoch_loss_D += loss_D.item()
+            epoch_loss_parts['adv'] += loss_parts[0].item()
+            epoch_loss_parts['lr'] += loss_parts[1].item()
+            epoch_loss_parts['per'] += loss_parts[2].item()
+            epoch_loss_parts['style'] += loss_parts[3].item()
+            epoch_loss_parts['sn'] += loss_parts[4].item()
+            epoch_loss_parts['block'] += loss_parts[5].item()
 
             # 进度条显示
             pbar.set_postfix({
@@ -422,12 +481,30 @@ def train_ensexam(
                 'Loss_G_adv': f"{loss_parts[0].item():.4f}",
                 'Loss_G_lr': f"{loss_parts[1].item():.4f}"
             })
+            if wandb_run is not None:
+                wandb.log({
+                    'batch_loss_G': loss_G.item(),
+                    'batch_loss_D': loss_D.item(),
+                    'batch_loss_G_adv': loss_parts[0].item(),
+                    'batch_loss_G_lr': loss_parts[1].item(),
+                    'batch_loss_G_per': loss_parts[2].item(),
+                    'batch_loss_G_style': loss_parts[3].item(),
+                    'batch_loss_G_sn': loss_parts[4].item(),
+                    'batch_loss_G_block': loss_parts[5].item()
+                })
 
         # ---------------------- 步骤4：Epoch结束处理 ----------------------
         # 计算Epoch平均损失
         avg_loss_G = epoch_loss_G / len(train_loader)
         avg_loss_D = epoch_loss_D / len(train_loader)
+        avg_loss_parts = {k: v / len(train_loader) for k, v in epoch_loss_parts.items()}
         print(f"Epoch {epoch + 1} 平均损失：Loss_G={avg_loss_G:.4f}, Loss_D={avg_loss_D:.4f}")
+        if wandb_run is not None:
+            wandb.log({
+                'epoch': epoch + 1,
+                'avg_loss_G': avg_loss_G,
+                'avg_loss_D': avg_loss_D
+            })
 
         # 保存模型（每5个Epoch保存一次，同时保存最新模型）
         if (epoch + 1) % 5 == 0 or epoch == epochs - 1:
@@ -446,20 +523,34 @@ def train_ensexam(
             torch.save(checkpoint, os.path.join(save_dir, f'ensexam_epoch_{epoch + 1}.pth'))
             print(f"模型已保存：{os.path.join(save_dir, f'ensexam_epoch_{epoch + 1}.pth')}")
 
+    if wandb_run is not None:
+        wandb.finish()
+    print("训练完成！")
+
 
 # ====================== 4. 启动训练 ======================
 if __name__ == "__main__":
-    # 设备选择
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    print(f"使用设备：{device}")
+    parser = argparse.ArgumentParser(description='EnsExam 训练')
+    parser.add_argument('--epochs', type=int, default=None, help='训练轮数')
+    parser.add_argument('--batch_size', type=int, default=None, help='批次大小')
+    parser.add_argument('--lr', type=float, default=None, help='学习率')
+    parser.add_argument('--device', type=str, default=None, help='设备 (cuda/cpu)')
+    parser.add_argument('--data_root', type=str, default=None, help='数据集路径')
+    parser.add_argument('--save_dir', type=str, default=None, help='模型保存目录')
+    parser.add_argument('--resume', action='store_true', help='断点续训')
+    parser.add_argument('--no_wandb', action='store_true', help='禁用 wandb')
+    args = parser.parse_args()
 
-    # 启动训练
+    use_wandb = not args.no_wandb
+    device = args.device
+
     train_ensexam(
-        epochs=100,
-        batch_size=4,
-        lr=0.0001,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        lr=args.lr,
         device=device,
-        save_dir='./ensexam_checkpoints',
-        resume=False,
-        data_root=r"D:\PythonProject1\LLM\adcj\src\adcj\EnsExam\SCUT-EnsExam\SCUT-EnsExam",
+        data_root=args.data_root,
+        save_dir=args.save_dir,
+        resume=args.resume,
+        use_wandb=use_wandb
     )

--- a/backend/models/train.py
+++ b/backend/models/train.py
@@ -120,8 +120,8 @@ class EnsExamRealDataset(Dataset):
         Ms_gt_np, Mb_gt_np = generate_mask_from_pair(Iin, Igt, threshold=20)
 
         # 3. 图像预处理（归一化到[-1,1]）
-        Iin = self.img_transform(Iin.astype(np.float32))  # (3,512,512)，[-1,1]
-        Igt = self.img_transform(Igt.astype(np.float32))  # (3,512,512)，[-1,1]
+        Iin = self.img_transform(Iin)  # (3,512,512)，[-1,1]
+        Igt = self.img_transform(Igt)  # (3,512,512)，[-1,1]
 
         # 4. 掩码预处理（归一化到[0,1]，扩展通道维度）
         Ms_gt = torch.from_numpy(Ms_gt_np).unsqueeze(0).float()  # (1,512,512)，[0,1]
@@ -204,34 +204,29 @@ def train_ensexam(
             # ---------------------- 步骤1：训练判别器D ----------------------
             optimizer_D.zero_grad()
 
-            # 1.1 真实图像的判别损失（label=real）
-            real_global_score, real_local_score = D(Igt, Mb_gt)
-            loss_D_real = (criterion.adversarial_loss(real_global_score, is_real=True) +
-                           criterion.adversarial_loss(real_local_score, is_real=True)) / 2
-
-            # 1.2 生成图像的判别损失（label=fake）
+            # 1.1 真实图像判别
+            real_global, real_local = D(Igt, Mb_gt)
+            # 1.2 生成图像判别
             gen_out = G(Iin)
-            Icomp = gen_out[-1]  # 生成的最终擦除结果
-            fake_global_score, fake_local_score = D(Icomp.detach(), Mb_gt)  # detach避免更新G
-            loss_D_fake = (criterion.adversarial_loss(fake_global_score, is_real=False) +
-                           criterion.adversarial_loss(fake_local_score, is_real=False)) / 2
+            Icomp = gen_out[-1]  # 取最后一个输出Icomp
+            fake_global, fake_local = D(Icomp.detach(), Mb_gt)
+            # 1.3 计算D损失（使用Model中的hinge_loss_D）
+            loss_D_global = EnsExamLoss.hinge_loss_D(real_global, fake_global)
+            loss_D_local = EnsExamLoss.hinge_loss_D(real_local, fake_local)
+            loss_D = (loss_D_global + loss_D_local) / 2
 
-            # 1.3 D总损失 & 反向传播
-            loss_D = (loss_D_real + loss_D_fake) / 2
             loss_D.backward()
             optimizer_D.step()
 
             # ---------------------- 步骤2：训练生成器G ----------------------
             optimizer_G.zero_grad()
 
-            # 2.1 重新计算生成图像的判别分数（用于G的对抗损失）
-            fake_global_score, fake_local_score = D(Icomp, Mb_gt)
-            disc_score = (fake_global_score, fake_local_score)
-
-            # 2.2 计算G的全量损失
+            # 2.1 重新计算生成图像的判别分数
+            fake_global, fake_local = D(Icomp, Mb_gt)
+            disc_score = (fake_global, fake_local)
+            # 2.2 计算G的全量损失（Model中的EnsExamLoss.forward）
             loss_G, loss_parts = criterion(gen_out, gt, disc_score)
 
-            # 2.3 G反向传播
             loss_G.backward()
             optimizer_G.step()
 

--- a/backend/models/train.py
+++ b/backend/models/train.py
@@ -1,0 +1,289 @@
+# 设备
+import os
+
+import numpy as np
+import torch
+from torch import optim
+from torch.utils.data import Dataset, DataLoader
+from torchvision.transforms import transforms
+import torch.nn.functional as F
+from tqdm import tqdm
+
+from src.adcj.EnsExam.model import Generator, Discriminator, EnsExamLoss
+
+import os
+import torch
+import numpy as np
+import cv2
+from torch.utils.data import Dataset
+from torchvision import transforms
+import torch.nn.functional as F
+
+
+# -------------------------- 核心工具函数：自动生成掩码 --------------------------
+def generate_mask_from_pair(Iin, Igt, threshold=20):
+    """
+    从已resize的原始图(Iin)和擦除GT图(Igt)生成掩码：
+    ✅ 修复：移除函数内的resize，改用外部统一resize后的图像
+    :param Iin: 已resize的原始图像（H,W,3），0-255，RGB格式
+    :param Igt: 已resize的擦除GT图像（H,W,3），0-255，RGB格式
+    :param threshold: 像素差异阈值（适配手写文本）
+    :return: Ms_gt (H,W)、Mb_gt (H,W)，均为0-1的numpy数组
+    """
+    # 1. 生成粗笔画掩码（像素差异法）
+    diff = np.abs(Iin - Igt).mean(axis=-1)  # 灰度化相减，计算像素差异
+    coarse_mask = (diff > threshold).astype(np.uint8) * 255  # 二值化
+
+    # 2. 生成Mb_gt（文本块掩码：膨胀+闭运算，扩大文本区域）
+    kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (5, 5))
+    Mb_gt = cv2.dilate(coarse_mask, kernel, iterations=2)  # 膨胀扩大文本块
+    Mb_gt = cv2.morphologyEx(Mb_gt, cv2.MORPH_CLOSE, kernel)  # 闭运算填充孔洞
+    Mb_gt = Mb_gt / 255.0  # 归一化到0-1
+
+    # 3. 生成Ms_gt（软笔画掩码：细化+渐变）
+    # 步骤1：去噪（腐蚀+膨胀）
+    denoised_mask = cv2.morphologyEx(coarse_mask, cv2.MORPH_CLOSE, cv2.getStructuringElement(cv2.MORPH_RECT, (3, 3)))
+    # 步骤2：提取骨架（细化笔画）
+    skeleton = np.zeros_like(denoised_mask)
+    temp_mask = denoised_mask.copy()
+    while True:
+        eroded = cv2.erode(temp_mask, kernel)
+        temp = cv2.dilate(eroded, kernel)
+        temp = cv2.subtract(temp_mask, temp)
+        skeleton = cv2.bitwise_or(skeleton, temp)
+        temp_mask = eroded.copy()
+        if cv2.countNonZero(temp_mask) == 0:
+            break
+    # 步骤3：生成软掩码（骨架=1，边界渐变）
+    dist = cv2.distanceTransform(255 - denoised_mask, cv2.DIST_L2, 5)
+    dist = np.clip(dist, 0, 5)
+    alpha = 3
+    L = 5
+    C = (1 + np.exp(-alpha)) / (1 - np.exp(-alpha))
+    saf = C * (2 / (1 + np.exp(-alpha * dist / L)) - 1)
+    saf = np.clip(saf, 0, 1)
+    saf[skeleton > 0] = 1.0  # 骨架区域强制为1
+    Ms_gt = saf
+
+    return Ms_gt, Mb_gt
+
+
+# -------------------------- 真实数据集加载类（核心修复：统一图像尺寸） --------------------------
+class EnsExamRealDataset(Dataset):
+    """
+    适配“仅含原始图+擦除GT图”的数据集加载类
+    ✅ 修复：所有图像读取后先resize到img_size，保证批量尺寸一致
+    """
+
+    def __init__(self, data_root, img_size=512, is_train=True):
+        self.data_root = data_root
+        self.img_size = img_size  # 统一目标尺寸（512×512）
+        self.is_train = is_train
+
+        # 1. 定义图像预处理：归一化到[-1,1]（匹配GAN训练）
+        self.img_transform = transforms.Compose([
+            transforms.ToTensor(),  # HWC→CHW，0-255→0-1
+            transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])  # 0-1→[-1,1]
+        ])
+
+        # 2. 加载文件列表（保证images和gt目录下文件同名）
+        split = "train" if is_train else "test"
+        self.img_dir = os.path.join(data_root, split, "all_images")
+        self.gt_dir = os.path.join(data_root, split, "all_labels")
+
+        # 过滤有效文件（仅保留png/jpg/jpeg）
+        self.file_names = [
+            f for f in os.listdir(self.img_dir)
+            if f.endswith((".png", ".jpg", ".jpeg")) and os.path.exists(os.path.join(self.gt_dir, f))
+        ]
+        assert len(self.file_names) > 0, f"未找到匹配的图像文件！检查{self.img_dir}和{self.gt_dir}目录"
+
+    def __len__(self):
+        return len(self.file_names)
+
+    def __getitem__(self, idx):
+        # 1. 加载原始图和擦除GT图
+        file_name = self.file_names[idx]
+        img_path = os.path.join(self.img_dir, file_name)
+        gt_path = os.path.join(self.gt_dir, file_name)
+
+        # 读取图像（BGR→RGB，避免OpenCV默认BGR格式问题）
+        Iin = cv2.imread(img_path)[:, :, ::-1]  # (H,W,3)，0-255，RGB
+        Igt = cv2.imread(gt_path)[:, :, ::-1]  # (H,W,3)，0-255，RGB
+
+        # ✅ 核心修复1：先统一resize到img_size×img_size（所有样本尺寸一致）
+        Iin = cv2.resize(Iin, (self.img_size, self.img_size), interpolation=cv2.INTER_LINEAR)
+        Igt = cv2.resize(Igt, (self.img_size, self.img_size), interpolation=cv2.INTER_LINEAR)
+
+        # 2. 自动生成Ms_gt（软笔画掩码）、Mb_gt（文本块掩码）
+        # ✅ 核心修复2：传入已resize的图像，函数内不再重复resize
+        Ms_gt_np, Mb_gt_np = generate_mask_from_pair(Iin, Igt, threshold=20)
+
+        # 3. 图像预处理（归一化到[-1,1]）
+        Iin = self.img_transform(Iin.astype(np.float32))  # (3,512,512)，[-1,1]
+        Igt = self.img_transform(Igt.astype(np.float32))  # (3,512,512)，[-1,1]
+
+        # 4. 掩码预处理（归一化到[0,1]，扩展通道维度）
+        Ms_gt = torch.from_numpy(Ms_gt_np).unsqueeze(0).float()  # (1,512,512)，[0,1]
+        Mb_gt = torch.from_numpy(Mb_gt_np).unsqueeze(0).float()  # (1,512,512)，[0,1]
+
+        # 5. 生成多尺度擦除GT（1/4, 1/2, 1/1）
+        # Igt4：512→128，Igt2：512→256，Igt1：原尺寸
+        Igt4 = F.interpolate(Igt.unsqueeze(0), size=(self.img_size // 4, self.img_size // 4), mode='bilinear',
+                             align_corners=False).squeeze(0)
+        Igt2 = F.interpolate(Igt.unsqueeze(0), size=(self.img_size // 2, self.img_size // 2), mode='bilinear',
+                             align_corners=False).squeeze(0)
+        Igt1 = Igt  # 1:1尺度
+
+        # 返回顺序：Iin, Ms_gt, Mb_gt, Igt4, Igt2, Igt1, Igt
+        return Iin, Ms_gt, Mb_gt, Igt4, Igt2, Igt1, Igt
+
+# ====================== 3. 核心训练函数 ======================
+def train_ensexam(
+        epochs=100,
+        batch_size=4,
+        lr=0.0001,
+        device='cuda',
+        save_dir='./checkpoints',
+        resume=False,  # 是否断点续训
+        resume_path='./checkpoints/latest.pth',
+        data_root='./data',
+):
+    # 0. 初始化目录
+    os.makedirs(save_dir, exist_ok=True)
+
+    # 1. 数据加载
+    train_dataset = EnsExamRealDataset(data_root=data_root)
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=0,  # Windows下建议设为0，避免多进程问题
+        drop_last=True
+    )
+
+    # 2. 模型初始化
+    G = Generator().to(device)
+    D = Discriminator().to(device)
+    criterion = EnsExamLoss().to(device)
+
+    # 3. 优化器
+    optimizer_G = optim.Adam(G.parameters(), lr=lr, betas=(0.5, 0.9))
+    optimizer_D = optim.Adam(D.parameters(), lr=lr, betas=(0.5, 0.9))
+
+    # 4. 断点续训
+    start_epoch = 0
+    if resume and os.path.exists(resume_path):
+        checkpoint = torch.load(resume_path, map_location=device)
+        G.load_state_dict(checkpoint['G_state_dict'])
+        D.load_state_dict(checkpoint['D_state_dict'])
+        optimizer_G.load_state_dict(checkpoint['optimizer_G'])
+        optimizer_D.load_state_dict(checkpoint['optimizer_D'])
+        start_epoch = checkpoint['epoch']
+        print(f"断点续训：从第{start_epoch}Epoch恢复")
+
+    # 5. 训练循环
+    G.train()
+    D.train()
+    for epoch in range(start_epoch, epochs):
+        epoch_loss_G = 0.0  # 生成器总损失
+        epoch_loss_D = 0.0  # 判别器总损失
+        pbar = tqdm(train_loader, desc=f"Epoch {epoch + 1}/{epochs}")
+
+        for batch_idx, (Iin, Ms_gt, Mb_gt, Igt4, Igt2, Igt1, Igt) in enumerate(pbar):
+            # 数据移到设备
+            Iin = Iin.to(device)
+            Ms_gt = Ms_gt.to(device)
+            Mb_gt = Mb_gt.to(device)
+            Igt4 = Igt4.to(device)
+            Igt2 = Igt2.to(device)
+            Igt1 = Igt1.to(device)
+            Igt = Igt.to(device)
+            gt = (Ms_gt, Mb_gt, Igt4, Igt2, Igt1, Igt)
+
+            # ---------------------- 步骤1：训练判别器D ----------------------
+            optimizer_D.zero_grad()
+
+            # 1.1 真实图像的判别损失（label=real）
+            real_global_score, real_local_score = D(Igt, Mb_gt)
+            loss_D_real = (criterion.adversarial_loss(real_global_score, is_real=True) +
+                           criterion.adversarial_loss(real_local_score, is_real=True)) / 2
+
+            # 1.2 生成图像的判别损失（label=fake）
+            gen_out = G(Iin)
+            Icomp = gen_out[-1]  # 生成的最终擦除结果
+            fake_global_score, fake_local_score = D(Icomp.detach(), Mb_gt)  # detach避免更新G
+            loss_D_fake = (criterion.adversarial_loss(fake_global_score, is_real=False) +
+                           criterion.adversarial_loss(fake_local_score, is_real=False)) / 2
+
+            # 1.3 D总损失 & 反向传播
+            loss_D = (loss_D_real + loss_D_fake) / 2
+            loss_D.backward()
+            optimizer_D.step()
+
+            # ---------------------- 步骤2：训练生成器G ----------------------
+            optimizer_G.zero_grad()
+
+            # 2.1 重新计算生成图像的判别分数（用于G的对抗损失）
+            fake_global_score, fake_local_score = D(Icomp, Mb_gt)
+            disc_score = (fake_global_score, fake_local_score)
+
+            # 2.2 计算G的全量损失
+            loss_G, loss_parts = criterion(gen_out, gt, disc_score)
+
+            # 2.3 G反向传播
+            loss_G.backward()
+            optimizer_G.step()
+
+            # ---------------------- 步骤3：日志记录 ----------------------
+            epoch_loss_G += loss_G.item()
+            epoch_loss_D += loss_D.item()
+
+            # 进度条显示
+            pbar.set_postfix({
+                'Loss_D': f"{loss_D.item():.4f}",
+                'Loss_G': f"{loss_G.item():.4f}",
+                'Loss_G_adv': f"{loss_parts[0].item():.4f}",
+                'Loss_G_lr': f"{loss_parts[1].item():.4f}"
+            })
+
+        # ---------------------- 步骤4：Epoch结束处理 ----------------------
+        # 计算Epoch平均损失
+        avg_loss_G = epoch_loss_G / len(train_loader)
+        avg_loss_D = epoch_loss_D / len(train_loader)
+        print(f"Epoch {epoch + 1} 平均损失：Loss_G={avg_loss_G:.4f}, Loss_D={avg_loss_D:.4f}")
+
+        # 保存模型（每5个Epoch保存一次，同时保存最新模型）
+        if (epoch + 1) % 5 == 0 or epoch == epochs - 1:
+            checkpoint = {
+                'epoch': epoch + 1,
+                'G_state_dict': G.state_dict(),
+                'D_state_dict': D.state_dict(),
+                'optimizer_G': optimizer_G.state_dict(),
+                'optimizer_D': optimizer_D.state_dict(),
+                'avg_loss_G': avg_loss_G,
+                'avg_loss_D': avg_loss_D
+            }
+            # 保存最新模型（用于断点续训）
+            torch.save(checkpoint, os.path.join(save_dir, 'latest.pth'))
+            # 保存Epoch模型
+            torch.save(checkpoint, os.path.join(save_dir, f'ensexam_epoch_{epoch + 1}.pth'))
+            print(f"模型已保存：{os.path.join(save_dir, f'ensexam_epoch_{epoch + 1}.pth')}")
+
+
+# ====================== 4. 启动训练 ======================
+if __name__ == "__main__":
+    # 设备选择
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    print(f"使用设备：{device}")
+
+    # 启动训练
+    train_ensexam(
+        epochs=100,
+        batch_size=4,
+        lr=0.0001,
+        device=device,
+        save_dir='./ensexam_checkpoints',
+        resume=False,
+        data_root=r"D:\PythonProject1\LLM\adcj\src\adcj\EnsExam\SCUT-EnsExam\SCUT-EnsExam",
+    )

--- a/backend/web_app.py
+++ b/backend/web_app.py
@@ -804,7 +804,6 @@ def erase_text():
 
     try:
         from models.inference import InferenceEngine
-        import uuid
 
         result_img = InferenceEngine().run(image_bytes)
 

--- a/backend/web_app.py
+++ b/backend/web_app.py
@@ -764,6 +764,64 @@ def serve_image(filename):
     return send_file(file_path)
 
 
+@app.route('/erased/<path:filename>')
+def serve_erased_image(filename):
+    """提供擦除结果图片"""
+    file_path = _safe_join(str(settings.erased_dir), filename)
+    if not file_path or not os.path.exists(file_path):
+        return jsonify({'success': False, 'error': '图片不存在'}), 404
+    return send_file(file_path)
+
+
+@app.route('/api/models/erase', methods=['POST'])
+def erase_text():
+    """文字擦除接口
+
+    使用 GAN 模型将试卷图片中的手写笔迹擦除，还原干净的题目底图。
+
+    Request:
+        multipart/form-data，字段 file：图片文件（JPEG/PNG/BMP 等）
+
+    Response:
+        {"success": true, "result_url": "/erased/<filename>"}
+    """
+    if 'file' not in request.files:
+        return jsonify({'success': False, 'error': '缺少 file 字段'}), 400
+
+    file = request.files['file']
+    if not file or not file.filename:
+        return jsonify({'success': False, 'error': '文件为空'}), 400
+
+    ext = os.path.splitext(file.filename)[1].lower() or '.png'
+    allowed = {'.jpg', '.jpeg', '.png', '.bmp', '.tiff', '.webp'}
+    if ext not in allowed:
+        return jsonify({'success': False, 'error': f'不支持的图片格式: {ext}'}), 400
+
+    try:
+        image_bytes = file.read()
+    except Exception:
+        return jsonify({'success': False, 'error': '读取文件失败'}), 400
+
+    try:
+        from models.inference import InferenceEngine
+        import uuid
+
+        result_img = InferenceEngine().run(image_bytes)
+
+        filename = uuid.uuid4().hex + '.png'
+        save_path = settings.erased_dir / filename
+        result_img.save(save_path, format='PNG')
+
+        return jsonify({'success': True, 'result_url': f'/erased/{filename}'})
+
+    except FileNotFoundError as e:
+        logger.error("模型权重缺失: %s", e)
+        return jsonify({'success': False, 'error': str(e)}), 503
+    except Exception:
+        logger.exception("文字擦除失败")
+        return jsonify({'success': False, 'error': '擦除处理失败，请稍后重试'}), 500
+
+
 @app.route('/api/status', methods=['GET'])
 def get_status():
     """

--- a/frontend/src/components/SettingsView.vue
+++ b/frontend/src/components/SettingsView.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, inject, onMounted, watch } from 'vue'
 import { fetchAppConfig, updateAppConfig } from '../api.js'
+import { genId } from '../utils.js'
 import ProviderDialog from './ProviderDialog.vue'
 import ProviderSection from './ProviderSection.vue'
 
@@ -18,7 +19,7 @@ const saving = ref(false)
 // ---------- 多 Provider 数据结构 ----------
 
 const makeOpenAIProvider = (data = {}) => ({
-  id: data.id || crypto.randomUUID(),
+  id: data.id || genId(),
   name: data.name || '',
   api_key: data.api_key || '',
   base_url: data.base_url || '',
@@ -30,7 +31,7 @@ const makeOpenAIProvider = (data = {}) => ({
 })
 
 const makeAnthropicProvider = (data = {}) => ({
-  id: data.id || crypto.randomUUID(),
+  id: data.id || genId(),
   name: data.name || '',
   api_key: data.api_key || '',
   base_url: data.base_url || '',
@@ -40,7 +41,7 @@ const makeAnthropicProvider = (data = {}) => ({
 })
 
 const makePaddleOCRProvider = (data = {}) => ({
-  id: data.id || crypto.randomUUID(),
+  id: data.id || genId(),
   name: data.name || '',
   api_key: data.api_key || '',
   base_url: data.base_url || data.api_url || '',

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -3,6 +3,16 @@ import DOMPurify from 'dompurify'
 /** 生成文件唯一标识 */
 export const fileKey = (file) => `${file.name}|${file.size}|${file.lastModified}`
 
+/** 生成唯一 ID（兼容非 HTTPS 上下文，使用 getRandomValues 确保密码学安全） */
+export const genId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  const bytes = new Uint8Array(16)
+  crypto.getRandomValues(bytes)
+  return Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('')
+}
+
 /** 格式化选项文本 */
 export const formatOption = (s) => String(s || '')
 


### PR DESCRIPTION
# feat: GAN 文字擦除 + Provider 配置数据库化

## Summary

- 新增 GAN 文字擦除功能：上传试卷图片，使用训练好的 Generator 模型将手写笔迹从底图中擦除，返回擦除结果
- API Provider 配置从 `.env` 迁移至数据库：支持 OpenAI / Anthropic / PaddleOCR 三类供应商各配多个并激活一个，凭据与用户账号绑定
- 精简核对页头部，将选择控件上移至标题栏，减少视觉层级冗余

## 变更详情

### GAN 文字擦除

**模型层**
- `backend/models/model.py`（新建）：GAN Generator / Discriminator 模型定义（CoarseNet + RefineNet 两阶段结构）
- `backend/models/train.py`（新建）：GAN 训练脚本（含损失函数、数据加载、保存 checkpoint）
- `backend/models/inference.py`（新建）：`InferenceEngine` 线程安全单例，双重检查锁懒加载 Generator 权重；图像预处理归一化至 [-1,1] 并 padding 为 512 整数倍；滑动窗口推理（patch=512，overlap=32），float32 累加器直接从 tensor 提取，`torch.no_grad()` 置于循环外
- `backend/models/test_erase.py`（新建）：CLI 推理测试脚本，接受图片路径参数，输出擦除结果

**配置**
- `backend/config.py`：`Settings` 新增 `model_path`（默认 `runtime_data/models/latest.pth`）和 `erased_dir`（默认 `runtime_data/erased`），`ensure_dirs()` 同步创建

**API 路由**
- `backend/web_app.py`：
  - `POST /api/models/erase`：multipart 上传图片，校验扩展名白名单，运行推理，结果以 UUID 文件名保存，返回结果 URL；权重缺失返回 503，其余异常返回 500
  - `GET /erased/<filename>`：静态图片服务，`_safe_join` 防路径穿越

---

### API Provider 配置数据库化

**数据库层**
- 新增 `ProviderConfig` ORM 模型，支持 openai / anthropic / paddleocr 三类，每类可配多个，`is_active` 标记激活项
- `crud.py`：新增 `get_active_provider`、Provider CRUD 系列函数

**后端**
- `config.py`：移除 `env_prefix` / `env_file`，LLM 凭据完全由 `load_providers_from_db()` 在请求入口注入
- `PaddleOCRClient` 改为参数传入凭据，移除 `os.getenv` 回退
- `/api/split`、`/api/chat/stream` 路由注入用户 DB 凭据
- `/api/config` GET/PUT 移除 `.env` fallback，要求登录
- `/api/status` 从数据库读取用户 provider 配置
- 删除 `get_config_for_ui`、`get_available_models`、`update_env_file` 等死代码
- `.env.example` 精简为仅保留 Flask 密钥和 LangSmith 配置

**前端**
- `SettingsView.vue`：重构为多供应商卡片式管理，自动保存（防抖），统一蓝色调；无可用模型时禁用上传和分割并显示配置引导
- `ProviderDialog.vue`（新建）：统一新增 / 编辑供应商弹窗，下拉改为玻璃态自定义组件，添加 info tooltip，`autocomplete` 防浏览器自动填充
- `utils.js`：`genId()` 回退改用 `crypto.getRandomValues()` 替换 `Math.random()`，非 HTTPS 环境下仍具密码学安全强度

---

### 核对页 UI 精简

- `QuestionList.vue`：移除内部重复的「题目数据核对」标题区块和选择控件
- `WorkspaceView.vue`：全选 / 清空 / 已选计数移至核对页顶部标题栏右侧，替换原有题目数徽标

## Commits

| Commit | 描述 |
|--------|------|
| `2f0ea2c` | 上传模型初步代码 |
| `40b8b61` | modify model |
| `510e493` | remove Mb_UpSampleBlock |
| `21dd0c7` | 修改 softmask |
| `ae38cde` | update |
| `a8345c7` | feat(erase): 新增文字擦除推理引擎与 API 接口 |
| `a368d06` | feat(settings): API Provider 配置迁移到数据库，支持多供应商管理 |
| `1564d7a` | fix(settings): 修复 provider 配置保存丢失 API Key 及连接测试依赖前端传参问题 |
| `97d0bab` | refactor(settings): 彻底移除环境变量依赖，完善 Provider 配置体验 |
| `f01ca1b` | refactor(infer): 优化推理引擎性能并修复弱随机 ID 安全问题 |
| `513f8d0` | refactor(workspace): 精简核对页头部，将选择控件上移至页面标题栏 |

## Test plan

- [x] 将 `latest.pth` 放置于 `backend/runtime_data/models/`，启动后端，确认 `erased/` 目录自动创建
- [ ] `POST /api/models/erase` 上传图片，确认返回 `result_url` 并可通过 `GET /erased/<filename>` 访问
- [x] CLI 测试：`cd backend/models && python test_erase.py <图片路径>`
- [x] 进入设置页，新增 OpenAI / Anthropic / PaddleOCR 供应商，确认配置保存至数据库、激活切换正常
- [x] 退出登录后重新登录，确认 provider 配置仍在且生效（不依赖 `.env`）
- [ ] 非 HTTPS 环境（HTTP）下点击「添加供应商」，确认不再报 `crypto.randomUUID is not a function`
- [ ] 核对页：确认全选 / 清空 / 已选计数显示在标题栏，页面内无重复标题区块
