### PR TITLE
feat(ui): 错题库交互重构与多项 UI 增强

### DIFF
--- a/backend/web_app.py
+++ b/backend/web_app.py
@@ -1344,6 +1344,34 @@ def get_question_types():
         return jsonify({'success': False, 'error': '获取题型列表失败'}), 500
 
 
+@app.route('/api/question/<int:question_id>', methods=['PATCH'])
+def update_question(question_id):
+    """编辑题目内容和/或答案"""
+    try:
+        data = request.get_json(silent=True) or {}
+        with SessionLocal() as db:
+            question = db.get(Question, question_id)
+            if not question:
+                return jsonify({'success': False, 'error': '题目不存在'}), 404
+            try:
+                if 'content' in data:
+                    text = str(data['content'])[:20000]
+                    blocks = [{'block_type': 'text', 'content': text}]
+                    question.content_json = json.dumps(blocks, ensure_ascii=False)
+                    question.content_hash = crud.compute_content_hash(blocks)
+                if 'answer' in data:
+                    question.answer = str(data['answer'])[:10000] if data['answer'] else None
+                question.updated_at = datetime.utcnow()
+                db.commit()
+                return jsonify({'success': True})
+            except Exception:
+                db.rollback()
+                raise
+    except Exception:
+        logger.exception("编辑题目失败")
+        return jsonify({'success': False, 'error': '保存失败，请稍后重试'}), 500
+
+
 @app.route('/api/question/<int:question_id>/answer', methods=['PATCH'])
 def update_question_answer(question_id):
     """保存用户答案"""

--- a/backend/web_app.py
+++ b/backend/web_app.py
@@ -523,9 +523,10 @@ def split_questions():
                 'error': '请先上传文件'
             }), 400
 
-        # 擦除手写字迹（如果 EnsExam 已接入，则自动执行）
+        # 擦除手写字迹（EnsExam 已接入且前端未关闭擦除开关时执行）
+        erase = data.get("erase", True)
         ensexam_configured = settings.model_path.exists()
