### PR TITLE
feat(frontend): 工作台交互优化与Landing深色主题

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "backend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/frontend/src/views/LandingView.vue
+++ b/frontend/src/views/LandingView.vue
@@ -2,7 +2,10 @@
 import { ref, onMounted, onUnmounted, nextTick } from 'vue'
 import { useTheme } from '../composables/useTheme.js'
 
-const { initTheme } = useTheme()
+const { initTheme, setTheme, isDark } = useTheme()
+
+// Landing 页固定深色：记住用户原始主题，离开时恢复
+let savedTheme = null
 
 import LandingNav from '../components/landing/LandingNav.vue'
 import LandingHero from '../components/landing/LandingHero.vue'
@@ -210,6 +213,10 @@ function setupRevealObserver() {
 onMounted(async () => {
   initTheme()
 
+  // Landing 页强制深色模式
+  savedTheme = isDark.value ? 'dark' : 'light'
+  if (!isDark.value) setTheme(true)
+
   // 不再锁定 body overflow，中间页面允许正常滚动
 
   await nextTick()
@@ -243,6 +250,9 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
+  // 离开 Landing 页时恢复用户原有主题
+  if (savedTheme === 'light') setTheme(false)
+
   if (wheelUnlisten) wheelUnlisten()
   if (scrollUnlisten) scrollUnlisten()
   if (revealObserver) revealObserver.disconnect()

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -241,10 +241,13 @@ function closeChatMenu() {
   chatMenuOpenId.value = null
 }
 
-function startRenameChat(s) {
+async function startRenameChat(s) {
   chatMenuOpenId.value = null
   renamingChatId.value = s.id
   renameText.value = s.title
+  await nextTick()
+  const input = document.querySelector('input[data-rename-input]')
+  if (input) { input.focus(); input.selectionStart = input.selectionEnd = input.value.length }
 }
 
 async function confirmRenameChat(s) {
@@ -834,12 +837,12 @@ onBeforeUnmount(() => {
             <input
               v-if="renamingChatId === s.id"
               v-model="renameText"
+              data-rename-input
               @click.stop
               @keydown.enter="confirmRenameChat(s)"
               @keydown.escape="renamingChatId = null"
               @blur="confirmRenameChat(s)"
               class="flex-1 min-w-0 bg-transparent text-xs outline-none border-b border-blue-500 dark:border-indigo-400 py-0.5"
-              autofocus
             />
             <span v-else class="flex-1 truncate text-xs">{{ s.title }}</span>
 

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -237,6 +237,9 @@ const renameText = ref('')
 function toggleChatMenu(id) {
   chatMenuOpenId.value = chatMenuOpenId.value === id ? null : id
 }
+function closeChatMenu() {
+  chatMenuOpenId.value = null
+}
 
 function startRenameChat(s) {
   chatMenuOpenId.value = null
@@ -682,6 +685,7 @@ const pageLoading = ref(true)
 onMounted(() => {
   initTheme()
   document.addEventListener('keydown', onKeydown)
+  document.addEventListener('click', closeChatMenu)
   loadAiChatSessions()
 
   // 刷新时如果落在 /workspace/review 但没有数据，重定向回上传页
@@ -712,6 +716,7 @@ onMounted(() => {
 onBeforeUnmount(() => {
   stopFakeProgress()
   document.removeEventListener('keydown', onKeydown)
+  document.removeEventListener('click', closeChatMenu)
 })
 </script>
 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,6 @@
 /** @type {import('tailwindcss').Config} */
+import typography from '@tailwindcss/typography'
+
 export default {
   // 在 content 数组中补充 "./app.html"
   content: ["./index.html", "./app.html", "./src/**/*.{vue,js,ts,jsx,tsx}"],
@@ -7,6 +9,6 @@ export default {
     extend: {},
   },
   plugins: [
-    require('@tailwindcss/typography'),
+    typography,
   ],
 }


### PR DESCRIPTION
## Summary
- 强制 Landing 页使用深色主题，离开时恢复用户原主题设置
- 添加点击外部区域关闭聊天菜单功能
- 修复重命名聊天时输入框自动聚焦问题

## Test plan
- [ ] 验证 Landing 页始终显示深色主题，进入工作台后恢复原主题
- [ ] 验证点击聊天菜单外部区域可关闭菜单
- [ ] 验证重命名聊天时输入框正确聚焦