### PR TITLE
feat(ui): 错题库交互增强与多项 UI 修复

### DIFF
--- a/backend/web_app.py
+++ b/backend/web_app.py
@@ -523,27 +523,32 @@ def split_questions():
                 'error': '请先上传文件'
             }), 400
 
-        # 擦除手写字迹（可选）
-        erase = data.get("erase", False)
-        if erase:
+        # 擦除手写字迹（如果 EnsExam 已接入，则自动执行）
+        ensexam_configured = settings.model_path.exists()
+        if ensexam_configured:
             try:
                 from models.inference import InferenceEngine
                 engine = InferenceEngine()
                 erased_paths = []
                 for fp in file_paths:
+                    # 如果是 PDF 转换为图片的临时路径，或者是直接上传的图片
                     with open(fp, 'rb') as f:
                         img_bytes = f.read()
                     result_img = engine.run(img_bytes)
-                    erased_name = os.path.splitext(os.path.basename(fp))[0] + '_erased.png'
+                    
+                    # 生成擦除后的文件名，保存在 erased_dir
+                    erased_name = f"auto_{uuid.uuid4().hex[:8]}_{os.path.basename(fp)}"
+                    if not erased_name.lower().endswith(('.png', '.jpg', '.jpeg')):
+                        erased_name += '.png'
+                    
                     erased_path = settings.erased_dir / erased_name
                     result_img.save(str(erased_path), format='PNG')
                     erased_paths.append(str(erased_path))
+                
                 file_paths = erased_paths
-                logger.info("已擦除 %d 张图片的手写字迹", len(erased_paths))
-            except FileNotFoundError as e:
-                logger.warning("擦除模型未配置，跳过擦除: %s", e)
+                logger.info("EnsExam 已接入，自动擦除 %d 张图片的手写字迹", len(erased_paths))
             except Exception:
-                logger.exception("擦除手写字迹失败，使用原图继续")
+                logger.exception("自动擦除手写字迹失败，使用原图继续流程")
 
         current_thread_id = str(uuid.uuid4())
         config = {"configurable": {"thread_id": current_thread_id}}
@@ -854,6 +859,9 @@ def get_status():
     try:
         user_id = session.get('user_id')
 
+        # 检查 EnsExam 模型权重是否存在
+        ensexam_configured = settings.model_path.exists()
+
         if user_id:
             # 已登录：从数据库读取用户配置
             with SessionLocal() as db:
@@ -889,6 +897,7 @@ def get_status():
 
         status = {
             'paddleocr_configured': paddleocr_configured,
+            'ensexam_configured': ensexam_configured,
             'available_models': available_models,
             'langsmith_enabled': os.getenv('LANGSMITH_TRACING', 'false').lower() == 'true',
             'output_dirs': {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,10 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@bytemd/plugin-gfm": "^1.22.0",
+    "@bytemd/vue-next": "^1.22.0",
     "@headlessui/vue": "^1.7.23",
+    "bytemd": "^1.22.0",
     "dompurify": "^3.3.2",
     "lucide-vue-next": "^0.577.0",
     "vue": "^3.5.24",

--- a/frontend/src/components/ActionBar.vue
+++ b/frontend/src/components/ActionBar.vue
@@ -46,20 +46,20 @@ const emit = defineEmits(['split', 'export', 'save-to-db'])
 
     <!-- 导出按钮：极简现代感 -->
     <button
+      v-if="exportEnabled"
       type="button"
       class="group relative inline-flex h-14 items-center justify-center gap-3 rounded-2xl border border-slate-200 bg-white px-8 text-[13px] font-black tracking-widest text-slate-900 shadow-sm hover:border-slate-900 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-30 dark:border-white/10 dark:bg-slate-900 dark:text-white dark:hover:border-white dark:hover:bg-slate-800"
-      :disabled="!exportEnabled"
       @click="emit('export')"
     >
-      <i class="fa-solid fa-file-export transition-transform group-hover:-translate-y-0.5"></i>
+      <i class="fa-solid fa-file-export transition-transform group-hover:-translate-x-0.5"></i>
       导出错题本
     </button>
 
     <!-- 导入错题库按钮：极简现代感 -->
     <button
+      v-if="exportEnabled"
       type="button"
       class="group relative inline-flex h-14 items-center justify-center gap-3 rounded-2xl border border-slate-200 bg-white px-8 text-[13px] font-black tracking-widest text-slate-900 shadow-sm hover:border-slate-900 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-30 dark:border-white/10 dark:bg-slate-900 dark:text-white dark:hover:border-white dark:hover:bg-slate-800"
-      :disabled="!exportEnabled"
       @click="emit('save-to-db')"
     >
       <i class="fa-solid fa-database transition-transform group-hover:-translate-y-0.5"></i>

--- a/frontend/src/components/CalendarPicker.vue
+++ b/frontend/src/components/CalendarPicker.vue
@@ -83,47 +83,47 @@ useClickOutside('.custom-cal-wrapper', () => { open.value = false })
 
 <template>
   <div class="custom-cal-wrapper relative w-full min-w-0">
-    <div class="group flex h-10 w-full cursor-pointer items-center rounded-xl border border-slate-200/60 bg-white/70 px-4 shadow-sm backdrop-blur-xl transition-all hover:border-blue-400/60 hover:bg-white/80 dark:border-white/10 dark:bg-slate-800/60 dark:hover:border-indigo-500/40"
-         :class="{ 'border-blue-400 ring-2 ring-blue-500/20 dark:border-indigo-500': open }"
+    <div class="group flex h-11 w-full cursor-pointer items-center rounded-xl border bg-white/70 px-4 text-sm font-bold shadow-sm backdrop-blur-xl transition-all hover:border-blue-300 dark:border-white/10 dark:bg-white/[0.06] dark:backdrop-blur-xl dark:hover:border-indigo-500/30"
+         :class="{ 'border-blue-400 ring-2 ring-blue-500/20 dark:border-indigo-500/50 dark:ring-indigo-500/20': open }"
          @click.stop="toggle">
       <i class="fa-regular fa-calendar mr-2 text-sm text-slate-400 transition-colors group-hover:text-blue-500 dark:text-slate-500 dark:group-hover:text-indigo-400"></i>
-      <span v-if="!modelValue" class="text-xs font-bold text-slate-400 dark:text-slate-500">{{ label }}</span>
-      <span v-else class="text-xs font-bold text-slate-700 dark:text-white">{{ modelValue }}</span>
+      <span v-if="!modelValue" class="truncate text-sm font-bold text-slate-400 dark:text-slate-500">{{ label }}</span>
+      <span v-else class="truncate text-sm font-bold text-slate-800 dark:text-slate-200">{{ modelValue }}</span>
     </div>
     <Transition name="cal-dropdown">
       <div v-if="open"
-           class="absolute top-full z-50 mt-1 min-w-full w-64 rounded-xl border border-slate-200/60 bg-white/80 p-4 shadow-md backdrop-blur-2xl dark:border-white/10 dark:bg-slate-800/70 dark:backdrop-blur-2xl"
+           class="absolute top-full z-50 mt-2 min-w-full w-64 overflow-hidden rounded-2xl border border-slate-200/60 bg-white/95 p-4 shadow-xl backdrop-blur-3xl dark:border-white/10 dark:bg-[#12121A]/90 dark:bg-gradient-to-b dark:from-white/[0.08] dark:to-transparent dark:backdrop-blur-3xl dark:shadow-[0_20px_50px_rgba(0,0,0,0.6)]"
            :class="align === 'right' ? 'right-0' : 'left-0'">
         <!-- 月份导航 -->
-        <div class="mb-2 flex items-center justify-between">
-          <button @click.stop="prevMonth" class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-700 dark:hover:text-white">
+        <div class="mb-4 flex items-center justify-between">
+          <button @click.stop="prevMonth" class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-white/5 dark:hover:text-white transition-colors">
             <i class="fa-solid fa-chevron-left text-xs"></i>
           </button>
           <span class="text-sm font-black text-slate-700 dark:text-white">{{ calYear }}年{{ calMonth + 1 }}月</span>
-          <button @click.stop="nextMonth" class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-700 dark:hover:text-white">
+          <button @click.stop="nextMonth" class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-white/5 dark:hover:text-white transition-colors">
             <i class="fa-solid fa-chevron-right text-xs"></i>
           </button>
         </div>
         <!-- 星期标题 -->
-        <div class="mb-1 grid grid-cols-7">
+        <div class="mb-2 grid grid-cols-7">
           <span v-for="w in WEEKDAYS" :key="w" class="py-1 text-center text-xs font-black text-slate-400 dark:text-slate-500">{{ w }}</span>
         </div>
         <!-- 日期网格 -->
-        <div class="grid grid-cols-7 place-items-center gap-y-1">
+        <div class="grid grid-cols-7 place-items-center gap-1">
           <button v-for="(d, i) in calDays" :key="i" @click.stop="selectDate(d)"
-            class="flex h-8 w-8 items-center justify-center rounded-full text-xs font-bold"
+            class="flex h-8 w-8 items-center justify-center rounded-xl text-xs font-bold transition-all"
             :class="[
-              !d.cur ? 'text-slate-300 dark:text-slate-600' : 'text-slate-700 dark:text-slate-200 cursor-pointer hover:bg-blue-50 dark:hover:bg-slate-700',
-              isDaySel(d) ? '!bg-blue-500 !text-white shadow-md shadow-blue-500/30' : '',
-              isDayToday(d) && !isDaySel(d) ? 'ring-1 ring-blue-400 text-blue-600 dark:text-blue-400' : ''
+              !d.cur ? 'text-slate-300 dark:text-slate-600 opacity-30' : 'text-slate-700 dark:text-slate-200 cursor-pointer hover:bg-blue-50 dark:hover:bg-white/10',
+              isDaySel(d) ? '!bg-blue-600 !text-white shadow-lg shadow-blue-500/30 dark:!bg-indigo-500 dark:shadow-indigo-500/30' : '',
+              isDayToday(d) && !isDaySel(d) ? 'ring-1 ring-blue-400 text-blue-600 dark:text-indigo-400 dark:ring-indigo-500/50' : ''
             ]">
             {{ d.day }}
           </button>
         </div>
         <!-- 底部操作 -->
-        <div class="mt-2 flex justify-between border-t border-slate-100 pt-2 dark:border-slate-700">
-          <button @click.stop="clearDate" class="text-xs font-bold text-blue-500 hover:text-blue-700 dark:text-indigo-400">清除</button>
-          <button @click.stop="selectToday" class="text-xs font-bold text-blue-500 hover:text-blue-700 dark:text-indigo-400">今天</button>
+        <div class="mt-4 flex justify-between border-t border-slate-100 pt-3 dark:border-white/5">
+          <button @click.stop="clearDate" class="text-xs font-bold text-slate-400 hover:text-rose-500 dark:text-slate-500 dark:hover:text-rose-400 transition-colors">清除</button>
+          <button @click.stop="selectToday" class="text-xs font-bold text-blue-600 hover:text-blue-700 dark:text-indigo-400 dark:hover:text-indigo-300 transition-colors">今天</button>
         </div>
       </div>
     </Transition>

--- a/frontend/src/components/CustomSelect.vue
+++ b/frontend/src/components/CustomSelect.vue
@@ -22,44 +22,44 @@ const select = (val) => { emit('update:modelValue', val); open.value = false }
 
 <template>
   <div class="custom-select-wrapper relative" :class="widthClass">
-    <label v-if="label" class="mb-2 block text-xs font-black uppercase tracking-widest text-slate-500 dark:text-slate-500">{{ label }}</label>
+    <label v-if="label" class="mb-2 block text-[11px] font-black uppercase tracking-widest text-slate-500 dark:text-slate-500">{{ label }}</label>
     <button
       type="button"
       @click.stop="toggle"
-      class="flex h-10 w-full items-center justify-between rounded-xl border border-slate-200/80 bg-white/70 px-4 text-left text-sm font-bold backdrop-blur-xl transition-all dark:border-white/10 dark:bg-slate-800/60"
+      class="flex h-11 w-full items-center justify-between rounded-xl border bg-white/70 px-4 text-left text-sm font-bold shadow-sm backdrop-blur-xl transition-all hover:border-blue-300 dark:border-white/10 dark:bg-white/[0.06] dark:backdrop-blur-xl"
       :class="[
-        open ? 'border-blue-400 ring-2 ring-blue-500/20 dark:border-indigo-500/50 dark:ring-indigo-500/20' : 'hover:border-blue-300 dark:hover:border-indigo-500/30',
+        open ? 'border-blue-400 ring-2 ring-blue-500/20 dark:border-indigo-500/50 dark:ring-indigo-500/20' : 'border-slate-200/60 dark:hover:border-indigo-500/30',
         modelValue ? 'text-slate-800 dark:text-slate-200' : 'text-slate-400 dark:text-slate-500',
       ]"
     >
       <span class="truncate">{{ modelValue || placeholder }}</span>