-        if ensexam_configured:
+        if ensexam_configured and erase:
             try:
                 from models.inference import InferenceEngine
                 engine = InferenceEngine()

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -238,6 +238,18 @@ export async function requestAiAnalysis(questionIds) {
 
 // ── AI 辅导对话 API ──────────────────────────────────────
 
+export async function updateQuestion(questionId, payload) {
+  const resp = await fetch(`/api/question/${questionId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+  const data = await resp.json()
+  if (data && data.success) return data
+  throw new Error((data && data.error) || '保存失败')
+}
+
 export async function saveQuestionAnswer(questionId, answer) {
   const resp = await fetch(`/api/question/${questionId}/answer`, {
     method: 'PUT',

--- a/frontend/src/components/ActionBar.vue
+++ b/frontend/src/components/ActionBar.vue
@@ -45,27 +45,48 @@ const emit = defineEmits(['split', 'export', 'save-to-db'])
     </button>
 
     <!-- 导出按钮：极简现代感 -->
-    <button
-      v-if="exportEnabled"
-      type="button"
-      class="group relative inline-flex h-14 items-center justify-center gap-3 rounded-2xl border border-slate-200 bg-white px-8 text-[13px] font-black tracking-widest text-slate-900 shadow-sm hover:border-slate-900 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-30 dark:border-white/10 dark:bg-slate-900 dark:text-white dark:hover:border-white dark:hover:bg-slate-800"
-      @click="emit('export')"
-    >
-      <i class="fa-solid fa-file-export transition-transform group-hover:-translate-x-0.5"></i>
-      导出错题本
-    </button>
+    <Transition name="action-btn">
+      <button
+        v-if="exportEnabled"
+        type="button"
+        class="group relative inline-flex h-14 items-center justify-center gap-3 rounded-2xl border border-slate-200 bg-white px-8 text-[13px] font-black tracking-widest text-slate-900 shadow-sm hover:border-slate-900 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-30 dark:border-white/10 dark:bg-slate-900 dark:text-white dark:hover:border-white dark:hover:bg-slate-800"
+        @click="emit('export')"
+      >
+        <i class="fa-solid fa-file-export transition-transform group-hover:-translate-x-0.5"></i>
+        导出错题本
+      </button>
+    </Transition>
 
     <!-- 导入错题库按钮：极简现代感 -->
-    <button
-      v-if="exportEnabled"
-      type="button"
-      class="group relative inline-flex h-14 items-center justify-center gap-3 rounded-2xl border border-slate-200 bg-white px-8 text-[13px] font-black tracking-widest text-slate-900 shadow-sm hover:border-slate-900 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-30 dark:border-white/10 dark:bg-slate-900 dark:text-white dark:hover:border-white dark:hover:bg-slate-800"
-      @click="emit('save-to-db')"
-    >
-      <i class="fa-solid fa-database transition-transform group-hover:-translate-y-0.5"></i>
-      导入错题库
-    </button>
+    <Transition name="action-btn">
+      <button
+        v-if="exportEnabled"
+        type="button"
+        class="group relative inline-flex h-14 items-center justify-center gap-3 rounded-2xl border border-slate-200 bg-white px-8 text-[13px] font-black tracking-widest text-slate-900 shadow-sm hover:border-slate-900 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-30 dark:border-white/10 dark:bg-slate-900 dark:text-white dark:hover:border-white dark:hover:bg-slate-800"
+        @click="emit('save-to-db')"
+      >
+        <i class="fa-solid fa-database transition-transform group-hover:-translate-y-0.5"></i>
+        导入错题库
+      </button>
+    </Transition>
 
     </div>
   </div>
 </template>
+
+<style scoped>
+.action-btn-enter-active {
+  transition: opacity 0.3s ease, transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.action-btn-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.action-btn-enter-from {
+  opacity: 0;
+  transform: translateY(8px) scale(0.95);
+}
+.action-btn-leave-to {
+  opacity: 0;
+  transform: translateY(8px) scale(0.95);
+}
+</style>

--- a/frontend/src/components/ChatView.vue
+++ b/frontend/src/components/ChatView.vue
@@ -10,6 +10,7 @@ const props = defineProps({
   question: { type: Object, default: null },
   modelProvider: { type: String, default: 'openai' },
   modelName: { type: String, default: '' },
+  username: { type: String, default: '' },
 })
 
 const emit = defineEmits(['back'])
@@ -295,9 +296,9 @@ onBeforeUnmount(() => {
           <!-- user 头像 -->
           <div
             v-if="msg.role === 'user'"
-            class="ml-3 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-slate-200 text-xs text-slate-600 dark:bg-slate-700 dark:text-slate-300"
+            class="ml-3 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-indigo-600 dark:from-indigo-400 dark:to-indigo-600 text-xs font-extrabold text-white shadow-sm"
           >
-            <i class="fa-solid fa-user"></i>
+            {{ username?.[0]?.toUpperCase() ?? '?' }}
           </div>
         </div>
       </div>

--- a/frontend/src/components/EditNoteDialog.vue
+++ b/frontend/src/components/EditNoteDialog.vue
@@ -5,21 +5,35 @@ import gfm from '@bytemd/plugin-gfm'
 
 const props = defineProps({
   open: { type: Boolean, default: false },
-  field: { type: String, default: 'answer' },
+  field: { type: String, default: 'answer' }, // 'answer' | 'user_answer' | 'question'
   value: { type: String, default: '' },
+  valueAnswer: { type: String, default: '' }, // 仅 field='question' 时使用
   saving: { type: Boolean, default: false },
 })
 
 const emit = defineEmits(['close', 'save'])
-const draft = ref('')
-
 const plugins = computed(() => [gfm()])
 
+const draft = ref('')         // answer / user_answer / question content
+const draftAnswer = ref('')   // 仅 field='question' 时的答案草稿
+
 watch(() => props.open, (v) => {
-  if (v) draft.value = props.value || ''
+  if (v) {
+    draft.value = props.value || ''
+    draftAnswer.value = props.valueAnswer || ''
+  }
 })
 
 const handleChange = (v) => { draft.value = v }
+const handleAnswerChange = (v) => { draftAnswer.value = v }
+
+const onSave = () => {
+  if (props.field === 'question') {
+    emit('save', { content: draft.value, answer: draftAnswer.value })
+  } else {
+    emit('save', draft.value)
+  }
+}
 
 const config = () => {
   if (props.field === 'answer') {
@@ -29,6 +43,15 @@ const config = () => {
       iconBg: 'bg-emerald-50 dark:bg-emerald-500/10',
       iconCls: 'text-emerald-600 dark:text-emerald-400',
       btnCls: 'bg-emerald-600 hover:bg-emerald-700 dark:bg-emerald-500 dark:hover:bg-emerald-600',
+    }
+  }
+  if (props.field === 'question') {
+    return {
+      title: '编辑题目',
+      icon: 'fa-pen-to-square',
+      iconBg: 'bg-indigo-50 dark:bg-indigo-500/10',
+      iconCls: 'text-indigo-600 dark:text-indigo-400',
+      btnCls: 'bg-indigo-600 hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600',
     }
   }
   return {
@@ -49,7 +72,8 @@ const config = () => {
         <div class="absolute inset-0 bg-black/40 backdrop-blur-sm"></div>
 
         <!-- 弹窗 -->
-        <div class="relative w-full max-w-2xl rounded-2xl border border-slate-200/60 bg-white shadow-2xl dark:border-white/10 dark:bg-[#0f0f17]">
+        <div class="relative w-full max-w-2xl rounded-2xl border border-slate-200/60 bg-white shadow-2xl dark:border-white/10 dark:bg-[#0f0f17]"
+             :class="field === 'question' ? 'max-w-3xl' : 'max-w-2xl'">
           <!-- 头部 -->
           <div class="flex items-center justify-between border-b border-slate-100 px-6 py-4 dark:border-white/5">
             <div class="flex items-center gap-3">
@@ -63,8 +87,24 @@ const config = () => {
             </button>
           </div>
 
-          <!-- ByteMD 编辑器 -->
-          <div class="bytemd-wrapper px-6 py-4">
+          <!-- 编辑区 -->
+          <div v-if="field === 'question'" class="px-6 py-4 space-y-4">
+            <!-- 题目内容 -->
+            <div>
+              <p class="mb-2 text-xs font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500">题目内容</p>
+              <div class="bytemd-wrapper">
+                <Editor :value="draft" :plugins="plugins" @change="handleChange" />
+              </div>
+            </div>
+            <!-- 答案 -->
+            <div>
+              <p class="mb-2 text-xs font-bold uppercase tracking-widest text-emerald-600 dark:text-emerald-400">正确答案</p>
+              <div class="bytemd-wrapper">
+                <Editor :value="draftAnswer" :plugins="plugins" @change="handleAnswerChange" />
+              </div>
+            </div>
+          </div>
+          <div v-else class="bytemd-wrapper px-6 py-4">
             <Editor :value="draft" :plugins="plugins" @change="handleChange" />
           </div>
 
@@ -74,7 +114,7 @@ const config = () => {
               取消
             </button>
             <button
-              @click="emit('save', draft)"
+              @click="onSave"
               :disabled="saving"
               class="inline-flex h-10 items-center justify-center gap-2 rounded-xl px-6 text-sm font-bold text-white transition-all disabled:cursor-not-allowed disabled:opacity-50"
               :class="config().btnCls"
@@ -103,7 +143,7 @@ const config = () => {
 <style>
 /* ByteMD 暗色主题适配 */
 .bytemd-wrapper .bytemd {
-  height: 320px;
+  height: 220px;
   border-radius: 0.75rem;
   border: 1px solid rgba(226, 232, 240, 0.6);
   overflow: hidden;

--- a/frontend/src/components/ErrorBank.vue
+++ b/frontend/src/components/ErrorBank.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, reactive, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
+import { ref, reactive, computed, watch, nextTick, onBeforeUnmount } from 'vue'
 import * as api from '../api.js'
 import { typesetMath as _typesetMath } from '../utils.js'
 import CustomSelect from './CustomSelect.vue'
@@ -155,28 +155,12 @@ const doExport = async () => {
 
 
 // ---- 内联操作 ----
-const menuOpenId = ref(null)
-const menuStyle = ref({})
 const dialogOpen = ref(false)
 const dialogField = ref('answer')
 const dialogQuestion = ref(null)
 const dialogSaving = ref(false)
 
-const toggleMenu = (id, event) => {
-  if (menuOpenId.value === id) { menuOpenId.value = null; return }
-  const btn = event.currentTarget
-  const rect = btn.getBoundingClientRect()
-  menuStyle.value = {
-    position: 'fixed',
-    top: rect.bottom + 4 + 'px',
-    left: (rect.right - 160) + 'px',
-    zIndex: 9999,
-  }
-  menuOpenId.value = id
-}
-
 const openEditDialog = (q, field) => {
-  menuOpenId.value = null
   dialogQuestion.value = q
   dialogField.value = field
   dialogOpen.value = true
@@ -252,10 +236,6 @@ const refreshTags = async () => {
 
 const scrollContainerRef = ref(null)
 
-const handleScroll = () => {
-  if (menuOpenId.value) menuOpenId.value = null
-}
-
 const loadFilters = async () => {
   try {
     const [s, qt] = await Promise.all([
@@ -288,11 +268,8 @@ watch(() => props.visible, (v) => { if (v) { loadFilters(); doQuery() } }, { imm
 
 defineExpose({ refresh: doQuery })
 
-const closeMenu = () => { menuOpenId.value = null }
-onMounted(() => { document.addEventListener('click', closeMenu) })
 onBeforeUnmount(() => {
   if (debounceTimer) clearTimeout(debounceTimer)
-  document.removeEventListener('click', closeMenu)
 })
 </script>
 
@@ -385,65 +362,52 @@ onBeforeUnmount(() => {
           @toggle-select="toggleSelect"
         >
           <template #actions="{ question }">
-            <!-- 更多菜单 -->
-            <div>
-              <button @click.stop="toggleMenu(question.id, $event)"
-                class="flex h-8 w-8 items-center justify-center rounded-xl text-slate-400 transition-all hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-white/5 dark:hover:text-slate-300">
-                <i class="fa-solid fa-ellipsis"></i>
-              </button>
+            <div class="flex flex-col items-end gap-2">
+              <!-- 复习状态切换 -->
+              <div class="flex items-center gap-1 rounded-xl border border-slate-200/60 bg-slate-50/80 p-1 dark:border-white/10 dark:bg-white/[0.03]">
+                <button @click.stop="quickMarkStatus(question, '待复习')"
+                  class="flex h-6 w-6 items-center justify-center rounded-lg transition-all"
+                  :class="!question.review_status || question.review_status === '待复习' ? 'bg-slate-500/20 text-slate-600 dark:bg-slate-500/30 dark:text-slate-300' : 'text-slate-400 hover:bg-slate-500/10 dark:text-slate-600 dark:hover:bg-slate-500/10'"
+                  title="待复习">
+                  <i class="fa-solid fa-clock text-xs"></i>
+                </button>
+                <button @click.stop="quickMarkStatus(question, '复习中')"
+                  class="flex h-6 w-6 items-center justify-center rounded-lg transition-all"
+                  :class="question.review_status === '复习中' ? 'bg-indigo-500/20 text-indigo-600 dark:bg-indigo-500/30 dark:text-indigo-400' : 'text-slate-400 hover:bg-indigo-500/10 dark:text-slate-600 dark:hover:bg-indigo-500/10'"
+                  title="复习中">
+                  <i class="fa-solid fa-spinner text-xs"></i>
+                </button>
+                <button @click.stop="quickMarkStatus(question, '已掌握')"
+                  class="flex h-6 w-6 items-center justify-center rounded-lg transition-all"
+                  :class="question.review_status === '已掌握' ? 'bg-emerald-500/20 text-emerald-600 dark:bg-emerald-500/30 dark:text-emerald-400' : 'text-slate-400 hover:bg-emerald-500/10 dark:text-slate-600 dark:hover:bg-emerald-500/10'"
+                  title="已掌握">
+                  <i class="fa-solid fa-circle-check text-xs"></i>
+                </button>
+              </div>
+              <!-- 操作按钮 -->
+              <div class="flex items-center gap-1">
+                <button @click.stop="openEditDialog(question, 'question')"
+                  class="flex h-7 w-7 items-center justify-center rounded-lg text-slate-400 transition-all hover:bg-blue-500/10 hover:text-blue-600 dark:hover:bg-blue-500/20 dark:hover:text-blue-400"
+                  title="编辑">
+                  <i class="fa-solid fa-pen-to-square text-xs"></i>
+                </button>
+                <button @click.stop="openEditDialog(question, 'user_answer')"
+                  class="flex h-7 w-7 items-center justify-center rounded-lg text-slate-400 transition-all hover:bg-blue-500/10 hover:text-blue-600 dark:hover:bg-blue-500/20 dark:hover:text-blue-400"
+                  title="记笔记">
+                  <i class="fa-solid fa-note-sticky text-xs"></i>
+                </button>
+                <button @click.stop="emit('start-chat', question)"
+                  class="flex h-7 w-7 items-center justify-center rounded-lg text-slate-400 transition-all hover:bg-indigo-500/10 hover:text-indigo-600 dark:hover:bg-indigo-500/20 dark:hover:text-indigo-400"
+                  title="AI 辅导">
+                  <i class="fa-solid fa-wand-magic-sparkles text-xs"></i>
+                </button>
+                <button @click.stop="doDelete(question)"
+                  class="flex h-7 w-7 items-center justify-center rounded-lg text-slate-400 transition-all hover:bg-rose-500/10 hover:text-rose-500 dark:hover:bg-rose-500/20 dark:hover:text-rose-400"
+                  title="删除题目">
+                  <i class="fa-solid fa-trash-can text-xs"></i>
+                </button>
+              </div>
             </div>
-            <Teleport to="body">
-              <Transition
-                enter-active-class="transition duration-200 ease-out"
-                enter-from-class="translate-y-2 opacity-0 scale-95"
-                enter-to-class="translate-y-0 opacity-100 scale-100"
-                leave-active-class="transition duration-150 ease-in"
-                leave-from-class="translate-y-0 opacity-100 scale-100"
-                leave-to-class="translate-y-2 opacity-0 scale-95"
-              >
-                <div v-if="menuOpenId === question.id" :style="menuStyle"
-                  class="w-44 overflow-hidden rounded-2xl border border-slate-200/60 bg-white/95 p-1.5 shadow-xl backdrop-blur-3xl dark:border-white/10 dark:bg-[#12121A]/90 dark:bg-gradient-to-b dark:from-white/[0.08] dark:to-transparent dark:backdrop-blur-3xl dark:shadow-[0_20px_50px_rgba(0,0,0,0.6)]">
-                  <div class="px-3 pb-1 pt-2 text-[11px] font-black uppercase tracking-widest text-slate-400 dark:text-slate-500">复习状态</div>
-                  <button @click.stop="quickMarkStatus(question, '待复习'); menuOpenId = null"
-                    class="group flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold transition-all hover:bg-slate-500/10 hover:text-slate-600 dark:hover:bg-slate-500/20 dark:hover:text-slate-400"
-                    :class="question.review_status === '待复习' || !question.review_status ? 'bg-slate-500/10 text-slate-600 dark:bg-slate-500/20 dark:text-slate-400' : 'text-slate-600 dark:text-slate-300'">
-                    <i class="fa-solid fa-clock text-xs opacity-70"></i>待复习
-                    <i v-if="question.review_status === '待复习' || !question.review_status" class="fa-solid fa-check ml-auto text-[10px]"></i>
-                  </button>
-                  <button @click.stop="quickMarkStatus(question, '复习中'); menuOpenId = null"
-                    class="group flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold transition-all hover:bg-indigo-500/10 hover:text-indigo-600 dark:hover:bg-indigo-500/20 dark:hover:text-indigo-400"
-                    :class="question.review_status === '复习中' ? 'bg-indigo-500/10 text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-400' : 'text-slate-600 dark:text-slate-300'">
-                    <i class="fa-solid fa-spinner text-xs opacity-70"></i>复习中
-                    <i v-if="question.review_status === '复习中'" class="fa-solid fa-check ml-auto text-[10px]"></i>
-                  </button>
-                  <button @click.stop="quickMarkStatus(question, '已掌握'); menuOpenId = null"
-                    class="group flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold transition-all hover:bg-emerald-500/10 hover:text-emerald-600 dark:hover:bg-emerald-500/20 dark:hover:text-emerald-400"
-                    :class="question.review_status === '已掌握' ? 'bg-emerald-500/10 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-400' : 'text-slate-600 dark:text-slate-300'">
-                    <i class="fa-solid fa-circle-check text-xs opacity-70"></i>已掌握
-                    <i v-if="question.review_status === '已掌握'" class="fa-solid fa-check ml-auto text-[10px]"></i>
-                  </button>
-                  <div class="mx-2 my-1.5 border-t border-slate-100 dark:border-white/5"></div>
-                  <div class="px-3 pb-1 pt-1 text-[11px] font-black uppercase tracking-widest text-slate-400 dark:text-slate-500">操作</div>
-                  <button @click.stop="openEditDialog(question, 'question')"
-                    class="group flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold text-slate-600 transition-all hover:bg-blue-500/10 hover:text-blue-600 dark:text-slate-300 dark:hover:bg-blue-500/20 dark:hover:text-blue-400">
-                    <i class="fa-solid fa-pen-to-square text-xs opacity-70"></i>编辑
-                  </button>
-                  <button @click.stop="openEditDialog(question, 'user_answer')"
-                    class="group flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold text-slate-600 transition-all hover:bg-blue-500/10 hover:text-blue-600 dark:text-slate-300 dark:hover:bg-blue-500/20 dark:hover:text-blue-400">
-                    <i class="fa-solid fa-note-sticky text-xs opacity-70"></i>{{ question.user_answer ? '编辑笔记' : '记笔记' }}
-                  </button>
-                  <button @click.stop="emit('start-chat', question); menuOpenId = null"
-                    class="group flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold text-slate-600 transition-all hover:bg-indigo-500/10 hover:text-indigo-600 dark:text-slate-300 dark:hover:bg-indigo-500/20 dark:hover:text-indigo-400">
-                    <i class="fa-solid fa-wand-magic-sparkles text-xs opacity-70"></i>AI 辅导
-                  </button>
-                  <div class="mx-2 my-1.5 border-t border-slate-100 dark:border-white/5"></div>
-                  <button @click.stop="doDelete(question); menuOpenId = null"
-                    class="group flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold text-rose-500 transition-all hover:bg-rose-500/10 dark:text-rose-400 dark:hover:bg-rose-500/20">
-                    <i class="fa-solid fa-trash-can text-xs opacity-70"></i>删除题目
-                  </button>
-                </div>
-              </Transition>
-            </Teleport>
           </template>
 
         </QuestionItem>

--- a/frontend/src/components/ErrorBank.vue
+++ b/frontend/src/components/ErrorBank.vue
@@ -186,7 +186,11 @@ const onDialogSave = async (draft) => {
   if (dialogSaving.value || !dialogQuestion.value) return
   dialogSaving.value = true
   try {
-    if (dialogField.value === 'answer') {
+    if (dialogField.value === 'question') {
+      await api.updateQuestion(dialogQuestion.value.id, { content: draft.content, answer: draft.answer })
+      dialogQuestion.value.content_json = [{ block_type: 'text', content: draft.content }]
+      dialogQuestion.value.answer = draft.answer
+    } else if (dialogField.value === 'answer') {
       await api.saveQuestionAnswer(dialogQuestion.value.id, draft)
       dialogQuestion.value.answer = draft
     } else {
@@ -302,7 +306,7 @@ onBeforeUnmount(() => {
       >
         <template #extra>
           <div class="flex items-center gap-4">
-            <button @click="selectMode ? exitSelectMode() : enterSelectMode()" class="btn-secondary h-10 w-[150px] px-6 shadow-sm">
+            <button @click="selectMode ? exitSelectMode() : enterSelectMode()" class="group inline-flex h-10 w-[150px] items-center justify-center gap-2 rounded-xl border border-slate-200/60 bg-white/60 px-6 text-sm font-bold text-slate-700 shadow-sm backdrop-blur-xl transition-all hover:border-slate-300 hover:bg-white/80 dark:border-white/10 dark:bg-white/[0.03] dark:text-slate-300 dark:hover:border-white/20 dark:hover:bg-white/[0.06]">
               <i class="fa-solid" :class="selectMode ? 'fa-xmark' : 'fa-file-export'"></i>
               {{ selectMode ? '退出选择' : '导出题目' }}
             </button>
@@ -310,7 +314,7 @@ onBeforeUnmount(() => {
               <i class="fa-solid fa-plus-circle transition-transform group-hover:rotate-90"></i>
               录入新题目
             </button>
-            <button @click="resetFilters" class="btn-secondary h-10 px-4 shadow-sm transition-all" title="重置筛选">
+            <button @click="resetFilters" class="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200/60 bg-white/60 text-sm text-slate-700 shadow-sm backdrop-blur-xl transition-all hover:border-slate-300 hover:bg-white/80 dark:border-white/10 dark:bg-white/[0.03] dark:text-slate-300 dark:hover:border-white/20 dark:hover:bg-white/[0.06]" title="重置筛选">
               <i class="fa-solid fa-arrow-rotate-right"></i>
             </button>
           </div>
@@ -420,9 +424,9 @@ onBeforeUnmount(() => {
                   </button>
                   <div class="mx-2 my-1.5 border-t border-slate-100 dark:border-white/5"></div>
                   <div class="px-3 pb-1 pt-1 text-[11px] font-black uppercase tracking-widest text-slate-400 dark:text-slate-500">操作</div>
-                  <button @click.stop="openEditDialog(question, 'answer')"
+                  <button @click.stop="openEditDialog(question, 'question')"
                     class="group flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold text-slate-600 transition-all hover:bg-blue-500/10 hover:text-blue-600 dark:text-slate-300 dark:hover:bg-blue-500/20 dark:hover:text-blue-400">
-                    <i class="fa-solid fa-pen-to-square text-xs opacity-70"></i>{{ question.answer ? '编辑答案' : '录入答案' }}
+                    <i class="fa-solid fa-pen-to-square text-xs opacity-70"></i>编辑
                   </button>
                   <button @click.stop="openEditDialog(question, 'user_answer')"
                     class="group flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold text-slate-600 transition-all hover:bg-blue-500/10 hover:text-blue-600 dark:text-slate-300 dark:hover:bg-blue-500/20 dark:hover:text-blue-400">
@@ -477,7 +481,10 @@ onBeforeUnmount(() => {
     <EditNoteDialog
       :open="dialogOpen"
       :field="dialogField"
-      :value="dialogQuestion?.[dialogField] || ''"
+      :value="dialogField === 'question'
+        ? (dialogQuestion?.content_json?.filter(b => b.block_type === 'text').map(b => b.content).join('\n') || '')
+        : (dialogQuestion?.[dialogField] || '')"
+      :value-answer="dialogField === 'question' ? (dialogQuestion?.answer || '') : ''"
       :saving="dialogSaving"
       @close="dialogOpen = false"
       @save="onDialogSave"

--- a/frontend/src/components/ErrorBank.vue
+++ b/frontend/src/components/ErrorBank.vue
@@ -39,8 +39,8 @@ const reviewStatusIcon = (status) => {
 }
 
 const reviewStatusClass = (status) => {
-  if (status === '待复习') return 'bg-slate-500/10 text-slate-600 dark:bg-slate-500/20 dark:text-slate-400 border-slate-200/50 dark:border-slate-500/30'
-  if (status === '复习中') return 'bg-indigo-500/10 text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-400 border-indigo-200/50 dark:border-indigo-500/30'
+  if (status === '待复习') return 'bg-rose-500/10 text-rose-600 dark:bg-rose-500/20 dark:text-rose-400 border-rose-200/50 dark:border-rose-500/30'
+  if (status === '复习中') return 'bg-amber-500/10 text-amber-600 dark:bg-amber-500/20 dark:text-amber-400 border-amber-200/50 dark:border-amber-500/30'
   return 'bg-emerald-500/10 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-400 border-emerald-200/50 dark:border-emerald-500/30'
 }
 
@@ -159,6 +159,30 @@ const dialogOpen = ref(false)
 const dialogField = ref('answer')
 const dialogQuestion = ref(null)
 const dialogSaving = ref(false)
+
+// hover dropdown
+const hoverMenuId = ref(null)
+const hoverMenuStyle = ref({})
+let hoverCloseTimer = null
+
+const onMenuEnter = (id, el) => {
+  clearTimeout(hoverCloseTimer)
+  const rect = el.getBoundingClientRect()
+  hoverMenuStyle.value = {
+    position: 'fixed',
+    top: rect.bottom + 4 + 'px',
+    right: (window.innerWidth - rect.right) + 'px',
+    zIndex: 9999,
+  }
+  hoverMenuId.value = id
+}
+
+const onMenuLeave = () => {
+  hoverCloseTimer = setTimeout(() => { hoverMenuId.value = null }, 150)
+}
+
+const onMenuContentEnter = () => { clearTimeout(hoverCloseTimer) }
+const onMenuContentLeave = () => { hoverCloseTimer = setTimeout(() => { hoverMenuId.value = null }, 150) }
 
 const openEditDialog = (q, field) => {
   dialogQuestion.value = q
@@ -362,52 +386,65 @@ onBeforeUnmount(() => {
           @toggle-select="toggleSelect"
         >
           <template #actions="{ question }">
-            <div class="flex flex-col items-end gap-2">
-              <!-- 复习状态切换 -->
-              <div class="flex items-center gap-1 rounded-xl border border-slate-200/60 bg-slate-50/80 p-1 dark:border-white/10 dark:bg-white/[0.03]">
-                <button @click.stop="quickMarkStatus(question, '待复习')"
-                  class="flex h-6 w-6 items-center justify-center rounded-lg transition-all"
-                  :class="!question.review_status || question.review_status === '待复习' ? 'bg-slate-500/20 text-slate-600 dark:bg-slate-500/30 dark:text-slate-300' : 'text-slate-400 hover:bg-slate-500/10 dark:text-slate-600 dark:hover:bg-slate-500/10'"
-                  title="待复习">
-                  <i class="fa-solid fa-clock text-xs"></i>
-                </button>
-                <button @click.stop="quickMarkStatus(question, '复习中')"
-                  class="flex h-6 w-6 items-center justify-center rounded-lg transition-all"
-                  :class="question.review_status === '复习中' ? 'bg-indigo-500/20 text-indigo-600 dark:bg-indigo-500/30 dark:text-indigo-400' : 'text-slate-400 hover:bg-indigo-500/10 dark:text-slate-600 dark:hover:bg-indigo-500/10'"
-                  title="复习中">
-                  <i class="fa-solid fa-spinner text-xs"></i>
-                </button>
-                <button @click.stop="quickMarkStatus(question, '已掌握')"
-                  class="flex h-6 w-6 items-center justify-center rounded-lg transition-all"
-                  :class="question.review_status === '已掌握' ? 'bg-emerald-500/20 text-emerald-600 dark:bg-emerald-500/30 dark:text-emerald-400' : 'text-slate-400 hover:bg-emerald-500/10 dark:text-slate-600 dark:hover:bg-emerald-500/10'"
-                  title="已掌握">
-                  <i class="fa-solid fa-circle-check text-xs"></i>
-                </button>
-              </div>
-              <!-- 操作按钮 -->
-              <div class="flex items-center gap-1">
-                <button @click.stop="openEditDialog(question, 'question')"
-                  class="flex h-7 w-7 items-center justify-center rounded-lg text-slate-400 transition-all hover:bg-blue-500/10 hover:text-blue-600 dark:hover:bg-blue-500/20 dark:hover:text-blue-400"
-                  title="编辑">
-                  <i class="fa-solid fa-pen-to-square text-xs"></i>
-                </button>
-                <button @click.stop="openEditDialog(question, 'user_answer')"
-                  class="flex h-7 w-7 items-center justify-center rounded-lg text-slate-400 transition-all hover:bg-blue-500/10 hover:text-blue-600 dark:hover:bg-blue-500/20 dark:hover:text-blue-400"
-                  title="记笔记">
-                  <i class="fa-solid fa-note-sticky text-xs"></i>
-                </button>
-                <button @click.stop="emit('start-chat', question)"
-                  class="flex h-7 w-7 items-center justify-center rounded-lg text-slate-400 transition-all hover:bg-indigo-500/10 hover:text-indigo-600 dark:hover:bg-indigo-500/20 dark:hover:text-indigo-400"
-                  title="AI 辅导">
-                  <i class="fa-solid fa-wand-magic-sparkles text-xs"></i>
-                </button>
-                <button @click.stop="doDelete(question)"
-                  class="flex h-7 w-7 items-center justify-center rounded-lg text-slate-400 transition-all hover:bg-rose-500/10 hover:text-rose-500 dark:hover:bg-rose-500/20 dark:hover:text-rose-400"
-                  title="删除题目">
-                  <i class="fa-solid fa-trash-can text-xs"></i>
-                </button>
-              </div>
-            </div>
+            <button
+              @mouseenter="onMenuEnter(question.id, $event.currentTarget)"
+              @mouseleave="onMenuLeave"
+              class="flex h-8 w-8 items-center justify-center rounded-xl text-slate-400 transition-all hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-white/5 dark:hover:text-slate-300">
+              <i class="fa-solid fa-ellipsis text-sm"></i>
+            </button>
+            <Teleport to="body">
+              <Transition
+                enter-active-class="transition duration-150 ease-out"
+                enter-from-class="opacity-0 scale-95 -translate-y-1"
+                enter-to-class="opacity-100 scale-100 translate-y-0"
+                leave-active-class="transition duration-100 ease-in"
+                leave-from-class="opacity-100 scale-100 translate-y-0"
+                leave-to-class="opacity-0 scale-95 -translate-y-1"
+              >
+                <div v-if="hoverMenuId === question.id" :style="hoverMenuStyle"
+                  @mouseenter="onMenuContentEnter" @mouseleave="onMenuContentLeave"
+                  class="w-44 overflow-hidden rounded-2xl border border-slate-200/60 bg-white/95 p-1.5 shadow-xl backdrop-blur-3xl dark:border-white/10 dark:bg-[#12121A]/90 dark:bg-gradient-to-b dark:from-white/[0.08] dark:to-transparent dark:shadow-[0_20px_50px_rgba(0,0,0,0.6)]">
+                  <div class="px-3 pb-1 pt-2 text-[11px] font-black uppercase tracking-widest text-slate-400 dark:text-slate-500">复习状态</div>
+                  <button @click.stop="quickMarkStatus(question, '待复习')"
+                    class="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold transition-all"
+                    :class="!question.review_status || question.review_status === '待复习' ? 'bg-rose-500/10 text-rose-600 dark:bg-rose-500/20 dark:text-rose-400' : 'text-slate-600 hover:bg-rose-500/10 hover:text-rose-600 dark:text-slate-300 dark:hover:bg-rose-500/20 dark:hover:text-rose-400'">
+                    <i class="fa-solid fa-clock text-xs"></i>待复习
+                    <i v-if="!question.review_status || question.review_status === '待复习'" class="fa-solid fa-check ml-auto text-[10px]"></i>
+                  </button>
+                  <button @click.stop="quickMarkStatus(question, '复习中')"
+                    class="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold transition-all"
+                    :class="question.review_status === '复习中' ? 'bg-amber-500/10 text-amber-600 dark:bg-amber-500/20 dark:text-amber-400' : 'text-slate-600 hover:bg-amber-500/10 hover:text-amber-600 dark:text-slate-300 dark:hover:bg-amber-500/20 dark:hover:text-amber-400'">
+                    <i class="fa-solid fa-spinner text-xs"></i>复习中
+                    <i v-if="question.review_status === '复习中'" class="fa-solid fa-check ml-auto text-[10px]"></i>
+                  </button>
+                  <button @click.stop="quickMarkStatus(question, '已掌握')"
+                    class="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold transition-all"
+                    :class="question.review_status === '已掌握' ? 'bg-emerald-500/10 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-400' : 'text-slate-600 hover:bg-emerald-500/10 hover:text-emerald-600 dark:text-slate-300 dark:hover:bg-emerald-500/20 dark:hover:text-emerald-400'">
+                    <i class="fa-solid fa-circle-check text-xs"></i>已掌握
+                    <i v-if="question.review_status === '已掌握'" class="fa-solid fa-check ml-auto text-[10px]"></i>
+                  </button>
+                  <div class="mx-2 my-1.5 border-t border-slate-100 dark:border-white/5"></div>
+                  <div class="px-3 pb-1 text-[11px] font-black uppercase tracking-widest text-slate-400 dark:text-slate-500">操作</div>
+                  <button @click.stop="openEditDialog(question, 'question'); hoverMenuId = null"
+                    class="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold text-slate-600 transition-all hover:bg-blue-500/10 hover:text-blue-600 dark:text-slate-300 dark:hover:bg-blue-500/20 dark:hover:text-blue-400">
+                    <i class="fa-solid fa-pen-to-square text-xs"></i>编辑
+                  </button>
+                  <button @click.stop="openEditDialog(question, 'user_answer'); hoverMenuId = null"
+                    class="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold text-slate-600 transition-all hover:bg-blue-500/10 hover:text-blue-600 dark:text-slate-300 dark:hover:bg-blue-500/20 dark:hover:text-blue-400">
+                    <i class="fa-solid fa-note-sticky text-xs"></i>记笔记
+                  </button>
+                  <button @click.stop="emit('start-chat', question); hoverMenuId = null"
+                    class="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold text-slate-600 transition-all hover:bg-indigo-500/10 hover:text-indigo-600 dark:text-slate-300 dark:hover:bg-indigo-500/20 dark:hover:text-indigo-400">
+                    <i class="fa-solid fa-wand-magic-sparkles text-xs"></i>AI 辅导
+                  </button>
+                  <div class="mx-2 my-1.5 border-t border-slate-100 dark:border-white/5"></div>
+                  <button @click.stop="doDelete(question); hoverMenuId = null"
+                    class="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold text-rose-500 transition-all hover:bg-rose-500/10 dark:text-rose-400 dark:hover:bg-rose-500/20">
+                    <i class="fa-solid fa-trash-can text-xs"></i>删除题目
+                  </button>
+                </div>
+              </Transition>
+            </Teleport>
           </template>
 
         </QuestionItem>

--- a/frontend/src/components/QuestionCard.vue
+++ b/frontend/src/components/QuestionCard.vue
@@ -38,11 +38,11 @@ const cancelUserAnswer = () => { editingUserAnswer.value = false }
 
 <template>
   <div
-    class="question-card group relative overflow-hidden rounded-[2rem] border bg-white p-6 hover:shadow-[0_20px_40px_rgba(0,0,0,0.04)] dark:bg-slate-900/40"
+    class="question-card group relative overflow-hidden rounded-2xl border bg-white/70 p-6 shadow-sm backdrop-blur-xl transition-shadow hover:shadow-md dark:bg-white/[0.03]"
     :class="
       selected
-        ? 'border-blue-500/50 shadow-[0_0_30px_rgba(59,130,246,0.1)] dark:border-indigo-500/50 dark:shadow-[0_0_40px_rgba(99,102,241,0.2)]'
-        : 'border-slate-100 dark:border-white/5 hover:border-blue-200 dark:hover:border-white/10'
+        ? 'border-blue-500/50 shadow-blue-500/10 dark:border-indigo-500/50 dark:shadow-indigo-500/20'
+        : 'border-slate-200/60 dark:border-white/10 hover:border-blue-200 dark:hover:border-white/15'
     "
     @click="emit('toggle', question.question_id)"
   >
@@ -56,6 +56,7 @@ const cancelUserAnswer = () => { editingUserAnswer.value = false }
     <div class="mb-6 flex items-start gap-4">
       <!-- 题型与标签 -->
       <div class="flex flex-wrap items-center gap-2">
+        <span class="text-xs font-bold tracking-widest text-slate-400 dark:text-slate-500">AI 识别标签</span>
         <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-bold uppercase tracking-widest text-slate-500 dark:bg-white/5 dark:text-slate-400">
           {{ question.question_type }}
         </span>
@@ -83,7 +84,7 @@ const cancelUserAnswer = () => { editingUserAnswer.value = false }
     </div>
 
     <!-- 题目内容区 -->
-    <div class="question-content relative pl-2 border-l-2 border-slate-50 dark:border-white/5">
+    <div class="question-content relative">
       <template v-if="question.content_blocks?.length">
         <div v-for="(b, i) in question.content_blocks" :key="i">
           <div v-if="b.block_type === 'text'" class="my-4 text-base font-medium leading-relaxed text-slate-800 dark:text-slate-200" v-html="isHtml(b.content) ? sanitizeHtml(b.content) : b.content"></div>
@@ -109,58 +110,6 @@ const cancelUserAnswer = () => { editingUserAnswer.value = false }
       </div>
     </div>
 
-    <!-- 录入区 -->
-    <div class="mt-8 grid gap-4 border-t border-slate-50 pt-8 dark:border-white/5 sm:grid-cols-2" @click.stop>
-      <!-- 正确答案 -->
-      <div class="group/box relative rounded-2xl border border-emerald-100 bg-emerald-50/30 p-4 transition-colors hover:bg-emerald-50/50 dark:border-emerald-500/10 dark:bg-emerald-500/5">
-        <div class="mb-3 flex items-center justify-between">
-          <span class="text-xs font-bold uppercase tracking-widest text-emerald-600 dark:text-emerald-400">正确答案</span>
-          <button @click="startEditAnswer" class="text-xs font-bold text-emerald-600 underline-offset-4 hover:underline">
-            {{ question.answer ? '编辑' : '录入' }}
-          </button>
-        </div>
-        
-        <div v-if="editingAnswer" class="space-y-3">
-          <textarea
-            v-model="answerDraft"
-            rows="3"
-            class="w-full rounded-xl border-none bg-white p-3 text-sm font-bold text-slate-800 shadow-sm outline-none focus:ring-2 focus:ring-emerald-500/20 dark:bg-slate-800 dark:text-white"
-          ></textarea>
-          <div class="flex justify-end gap-3">
-            <button @click="cancelAnswer" class="text-xs font-bold text-slate-400 hover:text-slate-600 dark:hover:text-slate-200">取消</button>
-            <button @click="saveAnswer" class="h-8 rounded-lg bg-emerald-600 px-4 text-xs font-bold text-white shadow-sm transition-all hover:bg-emerald-500">完成</button>
-          </div>
-        </div>
-        <div v-else class="text-sm font-bold leading-relaxed text-slate-700 dark:text-slate-300">
-          {{ question.answer || '点击上方按钮录入参考答案...' }}
-        </div>
-      </div>
-
-      <!-- 错因笔记 -->
-      <div class="group/box relative rounded-2xl border border-blue-100 bg-blue-50/30 p-4 transition-colors hover:bg-blue-50/50 dark:border-indigo-500/10 dark:bg-indigo-500/5">
-        <div class="mb-3 flex items-center justify-between">
-          <span class="text-xs font-bold uppercase tracking-widest text-blue-600 dark:text-indigo-400">我的笔记</span>
-          <button @click="startEditUserAnswer" class="text-xs font-bold text-blue-600 underline-offset-4 hover:underline dark:text-indigo-400">
-            {{ question.user_answer ? '编辑' : '录入' }}
-          </button>
-        </div>
-        
-        <div v-if="editingUserAnswer" class="space-y-3">
-          <textarea
-            v-model="userAnswerDraft"
-            rows="3"
-            class="w-full rounded-xl border-none bg-white p-3 text-sm font-bold text-slate-800 shadow-sm outline-none focus:ring-2 focus:ring-blue-500/20 dark:bg-slate-800 dark:text-white"
-          ></textarea>
-          <div class="flex justify-end gap-3">
-            <button @click="cancelUserAnswer" class="text-xs font-bold text-slate-400 hover:text-slate-600 dark:hover:text-slate-200">取消</button>
-            <button @click="saveUserAnswer" class="h-8 rounded-lg bg-blue-600 px-4 text-xs font-bold text-white shadow-sm transition-all hover:bg-blue-500 dark:bg-indigo-600 dark:hover:bg-indigo-500">完成</button>
-          </div>
-        </div>
-        <div v-else class="text-sm font-bold leading-relaxed text-slate-700 dark:text-slate-300">
-          {{ question.user_answer || '记录你的错因或学习笔记...' }}
-        </div>
-      </div>
-    </div>
   </div>
 </template>
 

--- a/frontend/src/components/QuestionItem.vue
+++ b/frontend/src/components/QuestionItem.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { getQuestionSnippet } from '../utils.js'
+import { ref, watch, nextTick } from 'vue'
+import { getQuestionSnippet, typesetMath } from '../utils.js'
 
 const props = defineProps({
   question: { type: Object, required: true },
@@ -11,7 +12,16 @@ const props = defineProps({
 
 const emit = defineEmits(['click', 'toggle-select'])
 
+const optionsEl = ref(null)
+
 const summary = () => getQuestionSnippet(props.question)
+
+watch(() => props.question.options_json, async (val) => {
+  if (val?.length && optionsEl.value) {
+    await nextTick()
+    typesetMath(optionsEl.value)
+  }
+}, { immediate: true, flush: 'post' })
 
 const tags = () => {
   const all = props.question.knowledge_tags || []
@@ -57,21 +67,32 @@ const statusIcon = (status) => {
             <i class="fa-solid" :class="statusIcon(question.review_status)"></i>
             {{ question.review_status || '待复习' }}
           </span>
-          <span v-else class="ml-auto text-xs font-bold text-slate-400">{{ question.created_at ? new Date(question.created_at).toLocaleDateString() : '' }}</span>
         </div>
 
         <!-- 摘要 -->
         <p class="line-clamp-2 text-sm font-bold leading-relaxed text-slate-700 group-hover:text-slate-900 dark:text-slate-300 dark:group-hover:text-white">{{ summary() }}</p>
 
-        <!-- 底部信息（答案/笔记状态） -->
-        <div class="mt-2 flex flex-wrap items-center gap-2 text-xs" @click.stop>
-          <span v-if="question.answer" class="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-1 font-bold text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-400">
-            <i class="fa-solid fa-circle-check"></i>有答案
-          </span>
-          <span v-if="question.user_answer" class="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-1 font-bold text-blue-600 dark:bg-blue-500/10 dark:text-blue-400">
-            <i class="fa-solid fa-pen-to-square"></i>已记笔记
-          </span>
-          <span v-if="showStatus" class="ml-auto text-xs font-bold text-slate-400">{{ question.created_at ? new Date(question.created_at).toLocaleDateString() : '' }}</span>
+        <!-- 题目图片 -->
+        <div v-if="question.content_json?.some(b => b.block_type === 'image' && b.content)" class="mt-3 flex flex-wrap gap-2">
+          <img
+            v-for="(b, i) in question.content_json.filter(b => b.block_type === 'image' && b.content)"
+            :key="i"
+            :src="b.content"
+            class="max-h-32 rounded-xl border border-slate-100 object-contain dark:border-white/5"
+            @click.stop
+          />
+        </div>
+
+        <!-- 选择题选项 -->
+        <div v-if="question.options_json?.length" ref="optionsEl" class="mt-3 grid grid-cols-2 gap-1.5">
+          <div
+            v-for="(opt, idx) in question.options_json"
+            :key="idx"
+            class="flex items-start gap-2 rounded-lg border border-slate-100 bg-slate-50/50 px-3 py-1.5 text-xs font-bold text-slate-600 dark:border-white/5 dark:bg-white/[0.02] dark:text-slate-400"
+          >
+            <span class="shrink-0 text-slate-400 dark:text-slate-500">{{ String.fromCharCode(65 + idx) }}.</span>
+            <span class="line-clamp-1">{{ String(opt).replace(/^[A-Da-d][.、．]\s*/, '') }}</span>
+          </div>
         </div>
 
         <!-- 扩展插槽（内联编辑等） -->

--- a/frontend/src/components/QuestionItem.vue
+++ b/frontend/src/components/QuestionItem.vue
@@ -30,8 +30,14 @@ const tags = () => {
 
 const statusClass = (status) => {
   if (status === '已掌握') return 'bg-emerald-500/10 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-400 border border-emerald-200/50 dark:border-emerald-500/30'
-  if (status === '复习中') return 'bg-indigo-500/10 text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-400 border border-indigo-200/50 dark:border-indigo-500/30'
-  return 'bg-slate-500/10 text-slate-600 dark:bg-slate-500/20 dark:text-slate-400 border border-slate-200/50 dark:border-slate-500/30'
+  if (status === '复习中') return 'bg-amber-500/10 text-amber-600 dark:bg-amber-500/20 dark:text-amber-400 border border-amber-200/50 dark:border-amber-500/30'
+  return 'bg-rose-500/10 text-rose-600 dark:bg-rose-500/20 dark:text-rose-400 border border-rose-200/50 dark:border-rose-500/30'
+}
+
+const statusColor = (status) => {
+  if (status === '已掌握') return 'text-emerald-500 dark:text-emerald-400'
+  if (status === '复习中') return 'text-amber-500 dark:text-amber-400'
+  return 'text-rose-500 dark:text-rose-400'
 }
 
 const statusIcon = (status) => {
@@ -59,14 +65,11 @@ const statusIcon = (status) => {
       <div class="min-w-0 flex-1">
         <!-- 标签行 -->
         <div class="mb-2 flex flex-wrap items-center gap-2">
+          <!-- 复习状态图标 -->
+          <i v-if="showStatus" class="fa-solid text-sm" :class="[statusIcon(question.review_status), statusColor(question.review_status)]"></i>
           <span v-if="question.subject" class="rounded-full bg-blue-50 px-2 py-1 text-xs font-bold text-blue-600 dark:bg-blue-500/10 dark:text-blue-300">{{ question.subject }}</span>
           <span class="rounded-full bg-slate-100 px-2 py-1 text-xs font-bold uppercase tracking-widest text-slate-500 dark:bg-white/5 dark:text-slate-400">{{ question.question_type }}</span>
           <span v-for="tag in tags()" :key="tag" class="rounded-full border border-indigo-500/20 bg-indigo-500/5 px-2 py-1 text-xs font-bold text-indigo-600 dark:text-indigo-300">{{ tag }}</span>
-          <!-- 复习状态 -->
-          <span v-if="showStatus" class="ml-auto flex items-center gap-1 rounded-full px-2 py-1 text-xs font-bold" :class="statusClass(question.review_status)">
-            <i class="fa-solid" :class="statusIcon(question.review_status)"></i>
-            {{ question.review_status || '待复习' }}
-          </span>
         </div>
 
         <!-- 摘要 -->

--- a/frontend/src/components/SelectionPanel.vue
+++ b/frontend/src/components/SelectionPanel.vue
@@ -2,9 +2,11 @@
 defineProps({
   count: { type: Number, default: 0 },
   visible: { type: Boolean, default: false },
+  exportLabel: { type: String, default: '生成复习卷' },
+  showSave: { type: Boolean, default: false },
 })
 
-const emit = defineEmits(['export', 'clear'])
+const emit = defineEmits(['export', 'save', 'clear'])
 </script>
 
 <template>
@@ -25,18 +27,27 @@ const emit = defineEmits(['export', 'clear'])
           <span class="text-sm font-bold tracking-wider text-slate-700 dark:text-slate-200">已选中题目</span>
         </div>
 
-        <div class="flex items-center gap-4">
+        <div class="flex items-center gap-3">
           <button
             @click="emit('export')"
-            class="inline-flex h-10 items-center justify-center gap-2 rounded-xl bg-blue-600 px-6 text-sm font-bold text-white shadow-sm transition-all hover:bg-blue-700 hover:shadow-blue-500/20 active:scale-95 dark:bg-indigo-600 dark:hover:bg-indigo-500"
+            class="group inline-flex h-10 items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-6 text-[13px] font-black tracking-widest text-slate-900 shadow-sm transition-all hover:border-slate-900 hover:bg-slate-50 dark:border-white/10 dark:bg-slate-900 dark:text-white dark:hover:border-white dark:hover:bg-slate-800"
           >
-            <i class="fa-solid fa-file-export text-sm"></i>
-            生成复习卷
+            <i class="fa-solid fa-file-export transition-transform group-hover:-translate-x-0.5"></i>
+            {{ exportLabel }}
+          </button>
+
+          <button
+            v-if="showSave"
+            @click="emit('save')"
+            class="group inline-flex h-10 items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-6 text-[13px] font-black tracking-widest text-slate-900 shadow-sm transition-all hover:border-slate-900 hover:bg-slate-50 dark:border-white/10 dark:bg-slate-900 dark:text-white dark:hover:border-white dark:hover:bg-slate-800"
+          >
+            <i class="fa-solid fa-database transition-transform group-hover:-translate-y-0.5"></i>
+            导入错题库
           </button>
 
           <button
             @click="emit('clear')"
-            class="inline-flex h-10 items-center justify-center gap-2 rounded-xl border border-slate-200/60 bg-white/60 px-4 text-sm font-bold text-slate-600 transition-all hover:border-rose-200 hover:bg-rose-50 hover:text-rose-600 dark:border-white/10 dark:bg-white/5 dark:text-slate-400 dark:hover:border-rose-500/30 dark:hover:bg-rose-500/10 dark:hover:text-rose-400"
+            class="group inline-flex h-10 items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-6 text-[13px] font-black tracking-widest text-slate-900 shadow-sm transition-all hover:border-slate-900 hover:bg-slate-50 dark:border-white/10 dark:bg-slate-900 dark:text-white dark:hover:border-white dark:hover:bg-slate-800"
           >
             清除
           </button>

--- a/frontend/src/components/SplitLoading.vue
+++ b/frontend/src/components/SplitLoading.vue
@@ -48,16 +48,16 @@
 .loading-overlay {
   position: absolute;
   inset: 0;
-  z-index: 50;
+  z-index: 100;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(255, 255, 255, 0.4);
-  backdrop-filter: blur(12px);
+  background: rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(20px) saturate(180%);
 }
 
 :root.dark .loading-overlay {
-  background: rgba(10, 10, 15, 0.6);
+  background: rgba(10, 10, 15, 0.8);
 }
 
 .loading-content {

--- a/frontend/src/components/StatusBar.vue
+++ b/frontend/src/components/StatusBar.vue
@@ -93,9 +93,6 @@ const modelStatusError = computed(() => {
     class="relative z-20 flex flex-wrap items-center gap-4 py-2 text-sm shrink-0"
   >
     <div class="flex items-center gap-2.5">
-      <div class="flex h-6 w-6 items-center justify-center rounded-lg border border-slate-300 bg-white text-blue-600 shadow-sm backdrop-blur-sm dark:border-white/10 dark:bg-white/5 dark:text-indigo-400">
-        <i class="fa-solid fa-bolt-lightning text-[10px]"></i>
-      </div>
       <span class="text-[11px] font-bold uppercase tracking-[0.15em] text-slate-600 dark:text-slate-400">
         引擎状态
       </span>

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -4,6 +4,7 @@ import { useRouter, useRoute } from 'vue-router'
 import { fileKey, typesetMath as _typesetMathEl } from '../utils.js'
 import * as api from '../api.js'
 import { useAuth } from '../composables/useAuth.js'
+import { usePageTransition } from '../composables/usePageTransition.js'
 // 注意：移除了 AppHeader，因为现在由左侧边栏接管了全局导航功能
 import StatusBar from '../components/StatusBar.vue'
 import StepIndicator from '../components/StepIndicator.vue'
@@ -66,7 +67,8 @@ const currentView = computed({
   },
 })
 
-// ---- 主题 ----
+// ---- 状态定义 ----
+const { loading: globalLoading } = usePageTransition()
 const theme = ref('dark')
 const applyTheme = (nextTheme) => {
   theme.value = nextTheme === 'dark' ? 'dark' : 'light'
@@ -558,8 +560,25 @@ const pageLoading = ref(true)
 onMounted(() => {
   applyTheme('dark')
   document.addEventListener('keydown', onKeydown)
-  doFetchStatus()
-  setTimeout(() => { pageLoading.value = false }, 2000)
+  
+  // 延迟系统状态检查，直到入场加载动画完全结束
+  // 这能确保在动画过程中不会因为网络请求导致掉帧，且视觉上更连贯
+  setTimeout(() => {
+    pageLoading.value = false
+    
+    // 如果全局 loading 已经结束（说明动画已经淡出或不需要淡出），开始检查
+    if (!globalLoading.value) {
+      doFetchStatus()
+    } else {
+      // 否则，监听全局 loading 状态，待其变为 false（即 AppLoading 彻底消失）后触发
+      const unwatch = watch(globalLoading, (val) => {
+        if (!val) {
+          doFetchStatus()
+          unwatch()
+        }
+      })
+    }
+  }, 2000)
 })
 
 onBeforeUnmount(() => {
@@ -652,13 +671,11 @@ onBeforeUnmount(() => {
           </button>
 
           <button
-            @click="currentView = 'review'"
-            class="group relative flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-bold transition-all duration-200"
-            :class="currentView === 'review' ? 'bg-blue-600 text-white shadow-lg shadow-blue-600/20 dark:bg-indigo-500 dark:shadow-indigo-500/20' : 'text-slate-600 hover:bg-slate-100 hover:text-blue-600 dark:text-slate-400 dark:hover:bg-white/5 dark:hover:text-indigo-300'"
+            disabled
+            class="group relative flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-bold cursor-not-allowed opacity-40 text-slate-400 dark:text-slate-600"
           >
-            <i class="fa-solid fa-clock-rotate-left w-5 text-center text-lg transition-transform group-hover:scale-110"></i>
+            <i class="fa-solid fa-clock-rotate-left w-5 text-center text-lg"></i>
             <span>刷题</span>
-            <div v-if="currentView === 'review'" class="absolute right-2 h-1.5 w-1.5 rounded-full bg-white/60"></div>
           </button>
 
         </nav>
@@ -703,7 +720,7 @@ onBeforeUnmount(() => {
           <i class="fa-solid fa-file-arrow-up text-lg"></i>
           <span class="mt-1 text-xs font-bold">录题</span>
         </button>
-        <button @click="currentView = 'review'" class="flex flex-col items-center p-2" :class="currentView === 'review' ? 'text-blue-600 dark:text-indigo-400' : 'text-slate-500 dark:text-slate-400'">
+        <button disabled class="flex flex-col items-center p-2 cursor-not-allowed opacity-40 text-slate-400 dark:text-slate-600">
           <i class="fa-solid fa-clock-rotate-left text-lg"></i>
           <span class="mt-1 text-xs font-bold">刷题</span>
         </button>

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -984,8 +984,8 @@ onBeforeUnmount(() => {
         </div>
       </Transition>
 
-      <!-- AI 分割任务全局遮罩：置于 main 顶层，覆盖除侧边栏外的所有区域 -->
-      <SplitLoading v-if="splitting" />
+      <!-- AI 分割任务全局遮罩：置于 main 顶层，仅在录题视图且正在分割时显示 -->
+      <SplitLoading v-if="splitting && (currentView === 'workspace' || currentView === 'workspace_review')" />
     </main>
 
     <!-- 全局弹窗与通知 -->

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -746,8 +746,9 @@ onBeforeUnmount(() => {
     <!-- ================== 右侧主内容区 ================== -->
     <main class="relative z-10 flex-1 overflow-hidden pb-20 md:pb-0">
 
-      <!-- 视图 1：录题工作台（分两页：上传解析页 / 题目核对页） -->
-        <div v-show="currentView === 'workspace' || currentView === 'workspace_review'" class="relative h-full flex flex-col overflow-hidden">
+      <Transition name="view-fade" mode="out-in">
+        <!-- 视图 1：录题工作台（分两页：上传解析页 / 题目核对页） -->
+        <div v-if="currentView === 'workspace' || currentView === 'workspace_review'" key="workspace" class="relative h-full flex flex-col overflow-hidden">
           <div class="container relative z-10 mx-auto flex h-full min-h-0 max-w-6xl flex-col px-4 py-4 sm:px-8 sm:py-6">
             <Transition name="flip" mode="out-in">
               <!-- 第一页：录题与分析 -->
@@ -846,143 +847,145 @@ onBeforeUnmount(() => {
                 </div>
               </div>
 
-            <!-- 第二页：解析结果核对 -->
-            <div v-else-if="currentView === 'workspace_review'" key="review" class="flex flex-1 flex-col overflow-hidden">
-              <div class="mb-4 flex items-center justify-between pl-2 sm:pl-0 shrink-0">
-                <div class="flex items-center gap-4">
-                  <button
-                    @click="() => { doReset(); currentView = 'workspace' }"
-                    class="group flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200/60 bg-white/60 text-slate-500 backdrop-blur-md transition-all hover:border-blue-500/50 hover:bg-white hover:text-blue-600 dark:border-white/10 dark:bg-white/5 dark:text-slate-400 dark:hover:border-indigo-500/50 dark:hover:text-indigo-300"
-                  >
-                    <i class="fa-solid fa-arrow-left-long transition-transform group-hover:-translate-x-1"></i>
-                  </button>
-                  <div>
-                    <h2 class="text-2xl font-extrabold tracking-tight text-slate-900 sm:text-3xl dark:text-white">
-                      题目数据核对
-                    </h2>
-                    <p class="text-xs font-bold text-slate-400 dark:text-slate-500 mt-1">请确认解析结果的准确性并进行导出或存档</p>
+              <!-- 第二页：解析结果核对 -->
+              <div v-else-if="currentView === 'workspace_review'" key="review" class="flex flex-1 flex-col overflow-hidden">
+                <div class="mb-4 flex items-center justify-between pl-2 sm:pl-0 shrink-0">
+                  <div class="flex items-center gap-4">
+                    <button
+                      @click="() => { doReset(); currentView = 'workspace' }"
+                      class="group flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200/60 bg-white/60 text-slate-500 backdrop-blur-md transition-all hover:border-blue-500/50 hover:bg-white hover:text-blue-600 dark:border-white/10 dark:bg-white/5 dark:text-slate-400 dark:hover:border-indigo-500/50 dark:hover:text-indigo-300"
+                    >
+                      <i class="fa-solid fa-arrow-left-long transition-transform group-hover:-translate-x-1"></i>
+                    </button>
+                    <div>
+                      <h2 class="text-2xl font-extrabold tracking-tight text-slate-900 sm:text-3xl dark:text-white">
+                        题目数据核对
+                      </h2>
+                      <p class="text-xs font-bold text-slate-400 dark:text-slate-500 mt-1">请确认解析结果的准确性并进行导出或存档</p>
+                    </div>
+                  </div>
+                  <div class="flex items-center gap-4">
+                    <div class="flex items-center gap-1 rounded-xl border border-slate-100 bg-white/50 p-1 shadow-sm backdrop-blur-md dark:border-white/5 dark:bg-slate-800/50">
+                      <button
+                        type="button"
+                        class="flex items-center gap-2 rounded-lg px-4 py-2 text-xs font-black text-slate-600 hover:bg-white hover:text-blue-600 hover:shadow-sm dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-indigo-300"
+                        @click="selectAll"
+                      >
+                        全选
+                      </button>
+                      <button
+                        type="button"
+                        class="flex items-center gap-2 rounded-lg px-4 py-2 text-xs font-black text-slate-600 hover:bg-white hover:text-rose-500 hover:shadow-sm dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-rose-400"
+                        @click="deselectAll"
+                      >
+                        清空
+                      </button>
+                    </div>
+                    <div class="flex h-10 items-center gap-2 rounded-xl bg-slate-900 px-4 text-xs font-black text-white shadow-md dark:bg-white dark:text-slate-900 dark:shadow-none">
+                      <i class="fa-solid fa-square-check text-blue-400"></i>
+                      <span class="tracking-widest">已选 {{ selectedIds.size }} 项</span>
+                    </div>
                   </div>
                 </div>
-                <div class="flex items-center gap-4">
-                  <div class="flex items-center gap-1 rounded-xl border border-slate-100 bg-white/50 p-1 shadow-sm backdrop-blur-md dark:border-white/5 dark:bg-slate-800/50">
-                    <button
-                      type="button"
-                      class="flex items-center gap-2 rounded-lg px-4 py-2 text-xs font-black text-slate-600 hover:bg-white hover:text-blue-600 hover:shadow-sm dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-indigo-300"
-                      @click="selectAll"
-                    >
-                      全选
-                    </button>
-                    <button
-                      type="button"
-                      class="flex items-center gap-2 rounded-lg px-4 py-2 text-xs font-black text-slate-600 hover:bg-white hover:text-rose-500 hover:shadow-sm dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-rose-400"
-                      @click="deselectAll"
-                    >
-                      清空
-                    </button>
-                  </div>
-                  <div class="flex h-10 items-center gap-2 rounded-xl bg-slate-900 px-4 text-xs font-black text-white shadow-md dark:bg-white dark:text-slate-900 dark:shadow-none">
-                    <i class="fa-solid fa-square-check text-blue-400"></i>
-                    <span class="tracking-widest">已选 {{ selectedIds.size }} 项</span>
-                  </div>
-                </div>
-              </div>
 
-              <div class="flex-1 overflow-y-auto pr-2 custom-scrollbar py-2">
-                <QuestionList
-                  ref="questionListRef"
-                  :questions="questions"
-                  :selected-ids="selectedIds"
-                  @toggle-select="toggleQuestion"
-                  @select-all="selectAll"
-                  @deselect-all="deselectAll"
-                  @open-image="openModal"
-                  @reorder="reorderQuestions"
+                <div class="flex-1 overflow-y-auto pr-2 custom-scrollbar py-2">
+                  <QuestionList
+                    ref="questionListRef"
+                    :questions="questions"
+                    :selected-ids="selectedIds"
+                    @toggle-select="toggleQuestion"
+                    @select-all="selectAll"
+                    @deselect-all="deselectAll"
+                    @open-image="openModal"
+                    @reorder="reorderQuestions"
+                  />
+                </div>
+
+                <ActionBar
+                  class="shrink-0 border-t border-slate-200/60 pt-6 dark:border-white/5"
+                  :split-enabled="false"
+                  :export-enabled="exportEnabled"
+                  :splitting="false"
+                  :split-completed="true"
+                  @export="doExport"
+                  @save-to-db="doSaveToDb"
                 />
               </div>
-
-              <ActionBar
-                class="shrink-0 border-t border-slate-200/60 pt-6 dark:border-white/5"
-                :split-enabled="false"
-                :export-enabled="exportEnabled"
-                :splitting="false"
-                :split-completed="true"
-                @export="doExport"
-                @save-to-db="doSaveToDb"
-              />
-            </div>
             </Transition>
-          </div>
 
-          <!-- AI 分割任务全局遮罩 -->
-          <SplitLoading v-if="splitting" />
+          </div>
         </div>
 
-      <!-- 视图 2：待复习 -->
-      <div v-show="currentView === 'review'" class="h-full">
-        <ReviewView
-          :theme="theme"
-          :visible="currentView === 'review'"
-          @go-workspace="currentView = 'workspace'"
-          @push-toast="pushToast"
-          @open-image="openModal"
-          @start-chat="openChat"
-        />
-      </div>
+        <!-- 视图 2：待复习 -->
+        <div v-else-if="currentView === 'review'" key="review_view" class="h-full">
+          <ReviewView
+            :theme="theme"
+            :visible="currentView === 'review'"
+            @go-workspace="currentView = 'workspace'"
+            @push-toast="pushToast"
+            @open-image="openModal"
+            @start-chat="openChat"
+          />
+        </div>
 
-      <!-- 视图 3：数据面板 -->
-      <div v-show="currentView === 'dashboard'" class="h-full">
-        <Dashboard
-          :theme="theme"
-          :visible="currentView === 'dashboard'"
-          @go-workspace="currentView = 'workspace'"
-          @push-toast="pushToast"
-        />
-      </div>
+        <!-- 视图 3：数据面板 -->
+        <div v-else-if="currentView === 'dashboard'" key="dashboard_view" class="h-full">
+          <Dashboard
+            :theme="theme"
+            :visible="currentView === 'dashboard'"
+            @go-workspace="currentView = 'workspace'"
+            @push-toast="pushToast"
+          />
+        </div>
 
-      <!-- 视图 4：错题库 -->
-      <div v-show="currentView === 'error-bank'" class="h-full">
-        <ErrorBank
-          ref="errorBankRef"
-          :theme="theme"
-          :visible="currentView === 'error-bank'"
-          @go-workspace="currentView = 'workspace'"
-          @push-toast="pushToast"
-          @open-image="openModal"
-          @start-chat="openChat"
-        />
-      </div>
+        <!-- 视图 4：错题库 -->
+        <div v-else-if="currentView === 'error-bank'" key="error_bank_view" class="h-full">
+          <ErrorBank
+            ref="errorBankRef"
+            :theme="theme"
+            :visible="currentView === 'error-bank'"
+            @go-workspace="currentView = 'workspace'"
+            @push-toast="pushToast"
+            @open-image="openModal"
+            @start-chat="openChat"
+          />
+        </div>
 
-      <!-- 视图 5：分割历史 -->
-      <div v-show="currentView === 'split-history'" class="h-full">
-        <SplitHistory
-          :theme="theme"
-          :visible="currentView === 'split-history'"
-          @push-toast="pushToast"
-          @open-image="openModal"
-          @load-record="handleLoadRecord"
-          @go-workspace="currentView = splitCompleted ? 'workspace_review' : 'workspace'"
-        />
-      </div>
+        <!-- 视图 5：分割历史 -->
+        <div v-else-if="currentView === 'split-history'" key="split_history_view" class="h-full">
+          <SplitHistory
+            :theme="theme"
+            :visible="currentView === 'split-history'"
+            @push-toast="pushToast"
+            @open-image="openModal"
+            @load-record="handleLoadRecord"
+            @go-workspace="currentView = splitCompleted ? 'workspace_review' : 'workspace'"
+          />
+        </div>
 
-      <!-- 视图 6：系统设置 -->
-      <div v-show="currentView === 'settings'" class="h-full">
-        <SettingsView
-          :visible="currentView === 'settings'"
-          @saved="doFetchStatus"
-        />
-      </div>
+        <!-- 视图 6：系统设置 -->
+        <div v-else-if="currentView === 'settings'" key="settings_view" class="h-full">
+          <SettingsView
+            :visible="currentView === 'settings'"
+            @saved="doFetchStatus"
+          />
+        </div>
 
-      <!-- 视图 7：AI 辅导对话 -->
-      <div v-show="currentView === 'chat'" class="h-full">
-        <ChatView
-          v-if="chatActive"
-          :session-id="chatSessionId"
-          :question="chatQuestion"
-          :model-provider="selectedProvider"
-          :model-name="selectedModel"
-          @back="backToErrorBank"
-        />
-      </div>
+        <!-- 视图 7：AI 辅导对话 -->
+        <div v-else-if="currentView === 'chat'" key="chat_view" class="h-full">
+          <ChatView
+            v-if="chatActive"
+            :session-id="chatSessionId"
+            :question="chatQuestion"
+            :model-provider="selectedProvider"
+            :model-name="selectedModel"
+            @back="backToErrorBank"
+          />
+        </div>
+      </Transition>
+
+      <!-- AI 分割任务全局遮罩：置于 main 顶层，覆盖除侧边栏外的所有区域 -->
+      <SplitLoading v-if="splitting" />
     </main>
 
     <!-- 全局弹窗与通知 -->
@@ -1069,6 +1072,33 @@ onBeforeUnmount(() => {
 @keyframes wsLoadProgress {
   from { width: 0%; }
   to   { width: 100%; }
+}
+
+/* 视图切换：极简淡入淡出 (Simple Fade) */
+.view-fade-enter-active,
+.view-fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.view-fade-enter-from,
+.view-fade-leave-to {
+  opacity: 0;
+}
+
+/* 工作台内部页面切换：左右滑动淡入 (Flip) */
+.flip-enter-active,
+.flip-leave-active {
+  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.flip-enter-from {
+  opacity: 0;
+  transform: translateX(20px);
+}
+
+.flip-leave-to {
+  opacity: 0;
+  transform: translateX(-20px);
 }
 
 </style>

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -949,6 +949,7 @@ onBeforeUnmount(() => {
             :question="chatQuestion"
             :model-provider="selectedProvider"
             :model-name="selectedModel"
+            :username="currentUser?.username"
             @back="backToErrorBank"
           />
         </div>

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -12,6 +12,7 @@ import FileList from '../components/FileList.vue'
 import FileUploader from '../components/FileUploader.vue'
 import QuestionList from '../components/QuestionList.vue'
 import ActionBar from '../components/ActionBar.vue'
+import SelectionPanel from '../components/SelectionPanel.vue'
 import SplitLoading from '../components/SplitLoading.vue'
 import ImageModal from '../components/ImageModal.vue'
 import ToastContainer from '../components/ToastContainer.vue'
@@ -864,31 +865,9 @@ onBeforeUnmount(() => {
                       <p class="text-xs font-bold text-slate-400 dark:text-slate-500 mt-1">请确认解析结果的准确性并进行导出或存档</p>
                     </div>
                   </div>
-                  <div class="flex items-center gap-4">
-                    <div class="flex items-center gap-1 rounded-xl border border-slate-100 bg-white/50 p-1 shadow-sm backdrop-blur-md dark:border-white/5 dark:bg-slate-800/50">
-                      <button
-                        type="button"
-                        class="flex items-center gap-2 rounded-lg px-4 py-2 text-xs font-black text-slate-600 hover:bg-white hover:text-blue-600 hover:shadow-sm dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-indigo-300"
-                        @click="selectAll"
-                      >
-                        全选
-                      </button>
-                      <button
-                        type="button"
-                        class="flex items-center gap-2 rounded-lg px-4 py-2 text-xs font-black text-slate-600 hover:bg-white hover:text-rose-500 hover:shadow-sm dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-rose-400"
-                        @click="deselectAll"
-                      >
-                        清空
-                      </button>
-                    </div>
-                    <div class="flex h-10 items-center gap-2 rounded-xl bg-slate-900 px-4 text-xs font-black text-white shadow-md dark:bg-white dark:text-slate-900 dark:shadow-none">
-                      <i class="fa-solid fa-square-check text-blue-400"></i>
-                      <span class="tracking-widest">已选 {{ selectedIds.size }} 项</span>
-                    </div>
-                  </div>
                 </div>
 
-                <div class="flex-1 overflow-y-auto pr-2 custom-scrollbar py-2">
+                <div class="flex-1 overflow-y-auto pr-2 custom-scrollbar py-2 pb-24">
                   <QuestionList
                     ref="questionListRef"
                     :questions="questions"
@@ -901,15 +880,6 @@ onBeforeUnmount(() => {
                   />
                 </div>
 
-                <ActionBar
-                  class="shrink-0 border-t border-slate-200/60 pt-6 dark:border-white/5"
-                  :split-enabled="false"
-                  :export-enabled="exportEnabled"
-                  :splitting="false"
-                  :split-completed="true"
-                  @export="doExport"
-                  @save-to-db="doSaveToDb"
-                />
               </div>
             </Transition>
 
@@ -983,6 +953,17 @@ onBeforeUnmount(() => {
           />
         </div>
       </Transition>
+
+      <!-- workspace_review 浮动选择面板 -->
+      <SelectionPanel
+        :visible="currentView === 'workspace_review'"
+        :count="selectedIds.size"
+        export-label="导出错题本"
+        :show-save="true"
+        @export="doExport"
+        @save="doSaveToDb"
+        @clear="deselectAll"
+      />
 
       <!-- AI 分割任务全局遮罩：置于 main 顶层，仅在录题视图且正在分割时显示 -->
       <SplitLoading v-if="splitting && (currentView === 'workspace' || currentView === 'workspace_review')" />


### PR DESCRIPTION
## Summary

- **错题库操作菜单重构**：移除点击触发的下拉菜单，改为 hover 触发，使用 `Teleport` 渲染至 `body` 解决 `backdrop-blur` 层叠上下文导致的 z-index 问题
- **题目状态指示**：复习状态图标（红/黄/绿）移至标签行最前，无容器包裹，与科目标签同行显示
- **题目编辑能力增强**：支持同时编辑题目内容与正确答案（双 ByteMD 编辑器），新增后端 `PATCH /api/question/<id>` 端点
- **QuestionItem 渲染增强**：选择题选项内联展示（2列网格 + MathJax 渲染），图片按 `content_json` 顺序图文混排
- **workspace/review 操作栏统一**：替换 ActionBar 为浮动 `SelectionPanel`，玻璃态样式，添加出现/消失过渡动画
- **用户头像统一**：Chat 页面头像与侧边栏保持一致（渐变圆圈 + 用户名首字母）
- **加载时序优化**：页面加载动画结束后再检查引擎/模型状态
- **Bug 修复**：擦除手写字迹参数被忽略、切换视图时加载遮罩未消失