### PR TITLE
fix(ui): 登录按钮/输入框/Loading 样式统一

### DIFF
--- a/frontend/src/components/LoginView.vue
+++ b/frontend/src/components/LoginView.vue
@@ -2,6 +2,7 @@
 import { ref, reactive } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuth } from '../composables/useAuth.js'
+import LandingButton from './landing/LandingButton.vue'
 
 const router = useRouter()
 const { currentUser } = useAuth()
@@ -74,27 +75,9 @@ async function handleLogin() {
       <i class="fas fa-circle-exclamation text-xs"></i>{{ error }}
     </p>
 
-    <button
-      type="submit"
-      :disabled="loading"
-      class="auth-submit-btn w-full h-10 text-sm font-medium text-white rounded-xl transition-all duration-200 flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
-    >
+    <LandingButton variant="cta" type="submit" class="w-full" :disabled="loading">
       <i v-if="loading" class="fas fa-spinner fa-spin text-xs"></i>
       <span>{{ loading ? '登录中...' : '登录' }}</span>
-    </button>
+    </LandingButton>
   </form>
 </template>
-
-<style scoped>
-.auth-submit-btn {
-  background: linear-gradient(to bottom, rgba(129, 115, 223, 0.9), rgba(99, 87, 199, 0.9));
-  border: none;
-  box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.12);
-}
-.auth-submit-btn:hover:not(:disabled) {
-  background: linear-gradient(to bottom, rgba(145, 132, 235, 0.95), rgba(113, 100, 212, 0.95));
-  box-shadow:
-    inset 0 1px 0 0 rgba(255, 255, 255, 0.15),
-    0 0 20px 0 rgba(129, 115, 223, 0.25);
-}
-</style>

--- a/frontend/src/components/RegisterView.vue
+++ b/frontend/src/components/RegisterView.vue
@@ -2,6 +2,7 @@
 import { ref, reactive } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuth } from '../composables/useAuth.js'
+import LandingButton from './landing/LandingButton.vue'
 
 const router = useRouter()
 const { currentUser } = useAuth()
@@ -113,27 +114,9 @@ async function handleRegister() {
       <i class="fas fa-circle-check text-xs"></i>{{ success }}
     </p>
 
-    <button
-      type="submit"
-      :disabled="loading || passwordMismatch()"
-      class="auth-submit-btn w-full h-10 text-sm font-medium text-white rounded-xl transition-all duration-200 flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
-    >
+    <LandingButton variant="cta" type="submit" class="w-full" :disabled="loading || passwordMismatch()">
       <i v-if="loading" class="fas fa-spinner fa-spin text-xs"></i>
       <span>{{ loading ? '注册中...' : '创建账户' }}</span>
-    </button>
+    </LandingButton>
   </form>
 </template>
-
-<style scoped>
-.auth-submit-btn {
-  background: linear-gradient(to bottom, rgba(129, 115, 223, 0.9), rgba(99, 87, 199, 0.9));
-  border: none;
-  box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.12);
-}
-.auth-submit-btn:hover:not(:disabled) {
-  background: linear-gradient(to bottom, rgba(145, 132, 235, 0.95), rgba(113, 100, 212, 0.95));
-  box-shadow:
-    inset 0 1px 0 0 rgba(255, 255, 255, 0.15),
-    0 0 20px 0 rgba(129, 115, 223, 0.25);
-}
-</style>

--- a/frontend/src/components/landing/LandingButton.vue
+++ b/frontend/src/components/landing/LandingButton.vue
@@ -6,6 +6,8 @@ const props = defineProps({
   size: { type: String, default: 'md' },            // sm | md
   to: { type: String, default: '' },                // RouterLink 目标
   href: { type: String, default: '' },              // 普通链接
+  type: { type: String, default: 'button' },        // button | submit
+  disabled: { type: Boolean, default: false },
 })
 
 const tag = computed(() => {
@@ -17,7 +19,7 @@ const tag = computed(() => {
 const bindProps = computed(() => {
   if (props.to) return { to: props.to }
   if (props.href) return { href: props.href }
-  return { type: 'button' }
+  return { type: props.type, disabled: props.disabled }
 })
 </script>
 
@@ -26,7 +28,7 @@ const bindProps = computed(() => {
     :is="tag"
     v-bind="bindProps"
     :class="[
-      'landing-btn relative overflow-hidden inline-flex items-center justify-center font-medium gap-2 transition-all duration-200',
+      'landing-btn relative overflow-hidden inline-flex items-center justify-center font-medium gap-2 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed',
       size === 'sm' ? 'h-8 px-4 text-xs rounded-lg' : 'h-10 px-6 text-sm rounded-xl',
       {
         'landing-btn--primary': variant === 'primary',

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -6,6 +6,7 @@ import * as api from '../api.js'
 import { useAuth } from '../composables/useAuth.js'
 import { usePageTransition } from '../composables/usePageTransition.js'
 // 注意：移除了 AppHeader，因为现在由左侧边栏接管了全局导航功能
+import BrandLogo from '../components/BrandLogo.vue'
 import StatusBar from '../components/StatusBar.vue'
 import StepIndicator from '../components/StepIndicator.vue'
 import FileList from '../components/FileList.vue'
@@ -727,16 +728,11 @@ onBeforeUnmount(() => {
   <div class="flex h-screen w-full overflow-hidden bg-slate-50 font-sans text-slate-900 dark:bg-[#05050A] dark:text-slate-300">
 
     <Transition name="ws-loading-fade">
-      <div v-if="pageLoading" class="fixed inset-0 z-[200] flex flex-col items-center justify-center gap-8 bg-[#05050A]">
-        <div class="relative">
-          <div class="absolute inset-0 rounded-2xl bg-indigo-500/40 blur-xl"></div>
-          <div class="relative bg-gradient-to-br from-indigo-500 to-indigo-700 p-3.5 rounded-2xl shadow-lg border border-white/10">
-            <img src="/logo.svg" class="w-9 h-9 brightness-0 invert" alt="logo" />
-          </div>
-        </div>
+      <div v-if="pageLoading" class="fixed inset-0 z-[200] flex flex-col items-center justify-center gap-8 bg-[#0A0A0F]">
+        <BrandLogo size="lg" breathe />
         <div class="w-48">
           <div class="h-0.5 w-full rounded-full bg-white/10 overflow-hidden">
-            <div class="h-full rounded-full bg-gradient-to-r from-indigo-500 to-blue-400 ws-loading-bar"></div>
+            <div class="h-full rounded-full ws-loading-bar" style="background: linear-gradient(to right, rgba(129,115,223,0.8), rgba(99,87,199,0.8));"></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- 登录/注册按钮替换为 LandingButton 组件（网格纹理 + 品牌紫渐变）
- LandingButton 新增 type/disabled prop，支持表单提交场景
- 输入框改为 Linear 风格渐变背景 + autofill 样式覆盖
- WorkspaceView loading 替换为 BrandLogo 组件，与全局 AppLoading 风格统一

## Test plan
- [ ] 登录/注册按钮显示网格纹理
- [ ] 表单提交功能正常
- [ ] 输入框渐变背景可见
- [ ] 进入工作台 loading 使用 BrandLogo