-      <i class="fa-solid fa-chevron-down ml-2 text-xs text-slate-400 transition-transform duration-300" :class="open ? 'rotate-180' : ''"></i>
+      <i class="fa-solid fa-chevron-down ml-2 text-xs text-slate-400 transition-transform duration-300 dark:text-slate-500" :class="open ? 'rotate-180' : ''"></i>
     </button>
     <Transition name="dropdown">
-      <div v-if="open" class="absolute left-0 top-full z-50 mt-1 max-h-56 w-full overflow-y-auto rounded-xl border border-slate-200/60 bg-white/80 py-1 shadow-md backdrop-blur-2xl dark:border-white/10 dark:bg-slate-800/70 dark:backdrop-blur-2xl">
-        <button
-          type="button"
-          @click.stop="select('')"
-          class="flex w-full items-center gap-2 px-4 py-2 text-left text-sm transition-colors hover:bg-blue-50/80 dark:hover:bg-blue-500/10"
-          :class="modelValue === '' ? 'font-bold text-blue-600 dark:text-blue-400' : 'text-slate-700 dark:text-slate-300'"
-        >
-          <i v-if="modelValue === ''" class="fa-solid fa-check text-xs text-blue-500"></i>
-          <span :class="modelValue !== '' ? 'pl-[18px]' : ''">
-            <i v-if="icon" class="fa-solid fa-layer-group mr-2 text-xs text-slate-400 dark:text-slate-500"></i>{{ placeholder }}
-          </span>
-        </button>
-        <button
-          v-for="opt in options" :key="opt"
-          type="button"
-          @click.stop="select(opt)"
-          class="flex w-full items-center gap-2 px-4 py-2 text-left text-sm transition-colors hover:bg-blue-50/80 dark:hover:bg-blue-500/10"
-          :class="modelValue === opt ? 'font-bold text-blue-600 dark:text-blue-400' : 'text-slate-700 dark:text-slate-300'"
-        >
-          <i v-if="modelValue === opt" class="fa-solid fa-check text-xs text-blue-500"></i>
-          <span :class="modelValue !== opt ? 'pl-[18px]' : ''">
-            <i v-if="icon" class="fa-solid mr-2 text-xs" :class="icon(opt)"></i>{{ opt }}
-          </span>
-        </button>
+      <div v-if="open" class="absolute left-0 top-full z-50 mt-2 min-w-full w-max overflow-hidden rounded-2xl border border-slate-200/60 bg-white/95 p-1.5 shadow-xl backdrop-blur-3xl dark:border-white/10 dark:bg-[#12121A]/90 dark:bg-gradient-to-b dark:from-white/[0.08] dark:to-transparent dark:backdrop-blur-3xl dark:shadow-[0_20px_50px_rgba(0,0,0,0.6)]">
+        <div class="no-scrollbar max-h-56 space-y-0.5 overflow-y-auto">
+          <button
+            type="button"
+            @click.stop="select('')"
+            class="group flex w-full items-center gap-2 rounded-xl px-4 py-2.5 text-left text-sm font-bold transition-all hover:bg-blue-500/10 hover:text-blue-600 dark:hover:bg-indigo-500/20 dark:hover:text-indigo-400"
+            :class="modelValue === '' ? 'bg-blue-500/10 text-blue-600 dark:bg-indigo-500/20 dark:text-indigo-400' : 'text-slate-600 dark:text-slate-300'"
+          >
+            <i v-if="icon" class="fa-solid fa-layer-group text-xs opacity-70"></i>
+            <span>{{ placeholder }}</span>
+            <i v-if="modelValue === ''" class="fa-solid fa-check ml-auto text-[10px]"></i>
+          </button>
+          <button
+            v-for="opt in options" :key="opt"
+            type="button"
+            @click.stop="select(opt)"
+            class="group flex w-full items-center gap-2 rounded-xl px-4 py-2.5 text-left text-sm font-bold transition-all hover:bg-blue-500/10 hover:text-blue-600 dark:hover:bg-indigo-500/20 dark:hover:text-indigo-400"
+            :class="modelValue === opt ? 'bg-blue-500/10 text-blue-600 dark:bg-indigo-500/20 dark:text-indigo-400' : 'text-slate-600 dark:text-slate-300'"
+          >
+            <i v-if="icon" class="fa-solid text-xs opacity-70" :class="icon(opt)"></i>
+            <span>{{ opt }}</span>
+            <i v-if="modelValue === opt" class="fa-solid fa-check ml-auto text-[10px]"></i>
+          </button>
+        </div>
       </div>
     </Transition>
   </div>
@@ -68,11 +68,11 @@ const select = (val) => { emit('update:modelValue', val); open.value = false }
 <style scoped>
 .dropdown-enter-active,
 .dropdown-leave-active {
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  transition: all 0.25s cubic-bezier(0.16, 1, 0.3, 1);
 }
 .dropdown-enter-from,
 .dropdown-leave-to {
   opacity: 0;
-  transform: translateY(-6px);
+  transform: translateY(-8px) scale(0.98);
 }
 </style>

