### PR TITLE
fix(auth+split): 验证码频率限制实时倒计时 + 分割历史按用户隔离

### DIFF
--- a/backend/db/crud/split_records.py
+++ b/backend/db/crud/split_records.py
@@ -69,13 +69,13 @@ def _cleanup_old_split_records(db: Session):
 def get_recent_split_records(db, limit: int = 10, user_id=None):
     """获取最近 N 条分割记录（不加载 questions_json 大字段）"""
     from sqlalchemy.orm import defer
-    return (
+    query = (
         db.query(SplitRecord)
         .options(defer(SplitRecord.questions_json))
-        .order_by(SplitRecord.created_at.desc())
-        .limit(limit)
-        .all()
     )
+    if user_id is not None:
+        query = query.filter(SplitRecord.user_id == user_id)
+    return query.order_by(SplitRecord.created_at.desc()).limit(limit).all()
 
 
 def get_split_record_by_id(db: Session, record_id: int) -> Optional[SplitRecord]:

--- a/frontend/src/components/auth/RegisterView.vue
+++ b/frontend/src/components/auth/RegisterView.vue
@@ -15,7 +15,9 @@ const form = reactive({ username: '', email: '', password: '', confirm: '', code
 
 const sendingCode = ref(false)
 const countdown = ref(0)
+const rateLimitCountdown = ref(0)
 let countdownTimer = null
+let rateLimitTimer = null
 let sendDebounceTimer = null
 
 const passwordMismatch = () => form.confirm && form.password !== form.confirm
@@ -39,8 +41,32 @@ function startCountdown(seconds = 60) {
   }, 1000)
 }
 
+function clearRateLimitCountdown() {
+  if (rateLimitTimer) {
+    clearInterval(rateLimitTimer)
+    rateLimitTimer = null
+  }
+}
+
+function startRateLimitCountdown(seconds) {
+  clearRateLimitCountdown()
+  rateLimitCountdown.value = seconds
+  error.value = `发送过于频繁，请 ${seconds} 秒后再试`
+  rateLimitTimer = setInterval(() => {
+    rateLimitCountdown.value -= 1
+    if (rateLimitCountdown.value <= 0) {
+      clearRateLimitCountdown()
+      rateLimitCountdown.value = 0
+      error.value = ''
+    } else {
+      error.value = `发送过于频繁，请 ${rateLimitCountdown.value} 秒后再试`
+    }
+  }, 1000)
+}
+
 async function handleSendCode() {
   error.value = ''
+  clearRateLimitCountdown()
   if (sendingCode.value || countdown.value > 0) return
   const email = (form.email || '').trim()
   if (!email || !email.includes('@')) {
@@ -60,7 +86,14 @@ async function handleSendCode() {
       })
       const data = await res.json().catch(() => ({}))
       if (!res.ok) {
-        error.value = data.error || '发送失败'
+        // 429 频率限制：解析剩余秒数，启动错误提示倒计时
+        if (res.status === 429) {
+          const match = (data.error || '').match(/(\d+)\s*秒/)
+          const wait = match ? parseInt(match[1], 10) : 30
+          startRateLimitCountdown(wait)
+        } else {
+          error.value = data.error || '发送失败'
+        }
         return
       }
       success.value = '验证码已发送到邮箱，请查收'
@@ -108,6 +141,7 @@ async function handleRegister() {
 
 onBeforeUnmount(() => {
   clearCountdown()
+  clearRateLimitCountdown()
   if (sendDebounceTimer) clearTimeout(sendDebounceTimer)
 })
 </script>


### PR DESCRIPTION
## Summary
- 注册页发送验证码收到 429 频率限制时，错误提示秒数实时递减（如"请 20 秒后再试"→"请 19 秒后再试"...），倒计时结束自动清除提示
- 修复 `get_recent_split_records` 未按 `user_id` 过滤的 bug，新注册用户不再看到其他用户的分割历史（closes xiaozhejiya/error_correction#97）

## Test plan
- [x] 注册页连续点击"发送验证码"触发 429，观察秒数是否实时递减
- [x] 倒计时归零后错误提示自动消失
- [x] 新注册用户登录后分割历史为空
- [x] 已有用户只能看到自己的分割记录