--- a/frontend/src/components/Dashboard.vue
+++ b/frontend/src/components/Dashboard.vue
@@ -186,7 +186,7 @@ const heatmapCellColor = (val) => {
 // ---- 生命周期 ----
 watch(() => props.visible, (v) => {
   if (v) loadStats()
-})
+}, { immediate: true })
 
 watch(() => [props.theme, stats.value], () => {
   if (props.visible && stats.value) nextTick(initCharts)
@@ -223,8 +223,8 @@ onBeforeUnmount(() => {
       </div>
       <div v-else class="mb-8 grid grid-cols-2 gap-4 sm:grid-cols-4">
         <StatCard label="总错题" icon="fa-solid fa-layer-group" :value="stats?.total_questions || 0" unit="道" color="indigo" />
-        <StatCard label="待复习" icon="fa-solid fa-clock" :value="stats?.review_status_stats?.['待复习'] || 0" unit="道" color="blue" />
-        <StatCard label="已掌握" icon="fa-solid fa-circle-check" :value="stats?.review_status_stats?.['已掌握'] || 0" unit="道" color="emerald" />
+        <StatCard label="待复习" icon="fa-solid fa-clock" :value="stats?.review_stats?.['待复习'] || 0" unit="道" color="blue" />
+        <StatCard label="已掌握" icon="fa-solid fa-circle-check" :value="stats?.review_stats?.['已掌握'] || 0" unit="道" color="emerald" />
         <StatCard label="今日掌握" icon="fa-solid fa-bolt" :value="stats?.review_stats?.['已掌握'] || 0" unit="道" color="slate" />
       </div>
 

--- a/frontend/src/components/EditNoteDialog.vue
+++ b/frontend/src/components/EditNoteDialog.vue
@@ -1,0 +1,154 @@
+<script setup>
+import { ref, watch, computed } from 'vue'
+import { Editor } from '@bytemd/vue-next'
+import gfm from '@bytemd/plugin-gfm'
+
+const props = defineProps({
+  open: { type: Boolean, default: false },
+  field: { type: String, default: 'answer' },
+  value: { type: String, default: '' },
+  saving: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['close', 'save'])
+const draft = ref('')
+
+const plugins = computed(() => [gfm()])
+
+watch(() => props.open, (v) => {
+  if (v) draft.value = props.value || ''
+})
+
+const handleChange = (v) => { draft.value = v }
+
+const config = () => {
+  if (props.field === 'answer') {
+    return {
+      title: '正确答案',
+      icon: 'fa-circle-check',
+      iconBg: 'bg-emerald-50 dark:bg-emerald-500/10',
+      iconCls: 'text-emerald-600 dark:text-emerald-400',
+      btnCls: 'bg-emerald-600 hover:bg-emerald-700 dark:bg-emerald-500 dark:hover:bg-emerald-600',
+    }
+  }
+  return {
+    title: '我的笔记',
+    icon: 'fa-pen-to-square',
+    iconBg: 'bg-blue-50 dark:bg-blue-500/10',
+    iconCls: 'text-blue-600 dark:text-blue-400',
+    btnCls: 'bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600',
+  }
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="dialog-fade">
+      <div v-if="open" class="fixed inset-0 z-[101] flex items-center justify-center p-4 md:left-64" @click.self="emit('close')">
+        <!-- 遮罩 -->
+        <div class="absolute inset-0 bg-black/40 backdrop-blur-sm"></div>
+
+        <!-- 弹窗 -->
+        <div class="relative w-full max-w-2xl rounded-2xl border border-slate-200/60 bg-white shadow-2xl dark:border-white/10 dark:bg-[#0f0f17]">
+          <!-- 头部 -->
+          <div class="flex items-center justify-between border-b border-slate-100 px-6 py-4 dark:border-white/5">
+            <div class="flex items-center gap-3">
+              <div class="flex h-9 w-9 items-center justify-center rounded-xl" :class="config().iconBg">
+                <i class="fa-solid text-base" :class="[config().icon, config().iconCls]"></i>
+              </div>
+              <h3 class="text-base font-bold text-slate-800 dark:text-slate-200">{{ config().title }}</h3>
+            </div>
+            <button @click="emit('close')" class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-white/5 dark:hover:text-slate-300">
+              <i class="fa-solid fa-xmark"></i>
+            </button>
+          </div>
+
+          <!-- ByteMD 编辑器 -->
+          <div class="bytemd-wrapper px-6 py-4">
+            <Editor :value="draft" :plugins="plugins" @change="handleChange" />
+          </div>
+
+          <!-- 底部按钮 -->
+          <div class="flex justify-end gap-2 border-t border-slate-100 px-6 py-4 dark:border-white/5">
+            <button @click="emit('close')" class="inline-flex h-10 items-center justify-center rounded-xl px-4 text-sm font-bold text-slate-500 transition-all hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-300">
+              取消
+            </button>
+            <button
+              @click="emit('save', draft)"
+              :disabled="saving"
+              class="inline-flex h-10 items-center justify-center gap-2 rounded-xl px-6 text-sm font-bold text-white transition-all disabled:cursor-not-allowed disabled:opacity-50"
+              :class="config().btnCls"
+            >
+              <i v-if="saving" class="fa-solid fa-spinner animate-spin"></i>
+              {{ saving ? '保存中…' : '保存' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.dialog-fade-enter-active,
+.dialog-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+.dialog-fade-enter-from,
+.dialog-fade-leave-to {
+  opacity: 0;
+}
+</style>
+
+<style>
+/* ByteMD 暗色主题适配 */
+.bytemd-wrapper .bytemd {
+  height: 320px;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(226, 232, 240, 0.6);
+  overflow: hidden;
+}
+
+:root.dark .bytemd-wrapper .bytemd {
+  border-color: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.03);
+  color: #e2e8f0;
+}
+
+:root.dark .bytemd-wrapper .bytemd .bytemd-toolbar {
+  background: rgba(255, 255, 255, 0.03);
+  border-color: rgba(255, 255, 255, 0.05);
+}
+
+:root.dark .bytemd-wrapper .bytemd .bytemd-toolbar-icon:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+:root.dark .bytemd-wrapper .bytemd .bytemd-toolbar-icon {
+  color: #94a3b8;
+}
+
+:root.dark .bytemd-wrapper .bytemd .CodeMirror {
+  background: transparent;
+  color: #e2e8f0;
+}
+
+:root.dark .bytemd-wrapper .bytemd .CodeMirror-cursor {
+  border-left-color: #e2e8f0;
+}
+
+:root.dark .bytemd-wrapper .bytemd .bytemd-preview {
+  background: transparent;
+  color: #e2e8f0;
+}
+
+:root.dark .bytemd-wrapper .bytemd .bytemd-status {
+  background: rgba(255, 255, 255, 0.03);
+  border-color: rgba(255, 255, 255, 0.05);
+  color: #64748b;
+}
+
+:root.dark .bytemd-wrapper .bytemd .bytemd-split .bytemd-preview {
+  border-color: rgba(255, 255, 255, 0.05);
+}
+</style>

--- a/frontend/src/components/ErrorBank.vue
+++ b/frontend/src/components/ErrorBank.vue
@@ -1,14 +1,16 @@
 <script setup>
-import { ref, reactive, computed, watch, nextTick, onBeforeUnmount } from 'vue'
+import { ref, reactive, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import * as api from '../api.js'
 import { typesetMath as _typesetMath } from '../utils.js'
-import QuestionDetailModal from './QuestionDetailModal.vue'
 import CustomSelect from './CustomSelect.vue'
 import CalendarPicker from './CalendarPicker.vue'
 import GlassCard from './GlassCard.vue'
 import PageHeader from './PageHeader.vue'
 import SearchInput from './SearchInput.vue'
 import QuestionItem from './QuestionItem.vue'
+import QuestionItemSkeleton from './QuestionItemSkeleton.vue'
+import EditNoteDialog from './EditNoteDialog.vue'
+import SelectionPanel from './SelectionPanel.vue'
 
 const props = defineProps({
   theme: { type: String, default: 'light' },
@@ -30,11 +32,16 @@ const filters = reactive({
 const page = ref(1)
 const pageSize = ref(20)
 
-// 复习状态图标映射
 const reviewStatusIcon = (status) => {
-  if (status === '待复习') return 'fa-clock text-orange-500'
-  if (status === '复习中') return 'fa-spinner text-amber-500'
-  return 'fa-circle-check text-emerald-500'
+  if (status === '待复习') return 'fa-clock'
+  if (status === '复习中') return 'fa-spinner'
+  return 'fa-circle-check'
+}
+
+const reviewStatusClass = (status) => {
+  if (status === '待复习') return 'bg-slate-500/10 text-slate-600 dark:bg-slate-500/20 dark:text-slate-400 border-slate-200/50 dark:border-slate-500/30'
+  if (status === '复习中') return 'bg-indigo-500/10 text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-400 border-indigo-200/50 dark:border-indigo-500/30'
+  return 'bg-emerald-500/10 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-400 border-emerald-200/50 dark:border-emerald-500/30'
 }
 
 // ---- 数据 ----
@@ -46,9 +53,11 @@ const subjects = ref([])
 const questionTypes = ref([])
 const tagNames = ref([])
 const selectedIds = reactive(new Set())
+const selectMode = ref(false)
 
-const detailOpen = ref(false)
-const detailQuestion = ref(null)
+const enterSelectMode = () => { selectMode.value = true }
+const exitSelectMode = () => { selectMode.value = false; selectedIds.clear() }
+
 
 // ---- 知识点多选标签 ----
 const selectedTags = reactive(new Set())
@@ -144,26 +153,77 @@ const doExport = async () => {
   }
 }
 
-const openDetail = (q) => { detailQuestion.value = q; detailOpen.value = true }
-const closeDetail = () => { detailOpen.value = false; detailQuestion.value = null }
 
-const onDeleted = (id) => {
-  items.value = items.value.filter(q => q.id !== id)
-  total.value = Math.max(0, total.value - 1)
-  selectedIds.delete(id)
-  closeDetail()
+// ---- 内联操作 ----
+const menuOpenId = ref(null)
+const menuStyle = ref({})
+const dialogOpen = ref(false)
+const dialogField = ref('answer')
+const dialogQuestion = ref(null)
+const dialogSaving = ref(false)
+
+const toggleMenu = (id, event) => {
+  if (menuOpenId.value === id) { menuOpenId.value = null; return }
+  const btn = event.currentTarget
+  const rect = btn.getBoundingClientRect()
+  menuStyle.value = {
+    position: 'fixed',
+    top: rect.bottom + 4 + 'px',
+    left: (rect.right - 160) + 'px',
+    zIndex: 9999,
+  }
+  menuOpenId.value = id
 }
 
-const onAnswerSaved = (id, answer, updatedAt) => {
-  const q = items.value.find(x => x.id === id)
-  if (q) { q.user_answer = answer; q.updated_at = updatedAt }
+const openEditDialog = (q, field) => {
+  menuOpenId.value = null
+  dialogQuestion.value = q
+  dialogField.value = field
+  dialogOpen.value = true
 }
 
-const onReviewStatusChanged = (id, status, updatedAt) => {
-  const q = items.value.find(x => x.id === id)
-  if (q) { q.review_status = status; q.updated_at = updatedAt }
+const onDialogSave = async (draft) => {
+  if (dialogSaving.value || !dialogQuestion.value) return
+  dialogSaving.value = true
+  try {
+    if (dialogField.value === 'answer') {
+      await api.saveQuestionAnswer(dialogQuestion.value.id, draft)
+      dialogQuestion.value.answer = draft
+    } else {
+      await api.saveAnswer(dialogQuestion.value.id, draft)
+      dialogQuestion.value.user_answer = draft
+    }
+    dialogOpen.value = false
+    emit('push-toast', 'success', '已保存')
+  } catch (e) {
+    emit('push-toast', 'error', '保存失败')
+  } finally {
+    dialogSaving.value = false
+  }
 }
 
+const quickMarkStatus = async (q, status) => {
+  try {
+    const data = await api.updateReviewStatus(q.id, status)
+    q.review_status = data.review_status
+    emit('push-toast', 'success', `已标记为「${status}」`)
+  } catch (e) {
+    emit('push-toast', 'error', '更新状态失败')
+  }
+}
+
+const doDelete = async (q) => {
+  if (!window.confirm('确定要永久删除这道题吗？')) return
+  try {
+    await api.deleteQuestion(q.id)
+    items.value = items.value.filter(x => x.id !== q.id)
+    total.value = Math.max(0, total.value - 1)
+    selectedIds.delete(q.id)
+    emit('push-toast', 'success', '题目已删除')
+  } catch (e) {
+    emit('push-toast', 'error', '删除失败')
+  }
+}
 
 const typesetMath = async () => {
   await nextTick()
@@ -184,6 +244,12 @@ const pageButtons = computed(() => {
 
 const refreshTags = async () => {
   tagNames.value = await api.fetchTagNames(filters.subject || undefined)
+}
+
+const scrollContainerRef = ref(null)
+
+const handleScroll = () => {
+  if (menuOpenId.value) menuOpenId.value = null
 }
 
 const loadFilters = async () => {
@@ -214,17 +280,20 @@ const reloadTags = async () => {
 
 watch(() => filters.subject, () => { reloadTags() })
 
-watch(() => props.visible, (v) => { if (v) { loadFilters(); doQuery() } })
+watch(() => props.visible, (v) => { if (v) { loadFilters(); doQuery() } }, { immediate: true })
 
 defineExpose({ refresh: doQuery })
 
+const closeMenu = () => { menuOpenId.value = null }
+onMounted(() => { document.addEventListener('click', closeMenu) })
 onBeforeUnmount(() => {
   if (debounceTimer) clearTimeout(debounceTimer)
+  document.removeEventListener('click', closeMenu)
 })
 </script>
 
 <template>
-  <div class="relative h-full overflow-y-auto custom-scrollbar">
+  <div ref="scrollContainerRef" @scroll="handleScroll" class="relative h-full overflow-y-auto custom-scrollbar">
     <div class="container relative z-10 mx-auto max-w-6xl px-4 py-8 sm:px-8">
       <!-- 页面标题：强化科技质感 -->
       <PageHeader
@@ -233,6 +302,10 @@ onBeforeUnmount(() => {
       >
         <template #extra>
           <div class="flex items-center gap-4">
+            <button @click="selectMode ? exitSelectMode() : enterSelectMode()" class="btn-secondary h-10 w-[150px] px-6 shadow-sm">
+              <i class="fa-solid" :class="selectMode ? 'fa-xmark' : 'fa-file-export'"></i>
+              {{ selectMode ? '退出选择' : '导出题目' }}
+            </button>
             <button @click="emit('go-workspace')" class="btn-primary group h-10 px-8 shadow-md shadow-blue-500/20">
               <i class="fa-solid fa-plus-circle transition-transform group-hover:rotate-90"></i>
               录入新题目
@@ -246,18 +319,28 @@ onBeforeUnmount(() => {
 
       <!-- 搜索控制台 -->
       <div class="relative z-20 mb-8 space-y-6">
-        <!-- 第一行：关键词 + 三个下拉 -->
+        <!-- 第一行：关键词 + 学科 + 题型 + 复习状态 -->
         <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
           <SearchInput v-model="filters.keyword" label="内容检索" placeholder="搜索题目关键词..." />
-
           <CustomSelect v-model="filters.subject" :options="subjects" label="学科" placeholder="全部学科" />
           <CustomSelect v-model="filters.question_type" :options="questionTypes" label="题型" placeholder="全部题型" />
+          <CustomSelect v-model="filters.review_status" :options="['待复习', '复习中', '已掌握']" label="复习状态" placeholder="全部状态" />
+        </div>
+
+        <!-- 第二行：日期范围 -->
+        <div>
+          <label class="mb-2 block text-xs font-black uppercase tracking-widest text-slate-500 dark:text-slate-500">时间跨度</label>
+          <div class="flex items-center gap-4">
+            <CalendarPicker v-model="filters.start_date" label="开始日期" align="left" />
+            <span class="shrink-0 text-slate-400 dark:text-slate-600 font-black">—</span>
+            <CalendarPicker v-model="filters.end_date" label="结束日期" align="right" />
+          </div>
         </div>
 
         <!-- 知识点多选标签 -->
         <div v-if="tagNames.length">
-          <label class="mb-2 block text-xs font-black uppercase tracking-widest text-slate-500 dark:text-slate-500">知识点标签</label>
-          <div class="flex flex-wrap gap-2">
+          <label class="mb-2 block text-[11px] font-black uppercase tracking-widest text-slate-500 dark:text-slate-500">知识点标签</label>
+          <div class="no-scrollbar max-h-[128px] overflow-y-auto pr-2 flex flex-wrap gap-2 py-1">
             <button v-for="tag in tagNames" :key="tag"
               @click="toggleTagSelect(tag)"
               class="rounded-xl px-3 py-1.5 text-xs font-bold transition-all"
@@ -274,34 +357,11 @@ onBeforeUnmount(() => {
             </button>
           </div>
         </div>
-
-        <!-- 第二行：复习状态 + 日期范围 + 重置 -->
-        <div class="flex flex-wrap items-end gap-6">
-          <CustomSelect v-model="filters.review_status" :options="['待复习', '复习中', '已掌握']" label="复习状态" placeholder="全部状态" :icon="reviewStatusIcon" width-class="w-40 shrink-0" />
-
-          <!-- 时间跨度 -->
-          <div class="min-w-0 flex-1">
-            <label class="mb-2 block text-xs font-black uppercase tracking-widest text-slate-500 dark:text-slate-500">时间跨度</label>
-            <div class="flex items-center gap-4">
-              <CalendarPicker v-model="filters.start_date" label="开始日期" align="left" />
-              <span class="shrink-0 text-slate-400 dark:text-slate-600 font-black">—</span>
-              <CalendarPicker v-model="filters.end_date" label="结束日期" align="right" />
-            </div>
-          </div>
-          
-
-        </div>
       </div>
 
 
-      <!-- 列表区：使用精美的卡片网格 -->
-      <div v-if="loading" class="flex flex-col items-center justify-center py-40">
-        <div class="relative h-16 w-16">
-          <div class="absolute inset-0 animate-spin rounded-full border-4 border-blue-500/20 border-t-blue-500"></div>
-          <i class="fa-solid fa-cube absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-xl text-blue-500"></i>
-        </div>
-        <p class="mt-6 font-mono text-xs font-black uppercase tracking-[0.3em] text-slate-400">正在加载题库...</p>
-      </div>
+      <!-- 列表区 -->
+      <QuestionItemSkeleton v-if="loading" />
 
       <div v-else-if="!items.length" class="flex flex-col items-center justify-center rounded-[2.5rem] border-2 border-dashed border-slate-200 bg-slate-50/50 py-32 dark:border-white/5 dark:bg-white/5">
         <div class="mb-8 flex h-24 w-24 items-center justify-center rounded-3xl bg-white shadow-md dark:bg-slate-900">
@@ -315,67 +375,112 @@ onBeforeUnmount(() => {
         <QuestionItem
           v-for="q in items" :key="q.id"
           :question="q"
-          :selectable="true"
+          :selectable="selectMode"
           :selected="selectedIds.has(q.id)"
           :show-status="true"
-          @click="openDetail(q)"
           @toggle-select="toggleSelect"
-        />
+        >
+          <template #actions="{ question }">
+            <!-- 更多菜单 -->
+            <div>
+              <button @click.stop="toggleMenu(question.id, $event)"
+                class="flex h-8 w-8 items-center justify-center rounded-xl text-slate-400 transition-all hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-white/5 dark:hover:text-slate-300">
+                <i class="fa-solid fa-ellipsis"></i>
+              </button>
+            </div>
+            <Teleport to="body">
+              <Transition
+                enter-active-class="transition duration-200 ease-out"
+                enter-from-class="translate-y-2 opacity-0 scale-95"
+                enter-to-class="translate-y-0 opacity-100 scale-100"
+                leave-active-class="transition duration-150 ease-in"
+                leave-from-class="translate-y-0 opacity-100 scale-100"
+                leave-to-class="translate-y-2 opacity-0 scale-95"
+              >
+                <div v-if="menuOpenId === question.id" :style="menuStyle"
+                  class="w-44 overflow-hidden rounded-2xl border border-slate-200/60 bg-white/95 p-1.5 shadow-xl backdrop-blur-3xl dark:border-white/10 dark:bg-[#12121A]/90 dark:bg-gradient-to-b dark:from-white/[0.08] dark:to-transparent dark:backdrop-blur-3xl dark:shadow-[0_20px_50px_rgba(0,0,0,0.6)]">
+                  <div class="px-3 pb-1 pt-2 text-[11px] font-black uppercase tracking-widest text-slate-400 dark:text-slate-500">复习状态</div>
+                  <button @click.stop="quickMarkStatus(question, '待复习'); menuOpenId = null"
+                    class="group flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold transition-all hover:bg-slate-500/10 hover:text-slate-600 dark:hover:bg-slate-500/20 dark:hover:text-slate-400"
+                    :class="question.review_status === '待复习' || !question.review_status ? 'bg-slate-500/10 text-slate-600 dark:bg-slate-500/20 dark:text-slate-400' : 'text-slate-600 dark:text-slate-300'">
+                    <i class="fa-solid fa-clock text-xs opacity-70"></i>待复习
+                    <i v-if="question.review_status === '待复习' || !question.review_status" class="fa-solid fa-check ml-auto text-[10px]"></i>
+                  </button>
+                  <button @click.stop="quickMarkStatus(question, '复习中'); menuOpenId = null"
+                    class="group flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold transition-all hover:bg-indigo-500/10 hover:text-indigo-600 dark:hover:bg-indigo-500/20 dark:hover:text-indigo-400"
+                    :class="question.review_status === '复习中' ? 'bg-indigo-500/10 text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-400' : 'text-slate-600 dark:text-slate-300'">
+                    <i class="fa-solid fa-spinner text-xs opacity-70"></i>复习中
+                    <i v-if="question.review_status === '复习中'" class="fa-solid fa-check ml-auto text-[10px]"></i>
+                  </button>
+                  <button @click.stop="quickMarkStatus(question, '已掌握'); menuOpenId = null"
+                    class="group flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold transition-all hover:bg-emerald-500/10 hover:text-emerald-600 dark:hover:bg-emerald-500/20 dark:hover:text-emerald-400"
+                    :class="question.review_status === '已掌握' ? 'bg-emerald-500/10 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-400' : 'text-slate-600 dark:text-slate-300'">
+                    <i class="fa-solid fa-circle-check text-xs opacity-70"></i>已掌握
+                    <i v-if="question.review_status === '已掌握'" class="fa-solid fa-check ml-auto text-[10px]"></i>
+                  </button>
+                  <div class="mx-2 my-1.5 border-t border-slate-100 dark:border-white/5"></div>
+                  <div class="px-3 pb-1 pt-1 text-[11px] font-black uppercase tracking-widest text-slate-400 dark:text-slate-500">操作</div>
+                  <button @click.stop="openEditDialog(question, 'answer')"
+                    class="group flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold text-slate-600 transition-all hover:bg-blue-500/10 hover:text-blue-600 dark:text-slate-300 dark:hover:bg-blue-500/20 dark:hover:text-blue-400">
+                    <i class="fa-solid fa-pen-to-square text-xs opacity-70"></i>{{ question.answer ? '编辑答案' : '录入答案' }}
+                  </button>
+                  <button @click.stop="openEditDialog(question, 'user_answer')"
+                    class="group flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold text-slate-600 transition-all hover:bg-blue-500/10 hover:text-blue-600 dark:text-slate-300 dark:hover:bg-blue-500/20 dark:hover:text-blue-400">
+                    <i class="fa-solid fa-note-sticky text-xs opacity-70"></i>{{ question.user_answer ? '编辑笔记' : '记笔记' }}
+                  </button>
+                  <button @click.stop="emit('start-chat', question); menuOpenId = null"
+                    class="group flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold text-slate-600 transition-all hover:bg-indigo-500/10 hover:text-indigo-600 dark:text-slate-300 dark:hover:bg-indigo-500/20 dark:hover:text-indigo-400">
+                    <i class="fa-solid fa-wand-magic-sparkles text-xs opacity-70"></i>AI 辅导
+                  </button>
+                  <div class="mx-2 my-1.5 border-t border-slate-100 dark:border-white/5"></div>
+                  <button @click.stop="doDelete(question); menuOpenId = null"
+                    class="group flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold text-rose-500 transition-all hover:bg-rose-500/10 dark:text-rose-400 dark:hover:bg-rose-500/20">
+                    <i class="fa-solid fa-trash-can text-xs opacity-70"></i>删除题目
+                  </button>
+                </div>
+              </Transition>
+            </Teleport>
+          </template>
+
+        </QuestionItem>
       </div>
 
       <!-- 分页控制：浮动微拟物风格 -->
-      <div v-if="totalPages > 1" class="mt-16 flex items-center justify-center gap-2">
-        <button @click="goPage(page - 1)" :disabled="page <= 1" class="btn-secondary h-11 w-11 p-0 disabled:opacity-30">
-          <i class="fa-solid fa-chevron-left"></i>
+      <div v-if="totalPages > 1" class="mt-12 flex items-center justify-center gap-4">
+        <button @click="goPage(page - 1)" :disabled="page <= 1" class="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200/60 bg-white/60 text-slate-700 shadow-sm transition-all hover:bg-white disabled:cursor-not-allowed disabled:opacity-30 dark:border-white/10 dark:bg-white/5 dark:text-slate-300">
+          <i class="fa-solid fa-chevron-left text-sm"></i>
         </button>
-        <div class="flex items-center gap-1.5 rounded-2xl bg-white/50 p-1.5 shadow-sm dark:bg-white/5">
+        <div class="flex items-center gap-2 rounded-2xl bg-white/50 p-1.5 shadow-sm backdrop-blur-md dark:bg-white/5">
           <template v-for="(p, i) in pageButtons" :key="i">
             <span v-if="p === '...'" class="flex w-8 justify-center font-bold text-slate-400">...</span>
             <button v-else @click="goPage(p)" 
-              class="h-9 min-w-[36px] rounded-xl text-xs font-black"
-              :class="p === page ? 'bg-blue-600 text-white shadow-lg shadow-blue-500/30' : 'text-slate-500 hover:bg-white dark:hover:bg-white/10'">
+              class="h-9 min-w-[36px] rounded-xl text-sm font-bold transition-all"
+              :class="p === page ? 'bg-blue-600 text-white shadow-sm dark:bg-indigo-600' : 'text-slate-500 hover:bg-white dark:text-slate-400 dark:hover:bg-white/10'">
               {{ p }}
             </button>
           </template>
         </div>
-        <button @click="goPage(page + 1)" :disabled="page >= totalPages" class="btn-secondary h-11 w-11 p-0 disabled:opacity-30">
-          <i class="fa-solid fa-chevron-right"></i>
+        <button @click="goPage(page + 1)" :disabled="page >= totalPages" class="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200/60 bg-white/60 text-slate-700 shadow-sm transition-all hover:bg-white disabled:cursor-not-allowed disabled:opacity-30 dark:border-white/10 dark:bg-white/5 dark:text-slate-300">
+          <i class="fa-solid fa-chevron-right text-sm"></i>
         </button>
       </div>
     </div>
 
-    <!-- 底部悬浮操作胶囊：导出专用 -->
-    <Transition enter-active-class="transition duration-500 ease-out" enter-from-class="translate-y-20 opacity-0" enter-to-class="translate-y-0 opacity-100" leave-active-class="transition duration-300 ease-in" leave-from-class="translate-y-0 opacity-100" leave-to-class="translate-y-20 opacity-0">
-      <div v-if="selectedIds.size" class="fixed bottom-24 left-1/2 z-50 -translate-x-1/2 md:bottom-10">
-        <div class="flex items-center gap-6 rounded-full border border-white/20 bg-slate-900/90 px-8 py-4 shadow-[0_20px_50px_rgba(0,0,0,0.3)] backdrop-blur-2xl dark:bg-slate-800/80">
-          <div class="flex items-center gap-3 border-r border-white/10 pr-6">
-            <div class="flex h-8 w-8 items-center justify-center rounded-full bg-blue-500 font-mono text-xs font-black text-white outline outline-4 outline-blue-500/20">
-              {{ selectedIds.size }}
-            </div>
-            <span class="text-sm font-black tracking-widest text-white uppercase">已选中</span>
-          </div>
-          <div class="flex items-center gap-4">
-            <button @click="doExport" class="btn-primary h-10 px-6 text-xs font-black shadow-lg shadow-blue-500/40">
-              <i class="fa-solid fa-file-export mr-2"></i> 生成复习卷
-            </button>
-            <button @click="clearSelection" class="text-xs font-black tracking-widest text-slate-400 hover:text-white transition-colors">
-              清除
-            </button>
-          </div>
-        </div>
-      </div>
-    </Transition>
+    <!-- 选择模式浮动面板 -->
+    <SelectionPanel
+      :visible="selectMode"
+      :count="selectedIds.size"
+      @export="doExport"
+      @clear="clearSelection"
+    />
 
-    <QuestionDetailModal
-      :open="detailOpen"
-      :question="detailQuestion"
-      @close="closeDetail"
-      @open-image="(src) => emit('open-image', src)"
-      @deleted="onDeleted"
-      @answer-saved="onAnswerSaved"
-      @review-status-changed="onReviewStatusChanged"
-      @push-toast="(type, msg) => emit('push-toast', type, msg)"
-      @start-chat="(q) => emit('start-chat', q)"
+    <EditNoteDialog
+      :open="dialogOpen"
+      :field="dialogField"
+      :value="dialogQuestion?.[dialogField] || ''"
+      :saving="dialogSaving"
+      @close="dialogOpen = false"
+      @save="onDialogSave"
     />
   </div>
 </template>

--- a/frontend/src/components/QuestionCard.vue
+++ b/frontend/src/components/QuestionCard.vue
@@ -53,42 +53,31 @@ const cancelUserAnswer = () => { editingUserAnswer.value = false }
     ></div>
 
     <!-- 顶部状态栏 -->
-    <div class="mb-6 flex flex-wrap items-center gap-3">
-      <div
-        class="flex h-8 w-8 cursor-grab items-center justify-center rounded-xl border border-slate-100 bg-slate-50 text-slate-400 hover:bg-slate-100 hover:text-slate-600 active:cursor-grabbing dark:border-white/5 dark:bg-slate-800 dark:text-slate-500"
-        data-drag-handle="1"
-        @click.stop
-      >
-        <i class="fa-solid fa-grip-vertical text-xs"></i>
-      </div>
-
-      <div class="flex items-center gap-2 rounded-xl border border-slate-100 bg-slate-50/50 px-3 py-1.5 dark:border-white/5 dark:bg-white/5">
-        <span class="text-xs font-black text-blue-600 dark:text-indigo-400">#{{ question.question_id }}</span>
-        <div class="h-3 w-px bg-slate-200 dark:bg-white/10"></div>
-        <span class="text-[11px] font-bold text-slate-600 dark:text-slate-300">{{ question.question_type }}</span>
-      </div>
-
-      <!-- 知识点标签 -->
-      <div v-if="question.knowledge_tags?.length" class="flex flex-wrap items-center gap-2">
+    <div class="mb-6 flex items-start gap-4">
+      <!-- 题型与标签 -->
+      <div class="flex flex-wrap items-center gap-2">
+        <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-bold uppercase tracking-widest text-slate-500 dark:bg-white/5 dark:text-slate-400">
+          {{ question.question_type }}
+        </span>
         <span
           v-for="tag in question.knowledge_tags"
           :key="tag"
-          class="rounded-lg bg-blue-50 px-2.5 py-1.5 text-[10px] font-black tracking-wider text-blue-600 dark:bg-indigo-500/10 dark:text-indigo-400"
+          class="rounded-full bg-blue-50 px-3 py-1 text-xs font-bold text-blue-600 dark:bg-indigo-500/10 dark:text-indigo-400"
         >
           {{ tag }}
         </span>
       </div>
 
       <!-- 右侧复选框 -->
-      <div class="ml-auto flex items-center gap-3">
-        <span class="text-[11px] font-black uppercase tracking-widest text-slate-400" :class="selected && 'text-blue-600 dark:text-indigo-400'">
+      <div class="ml-auto flex items-center gap-4">
+        <span class="text-xs font-bold uppercase tracking-widest text-slate-400" :class="selected && 'text-blue-600 dark:text-indigo-400'">
           {{ selected ? '已选择' : '未选择' }}
         </span>
         <div
-          class="flex h-6 w-6 items-center justify-center rounded-lg border-2"
-          :class="selected ? 'border-blue-500 bg-blue-500 shadow-lg shadow-blue-500/20 dark:border-indigo-500 dark:bg-indigo-500' : 'border-slate-200 bg-white dark:border-white/5 dark:bg-slate-800'"
+          class="flex h-5 w-5 items-center justify-center rounded-lg border-2 transition-all"
+          :class="selected ? 'border-blue-500 bg-blue-500 text-white shadow-sm dark:border-indigo-500 dark:bg-indigo-500' : 'border-slate-200 bg-white dark:border-white/5 dark:bg-slate-800'"
         >
-          <i v-if="selected" class="fa-solid fa-check text-[10px] text-white"></i>
+          <i v-if="selected" class="fa-solid fa-check text-[10px]"></i>
         </div>
       </div>
     </div>
@@ -123,10 +112,10 @@ const cancelUserAnswer = () => { editingUserAnswer.value = false }
     <!-- 录入区 -->
     <div class="mt-8 grid gap-4 border-t border-slate-50 pt-8 dark:border-white/5 sm:grid-cols-2" @click.stop>
       <!-- 正确答案 -->
-      <div class="group/box relative rounded-2xl border border-emerald-100 bg-emerald-50/30 p-4 hover:bg-emerald-50/50 dark:border-emerald-500/10 dark:bg-emerald-500/5">
+      <div class="group/box relative rounded-2xl border border-emerald-100 bg-emerald-50/30 p-4 transition-colors hover:bg-emerald-50/50 dark:border-emerald-500/10 dark:bg-emerald-500/5">
         <div class="mb-3 flex items-center justify-between">
-          <span class="text-[10px] font-black uppercase tracking-widest text-emerald-600 dark:text-emerald-400">正确答案</span>
-          <button @click="startEditAnswer" class="text-[10px] font-black text-emerald-600 underline-offset-4 hover:underline">
+          <span class="text-xs font-bold uppercase tracking-widest text-emerald-600 dark:text-emerald-400">正确答案</span>
+          <button @click="startEditAnswer" class="text-xs font-bold text-emerald-600 underline-offset-4 hover:underline">
             {{ question.answer ? '编辑' : '录入' }}
           </button>
         </div>
@@ -135,23 +124,23 @@ const cancelUserAnswer = () => { editingUserAnswer.value = false }
           <textarea
             v-model="answerDraft"
             rows="3"
-            class="w-full rounded-xl border-none bg-white p-3 text-xs font-bold text-slate-800 shadow-sm focus:ring-2 focus:ring-emerald-500/20 dark:bg-slate-800 dark:text-white"
+            class="w-full rounded-xl border-none bg-white p-3 text-sm font-bold text-slate-800 shadow-sm outline-none focus:ring-2 focus:ring-emerald-500/20 dark:bg-slate-800 dark:text-white"
           ></textarea>
-          <div class="flex justify-end gap-2">
-            <button @click="cancelAnswer" class="text-[10px] font-black text-slate-400">取消</button>
-            <button @click="saveAnswer" class="rounded-lg bg-emerald-600 px-3 py-1.5 text-[10px] font-black text-white shadow-lg shadow-emerald-600/20">完成</button>
+          <div class="flex justify-end gap-3">
+            <button @click="cancelAnswer" class="text-xs font-bold text-slate-400 hover:text-slate-600 dark:hover:text-slate-200">取消</button>
+            <button @click="saveAnswer" class="h-8 rounded-lg bg-emerald-600 px-4 text-xs font-bold text-white shadow-sm transition-all hover:bg-emerald-500">完成</button>
           </div>
         </div>
-        <div v-else class="text-[13px] font-bold leading-relaxed text-slate-700 dark:text-slate-300">
+        <div v-else class="text-sm font-bold leading-relaxed text-slate-700 dark:text-slate-300">
           {{ question.answer || '点击上方按钮录入参考答案...' }}
         </div>
       </div>
 
       <!-- 错因笔记 -->
-      <div class="group/box relative rounded-2xl border border-blue-100 bg-blue-50/30 p-4 hover:bg-blue-50/50 dark:border-indigo-500/10 dark:bg-indigo-500/5">
+      <div class="group/box relative rounded-2xl border border-blue-100 bg-blue-50/30 p-4 transition-colors hover:bg-blue-50/50 dark:border-indigo-500/10 dark:bg-indigo-500/5">
         <div class="mb-3 flex items-center justify-between">
-          <span class="text-[10px] font-black uppercase tracking-widest text-blue-600 dark:text-indigo-400">我的笔记</span>
-          <button @click="startEditUserAnswer" class="text-[10px] font-black text-blue-600 underline-offset-4 hover:underline dark:text-indigo-400">
+          <span class="text-xs font-bold uppercase tracking-widest text-blue-600 dark:text-indigo-400">我的笔记</span>
+          <button @click="startEditUserAnswer" class="text-xs font-bold text-blue-600 underline-offset-4 hover:underline dark:text-indigo-400">
             {{ question.user_answer ? '编辑' : '录入' }}
           </button>
         </div>
@@ -160,14 +149,14 @@ const cancelUserAnswer = () => { editingUserAnswer.value = false }
           <textarea
             v-model="userAnswerDraft"
             rows="3"
-            class="w-full rounded-xl border-none bg-white p-3 text-xs font-bold text-slate-800 shadow-sm focus:ring-2 focus:ring-blue-500/20 dark:bg-slate-800 dark:text-white"
+            class="w-full rounded-xl border-none bg-white p-3 text-sm font-bold text-slate-800 shadow-sm outline-none focus:ring-2 focus:ring-blue-500/20 dark:bg-slate-800 dark:text-white"
           ></textarea>
-          <div class="flex justify-end gap-2">
-            <button @click="cancelUserAnswer" class="text-[10px] font-black text-slate-400">取消</button>
-            <button @click="saveUserAnswer" class="rounded-lg bg-blue-600 px-3 py-1.5 text-[10px] font-black text-white shadow-lg shadow-blue-600/20 dark:bg-indigo-500">完成</button>
+          <div class="flex justify-end gap-3">
+            <button @click="cancelUserAnswer" class="text-xs font-bold text-slate-400 hover:text-slate-600 dark:hover:text-slate-200">取消</button>
+            <button @click="saveUserAnswer" class="h-8 rounded-lg bg-blue-600 px-4 text-xs font-bold text-white shadow-sm transition-all hover:bg-blue-500 dark:bg-indigo-600 dark:hover:bg-indigo-500">完成</button>
           </div>
         </div>
-        <div v-else class="text-[13px] font-bold leading-relaxed text-slate-700 dark:text-slate-300">
+        <div v-else class="text-sm font-bold leading-relaxed text-slate-700 dark:text-slate-300">
           {{ question.user_answer || '记录你的错因或学习笔记...' }}
         </div>
       </div>

--- a/frontend/src/components/QuestionItem.vue
+++ b/frontend/src/components/QuestionItem.vue
@@ -19,9 +19,9 @@ const tags = () => {
 }
 
 const statusClass = (status) => {
-  if (status === '已掌握') return 'bg-emerald-50 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-400'
-  if (status === '复习中') return 'bg-indigo-50 text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-400'
-  return 'bg-slate-100 text-slate-600 dark:bg-white/5 dark:text-slate-400'
+  if (status === '已掌握') return 'bg-emerald-500/10 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-400 border border-emerald-200/50 dark:border-emerald-500/30'
+  if (status === '复习中') return 'bg-indigo-500/10 text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-400 border border-indigo-200/50 dark:border-indigo-500/30'
+  return 'bg-slate-500/10 text-slate-600 dark:bg-slate-500/20 dark:text-slate-400 border border-slate-200/50 dark:border-slate-500/30'
 }
 
 const statusIcon = (status) => {
@@ -33,7 +33,7 @@ const statusIcon = (status) => {
 
 <template>
   <div
-    @click="emit('click', question)"
+    @click="selectable ? emit('toggle-select', question.id) : emit('click', question)"
     class="group cursor-pointer rounded-2xl border border-slate-200/60 bg-white/70 p-6 shadow-sm backdrop-blur-xl transition-all hover:shadow-md dark:border-white/10 dark:bg-white/[0.03]"
     :class="{ 'ring-2 ring-indigo-500/50 border-indigo-300 dark:border-indigo-500/40': selected }"
   >
@@ -66,7 +66,7 @@ const statusIcon = (status) => {
         <!-- 底部信息（答案/笔记状态） -->
         <div class="mt-2 flex flex-wrap items-center gap-2 text-xs" @click.stop>
           <span v-if="question.answer" class="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-1 font-bold text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-400">
-            <i class="fa-solid fa-circle-check"></i>已录入答案
+            <i class="fa-solid fa-circle-check"></i>有答案
           </span>
           <span v-if="question.user_answer" class="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-1 font-bold text-blue-600 dark:bg-blue-500/10 dark:text-blue-400">
             <i class="fa-solid fa-pen-to-square"></i>已记笔记

--- a/frontend/src/components/QuestionItemSkeleton.vue
+++ b/frontend/src/components/QuestionItemSkeleton.vue
@@ -1,0 +1,41 @@
+<script setup>
+defineProps({
+  count: { type: Number, default: 4 },
+})
+</script>
+
+<template>
+  <div class="space-y-4">
+    <div
+      v-for="i in count" :key="i"
+      class="rounded-2xl border border-slate-200/60 bg-white/70 p-6 backdrop-blur-xl dark:border-white/10 dark:bg-white/[0.03]"
+    >
+      <div class="flex items-start gap-4 animate-pulse">
+        <!-- 复选框占位 -->
+        <div class="mt-1 h-5 w-5 shrink-0 rounded-lg bg-slate-200 dark:bg-slate-700"></div>
+
+        <div class="min-w-0 flex-1 space-y-4">
+          <!-- 标签行 -->
+          <div class="flex items-center gap-2">
+            <div class="h-6 w-16 rounded-full bg-slate-200 dark:bg-slate-700"></div>
+            <div class="h-6 w-12 rounded-full bg-slate-200 dark:bg-slate-700"></div>
+            <div class="h-6 w-20 rounded-full bg-slate-200 dark:bg-slate-700"></div>
+            <div class="ml-auto h-6 w-14 rounded-full bg-slate-200 dark:bg-slate-700"></div>
+          </div>
+
+          <!-- 内容行 -->
+          <div class="space-y-2">
+            <div class="h-4 w-full rounded-lg bg-slate-200 dark:bg-slate-700"></div>
+            <div class="h-4 w-3/4 rounded-lg bg-slate-200 dark:bg-slate-700"></div>
+          </div>
+
+          <!-- 底部状态 -->
+          <div class="flex items-center gap-2">
+            <div class="h-6 w-20 rounded-full bg-slate-200 dark:bg-slate-700"></div>
+            <div class="h-6 w-16 rounded-full bg-slate-200 dark:bg-slate-700"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/ReviewView.vue
+++ b/frontend/src/components/ReviewView.vue
@@ -181,7 +181,7 @@ const closeAiModal = () => {
 // ---- 生命周期 ----
 watch(() => props.visible, (v) => {
   if (v) loadAll()
-})
+}, { immediate: true })
 </script>
 
 <template>

--- a/frontend/src/components/SearchInput.vue
+++ b/frontend/src/components/SearchInput.vue
@@ -13,13 +13,13 @@ const emit = defineEmits(['update:modelValue'])
   <div>
     <label v-if="label" class="mb-2 block text-[11px] font-black uppercase tracking-widest text-slate-500 dark:text-slate-500">{{ label }}</label>
     <div class="relative group">
-      <i :class="icon" class="absolute left-4 top-1/2 -translate-y-1/2 text-slate-500 group-focus-within:text-blue-500 transition-colors dark:group-focus-within:text-indigo-400"></i>
+      <i :class="icon" class="pointer-events-none absolute left-4 top-1/2 z-10 -translate-y-1/2 text-sm text-slate-400 transition-colors group-focus-within:text-blue-500 dark:text-slate-400 dark:group-focus-within:text-indigo-400"></i>
       <input
         :value="modelValue"
         @input="emit('update:modelValue', $event.target.value)"
         type="text"
         :placeholder="placeholder"
-        class="h-11 w-full rounded-xl border border-slate-200/60 bg-white/70 pl-11 pr-4 text-sm font-bold shadow-sm backdrop-blur-xl outline-none transition-all hover:border-blue-300 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 dark:border-white/10 dark:bg-white/[0.06] dark:text-white dark:hover:border-indigo-500/30 dark:focus:border-indigo-500/50 dark:focus:ring-indigo-500/20"
+        class="h-11 w-full rounded-xl border border-slate-200/60 bg-white/70 pl-11 pr-4 text-sm font-bold backdrop-blur-xl outline-none transition-all hover:border-blue-300 focus:border-blue-400 focus:ring-2 focus:ring-blue-500/20 dark:border-white/10 dark:bg-white/[0.06] dark:text-slate-200 dark:placeholder:text-slate-500 dark:hover:border-indigo-500/30 dark:focus:border-indigo-500/50 dark:focus:ring-indigo-500/20"
       />
     </div>
   </div>

--- a/frontend/src/components/SelectionPanel.vue
+++ b/frontend/src/components/SelectionPanel.vue
@@ -1,0 +1,47 @@
+<script setup>
+defineProps({
+  count: { type: Number, default: 0 },
+  visible: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['export', 'clear'])
+</script>
+
+<template>
+  <Transition
+    enter-active-class="transition-transform duration-300 ease-out"
+    enter-from-class="translate-y-12"
+    enter-to-class="translate-y-0"
+    leave-active-class="transition-transform duration-200 ease-in"
+    leave-from-class="translate-y-0"
+    leave-to-class="translate-y-12"
+  >
+    <div v-if="visible && count" class="fixed bottom-24 left-1/2 z-50 -translate-x-1/2 md:bottom-10">
+      <div class="flex items-center gap-6 rounded-full border border-slate-200/60 bg-white/70 px-6 py-3 shadow-md backdrop-blur-xl dark:border-white/10 dark:bg-white/[0.03]">
+        <div class="flex items-center gap-3 border-r border-slate-200/60 pr-6 dark:border-white/10">
+          <div class="flex h-8 w-8 items-center justify-center rounded-full bg-blue-600 font-mono text-xs font-bold text-white shadow-sm dark:bg-indigo-500">
+            {{ count }}
+          </div>
+          <span class="text-sm font-bold tracking-wider text-slate-700 dark:text-slate-200">已选中题目</span>
+        </div>
+
+        <div class="flex items-center gap-4">
+          <button
+            @click="emit('export')"
+            class="inline-flex h-10 items-center justify-center gap-2 rounded-xl bg-blue-600 px-6 text-sm font-bold text-white shadow-sm transition-all hover:bg-blue-700 hover:shadow-blue-500/20 active:scale-95 dark:bg-indigo-600 dark:hover:bg-indigo-500"
+          >
+            <i class="fa-solid fa-file-export text-sm"></i>
+            生成复习卷
+          </button>
+
+          <button
+            @click="emit('clear')"
+            class="inline-flex h-10 items-center justify-center gap-2 rounded-xl border border-slate-200/60 bg-white/60 px-4 text-sm font-bold text-slate-600 transition-all hover:border-rose-200 hover:bg-rose-50 hover:text-rose-600 dark:border-white/10 dark:bg-white/5 dark:text-slate-400 dark:hover:border-rose-500/30 dark:hover:bg-rose-500/10 dark:hover:text-rose-400"
+          >
+            清除
+          </button>
+        </div>
+      </div>
+    </div>
+  </Transition>
+</template>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,5 +1,6 @@
 import { createApp } from 'vue'
 import './style.css'
+import 'bytemd/dist/index.css'
 import App from './App.vue'
 import router from './router/index.js'
 

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -143,14 +143,16 @@ watch(systemStatus, (newVal) => {
 const statusPills = computed(() => {
   if (statusLoading.value) return [
     { key: 'paddle', loading: true, label: 'PaddleOCR' },
-    { key: 'ensexam', loading: true, label: 'EnsExam (未接入)' },
+    { key: 'ensexam', loading: true, label: 'EnsExam' },
     { key: 'langsmith', loading: true, label: 'LangSmith (未接入)' },
   ]
   const s = systemStatus.value
   if (!s) return []
   const pills = []
   pills.push({ key: 'paddle', ok: !!s.paddleocr_configured, label: s.paddleocr_configured ? 'PaddleOCR' : 'PaddleOCR未配置' })
-  pills.push({ key: 'ensexam', ok: false, label: 'EnsExam (未接入)', isPlaceholder: true })
+  if (s.ensexam_configured) {
+    pills.push({ key: 'ensexam', ok: true, label: 'EnsExam已接入' })
+  }
   pills.push(s.langsmith_enabled
     ? { key: 'langsmith', ok: true, label: 'LangSmith追踪' }
     : { key: 'langsmith', ok: false, label: 'LangSmith (未接入)', isPlaceholder: true }
@@ -269,7 +271,7 @@ const uploadBusy = ref(false)
 const uploadReady = ref(false)
 const splitting = ref(false)
 const splitCompleted = ref(false)
-const eraseEnabled = ref(false)
+const eraseEnabled = ref(true)
 
 const pendingFiles = reactive([])
 const fileProgress = reactive({})
@@ -640,16 +642,6 @@ onBeforeUnmount(() => {
           </button>
 
           <button
-            @click="currentView = 'review'"
-            class="group relative flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-bold transition-all duration-200"
-            :class="currentView === 'review' ? 'bg-blue-600 text-white shadow-lg shadow-blue-600/20 dark:bg-indigo-500 dark:shadow-indigo-500/20' : 'text-slate-600 hover:bg-slate-100 hover:text-blue-600 dark:text-slate-400 dark:hover:bg-white/5 dark:hover:text-indigo-300'"
-          >
-            <i class="fa-solid fa-clock-rotate-left w-5 text-center text-lg transition-transform group-hover:scale-110"></i>
-            <span>待复习</span>
-            <div v-if="currentView === 'review'" class="absolute right-2 h-1.5 w-1.5 rounded-full bg-white/60"></div>
-          </button>
-
-          <button
             @click="currentView = 'error-bank'"
             class="group relative flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-bold transition-all duration-200"
             :class="currentView === 'error-bank' ? 'bg-blue-600 text-white shadow-lg shadow-blue-600/20 dark:bg-indigo-500 dark:shadow-indigo-500/20' : 'text-slate-600 hover:bg-slate-100 hover:text-blue-600 dark:text-slate-400 dark:hover:bg-white/5 dark:hover:text-indigo-300'"
@@ -657,6 +649,16 @@ onBeforeUnmount(() => {
             <i class="fa-solid fa-database w-5 text-center text-lg transition-transform group-hover:scale-110"></i>
             <span>错题库</span>
             <div v-if="currentView === 'error-bank'" class="absolute right-2 h-1.5 w-1.5 rounded-full bg-white/60"></div>
+          </button>
+
+          <button
+            @click="currentView = 'review'"
+            class="group relative flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-bold transition-all duration-200"
+            :class="currentView === 'review' ? 'bg-blue-600 text-white shadow-lg shadow-blue-600/20 dark:bg-indigo-500 dark:shadow-indigo-500/20' : 'text-slate-600 hover:bg-slate-100 hover:text-blue-600 dark:text-slate-400 dark:hover:bg-white/5 dark:hover:text-indigo-300'"
+          >
+            <i class="fa-solid fa-clock-rotate-left w-5 text-center text-lg transition-transform group-hover:scale-110"></i>
+            <span>刷题</span>
+            <div v-if="currentView === 'review'" class="absolute right-2 h-1.5 w-1.5 rounded-full bg-white/60"></div>
           </button>
 
         </nav>
@@ -703,7 +705,7 @@ onBeforeUnmount(() => {
         </button>
         <button @click="currentView = 'review'" class="flex flex-col items-center p-2" :class="currentView === 'review' ? 'text-blue-600 dark:text-indigo-400' : 'text-slate-500 dark:text-slate-400'">
           <i class="fa-solid fa-clock-rotate-left text-lg"></i>
-          <span class="mt-1 text-xs font-bold">待复习</span>
+          <span class="mt-1 text-xs font-bold">刷题</span>
         </button>
         <button @click="currentView = 'dashboard'" class="flex flex-col items-center p-2" :class="currentView === 'dashboard' ? 'text-blue-600 dark:text-indigo-400' : 'text-slate-500 dark:text-slate-400'">
           <i class="fa-solid fa-chart-pie text-lg"></i>


### PR DESCRIPTION
## Summary

- 错题库新增"导出题目"选择模式，点击卡片即可选中，右侧浮动面板一键生成复习卷
- 新增 SelectionPanel、QuestionItemSkeleton、EditNoteDialog 三个组件
- EditNoteDialog 集成 ByteMD markdown 编辑器，支持 GFM 语法和暗色主题
- 题目操作菜单（更多按钮）改为 Teleport 渲染到 body，修复被卡片遮挡的层叠问题
- 修复 Dashboard 统计卡片"待复习"和"已掌握"始终为 0（字段名 `review_status_stats` → `review_stats`）
- 修复直接刷新 Dashboard / 错题库 / 刷题页面时数据不加载（watch 添加 `immediate: true`）
- 搜索图标添加 `z-index` 防止被输入框遮挡
- 侧边栏"待复习"改为"刷题"并移至错题库后面
- 擦除手写字迹开关默认开启
- 下拉组件和日历组件统一暗色玻璃态样式