### PR TITLE
refactor: 首页深浅色切换功能及浅色模式适配

### DIFF
--- a/frontend/src/components/base/BaseButton.vue
+++ b/frontend/src/components/base/BaseButton.vue
@@ -70,9 +70,32 @@ const bindProps = computed(() => {
   border-top-color: rgba(255, 255, 255, 0.15);
   border-bottom-color: rgba(255, 255, 255, 0.03);
 }
+:root.dark .home-btn--secondary {
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-top-color: rgba(255, 255, 255, 0.15);
+  border-bottom-color: rgba(255, 255, 255, 0.03);
+}
+:root:not(.dark) .home-btn--secondary {
+  background: #ffffff;
+  color: rgba(0, 0, 0, 0.75);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
 .home-btn--secondary:hover {
   background: rgba(255, 255, 255, 0.08);
   color: rgba(255, 255, 255, 0.8);
+}
+:root.dark .home-btn--secondary:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.8);
+}
+:root:not(.dark) .home-btn--secondary:hover {
+  background: #f9fafb;
+  color: rgba(0, 0, 0, 0.9);
+  border-color: rgba(0, 0, 0, 0.15);
 }
 
 /* ── CTA: 更强的品牌色，用于转化区 ── */

--- a/frontend/src/components/home/FeatureCard.vue
+++ b/frontend/src/components/home/FeatureCard.vue
@@ -31,11 +31,14 @@ const props = defineProps({
     :class="spanClass"
     :style="{ transitionDelay: delay }"
   >
-    <!-- 默认状态：灰色 Linear 渐变边框层 -->
-    <div class="absolute inset-0 bg-gradient-to-br from-white/[0.12] via-white/[0.04] to-transparent"></div>
+    <!-- 默认状态：灰色 Linear 渐变边框层 (去除浅色模式下的渐变边框，改用内部阴影和 border) -->
+    <div class="absolute inset-0 bg-transparent dark:bg-gradient-to-br dark:from-white/[0.12] dark:via-white/[0.04] dark:to-transparent transition-colors duration-300"></div>
+
+    <!-- Hover 状态下的发光背景层 (浅色模式下增加主题色微光) -->
+    <div class="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 bg-gradient-to-br from-indigo-500/15 via-violet-500/5 to-transparent dark:from-indigo-500/10 dark:via-violet-500/5 dark:to-transparent z-0"></div>
 
     <!-- 卡片主体背景层 — brand-btn 风格白玻璃 -->
-    <div class="relative h-full w-full rounded-[19px] p-6 flex flex-col items-start text-left transition-all duration-500 overflow-hidden" style="background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.08); border-top-color: rgba(255,255,255,0.15); border-bottom-color: rgba(255,255,255,0.03);">
+    <div class="feature-card-inner relative h-full w-full rounded-[19px] p-6 flex flex-col items-start text-left transition-all duration-500 overflow-hidden">
 
       <!-- 图标容器（BaseLogo 风格） -->
       <div class="feature-icon relative z-10 mb-4 flex h-10 w-10 items-center justify-center rounded-xl overflow-hidden">
@@ -44,13 +47,47 @@ const props = defineProps({
       </div>
       
       <!-- 文字内容 -->
-      <h3 class="relative z-10 mb-2 text-base font-semibold text-white/90 group-hover:text-white transition-colors duration-300">{{ title }}</h3>
-      <p class="relative z-10 text-sm leading-relaxed text-white/40 group-hover:text-white/60 transition-colors duration-300">{{ desc }}</p>
+      <h3 class="relative z-10 mb-2 text-base font-semibold text-gray-900 group-hover:text-gray-950 dark:text-white/90 dark:group-hover:text-white transition-colors duration-300">{{ title }}</h3>
+      <p class="relative z-10 text-sm leading-relaxed text-gray-500 group-hover:text-gray-700 dark:text-white/40 dark:group-hover:text-white/60 transition-colors duration-300">{{ desc }}</p>
     </div>
   </div>
 </template>
 
 <style scoped>
+.feature-card-inner {
+  background: #ffffff;
+  border: 1px solid rgba(0,0,0,0.06);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -2px rgba(0, 0, 0, 0.05);
+}
+:root.dark .feature-card-inner {
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-top-color: rgba(255,255,255,0.15);
+  border-bottom-color: rgba(255,255,255,0.03);
+  box-shadow: none;
+}
+
+.feature-card {
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.feature-card:hover {
+  transform: translateY(-4px);
+}
+
+.feature-card:hover .feature-card-inner {
+  background: rgba(255,255,255,0.9);
+  border-color: rgba(129, 115, 223, 0.4);
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.05), 0 8px 10px -6px rgba(0, 0, 0, 0.01), 0 0 0 1px rgba(129, 115, 223, 0.2);
+}
+:root.dark .feature-card:hover .feature-card-inner {
+  background: rgba(255,255,255,0.08);
+  border-color: rgba(255,255,255,0.08);
+  border-top-color: rgba(255,255,255,0.15);
+  border-bottom-color: rgba(255,255,255,0.03);
+  box-shadow: none;
+}
+
 .feature-icon {
   background: linear-gradient(to bottom, rgba(129, 115, 223, 0.9), rgba(99, 87, 199, 0.9));
   box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.12);

--- a/frontend/src/components/home/HomeFooter.vue
+++ b/frontend/src/components/home/HomeFooter.vue
@@ -7,20 +7,26 @@ import BaseButton from '@/components/base/BaseButton.vue'
 </script>
 
 <template>
-  <section id="cta" class="relative z-10 flex flex-col items-center justify-center py-32 px-6 overflow-hidden min-h-[70vh]">
+  <section id="cta" class="relative z-10 flex flex-col items-center justify-center py-32 px-6 overflow-hidden min-h-[70vh] bg-slate-50 dark:bg-transparent transition-colors duration-200">
     <!-- 底部中心光晕 -->
     <div class="absolute bottom-0 left-1/2 -translate-x-1/2 w-[80vw] h-[50vh] pointer-events-none z-0">
-      <div class="absolute inset-0 bg-indigo-500/10 blur-[120px] rounded-[100%] transform translate-y-1/2"></div>
-      <div class="absolute inset-0 bg-violet-500/5 blur-[150px] rounded-[100%] transform translate-y-1/2 scale-150"></div>
+      <div class="absolute inset-0 bg-indigo-500/20 dark:bg-indigo-500/10 blur-[120px] rounded-[100%] transform translate-y-1/2 transition-colors duration-200"></div>
+      <div class="absolute inset-0 bg-violet-500/10 dark:bg-violet-500/5 blur-[150px] rounded-[100%] transform translate-y-1/2 scale-150 transition-colors duration-200"></div>
     </div>
 
     <!-- CTA -->
     <div class="flex-1 flex flex-col items-center justify-center text-center relative z-10 w-full">
-      <h2 class="reveal text-4xl sm:text-5xl font-semibold tracking-tight mb-6 text-transparent bg-clip-text animate-gradient-sweep" style="
-            background-image: linear-gradient(to right, rgb(151, 137, 222) 0%, rgb(151, 137, 222) 20%, rgb(255, 255, 255) 50%, rgb(151, 137, 222) 80%, rgb(151, 137, 222) 100%);
-            background-size: 200% auto;
-          ">即刻开启高效学习模式</h2>
-      <p class="reveal text-white/40 text-base mb-10 max-w-md mx-auto leading-relaxed">告别低效抄录，让 AI 成为你的超级助教。注册即享完整试卷解析体验。</p>
+      <h2 class="reveal text-4xl sm:text-5xl font-semibold tracking-tight mb-6">
+        <span class="text-transparent bg-clip-text animate-gradient-sweep dark:hidden" style="
+          background-image: linear-gradient(to right, rgb(151, 137, 222) 0%, rgb(151, 137, 222) 20%, rgb(79, 70, 229) 50%, rgb(151, 137, 222) 80%, rgb(151, 137, 222) 100%);
+          background-size: 200% auto;
+        ">即刻开启高效学习模式</span>
+        <span class="text-transparent bg-clip-text animate-gradient-sweep hidden dark:inline" style="
+          background-image: linear-gradient(to right, rgb(151, 137, 222) 0%, rgb(151, 137, 222) 20%, rgb(255, 255, 255) 50%, rgb(151, 137, 222) 80%, rgb(151, 137, 222) 100%);
+          background-size: 200% auto;
+        ">即刻开启高效学习模式</span>
+      </h2>
+      <p class="reveal text-gray-600 dark:text-white/40 text-base mb-10 max-w-md mx-auto leading-relaxed transition-colors duration-200">告别低效抄录，让 AI 成为你的超级助教。注册即享完整试卷解析体验。</p>
       <div class="reveal">
         <BaseButton variant="cta" to="/auth" class="shadow-[0_0_30px_rgba(129,115,223,0.3)] hover:shadow-[0_0_50px_rgba(129,115,223,0.5)] transform hover:-translate-y-1 transition-all duration-300">
           免费创建错题库

--- a/frontend/src/components/home/HomeHeader.vue
+++ b/frontend/src/components/home/HomeHeader.vue
@@ -19,17 +19,17 @@ const emit = defineEmits(['scrollToSection'])
 </script>
 
 <template>
-  <nav
+    <nav
     id="top-nav"
-    class="fixed top-0 left-0 w-full z-50 border-b transition-[border-color] duration-200"
-    :class="navScrolled ? 'border-white/[0.06] bg-[#0A0A0F]/80' : 'border-transparent'"
+    class="fixed top-0 left-0 w-full z-50 border-b transition-[border-color,background-color] duration-200"
+    :class="navScrolled ? 'border-gray-200/50 bg-white/80 dark:border-white/[0.06] dark:bg-[#0A0A0F]/80 backdrop-blur-md' : 'border-transparent'"
   >
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex justify-between items-center h-14">
         <!-- Logo -->
         <div class="flex items-center gap-2.5">
           <BaseLogo size="sm" />
-          <span class="text-sm font-semibold text-white/90 tracking-wide">智卷错题本</span>
+          <span class="text-sm font-semibold text-gray-900 dark:text-white/90 tracking-wide">智卷错题本</span>
         </div>
 
         <!-- 中间导航 -->
@@ -39,13 +39,21 @@ const emit = defineEmits(['scrollToSection'])
             :key="s.id"
             @click="emit('scrollToSection', s.id)"
             class="px-3 py-1.5 text-[13px] font-medium rounded-md transition-colors"
-            :class="activeSection === s.id ? 'text-white bg-white/[0.06]' : 'text-white/40 hover:text-white/70'"
+            :class="activeSection === s.id ? 'text-gray-900 bg-gray-200 dark:text-white dark:bg-white/[0.06]' : 'text-gray-800 hover:text-black hover:bg-transparent dark:text-white/40 dark:hover:text-white/70 dark:hover:bg-transparent'"
           >{{ s.label }}</button>
         </div>
 
         <!-- 右侧操作 -->
         <div class="flex items-center gap-3">
-          <a href="https://github.com/xiaozhejiya/error_correction" target="_blank" rel="noopener noreferrer" class="text-white/30 hover:text-white/60 transition-colors">
+          <button
+            @click="toggleTheme($event.currentTarget)"
+            class="w-8 h-8 flex items-center justify-center rounded-md text-gray-800 hover:text-black hover:bg-transparent dark:text-white/40 dark:hover:text-white/70 dark:hover:bg-white/10 transition-colors"
+            title="切换主题"
+          >
+            <i class="fa-solid text-base" :class="isDark ? 'fa-sun' : 'fa-moon'"></i>
+          </button>
+          
+          <a href="https://github.com/xiaozhejiya/error_correction" target="_blank" rel="noopener noreferrer" class="w-8 h-8 flex items-center justify-center rounded-md text-gray-800 hover:text-black hover:bg-transparent dark:text-white/40 dark:hover:text-white/70 dark:hover:bg-white/10 transition-colors">
             <i class="fa-brands fa-github text-base"></i>
           </a>
           <BaseButton to="/auth" size="sm">

--- a/frontend/src/components/home/HomeSideNav.vue
+++ b/frontend/src/components/home/HomeSideNav.vue
@@ -27,10 +27,10 @@ const emit = defineEmits(['scrollToSection', 'back-to-top'])
       <div
         class="w-1 h-1 rounded-full transition-all duration-200"
         :class="activeSection === s.id
-          ? 'bg-white scale-150'
-          : 'bg-white/20 group-hover:bg-white/50'"
+          ? 'bg-indigo-600 dark:bg-white scale-150'
+          : 'bg-gray-300 dark:bg-white/20 group-hover:bg-indigo-400 dark:group-hover:bg-white/50'"
       ></div>
-      <span class="absolute right-10 px-2 py-1 rounded-md bg-[#111118] border border-white/[0.06] text-[11px] font-medium text-white/70 whitespace-nowrap pointer-events-none opacity-0 translate-x-1 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-200">
+      <span class="absolute right-10 px-2 py-1 rounded-md bg-white dark:bg-[#111118] border border-gray-200 dark:border-white/[0.06] text-[11px] font-medium text-gray-700 dark:text-white/70 whitespace-nowrap pointer-events-none opacity-0 translate-x-1 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-200 shadow-sm dark:shadow-none">
         {{ s.label }}
       </span>
     </button>
@@ -39,7 +39,7 @@ const emit = defineEmits(['scrollToSection', 'back-to-top'])
   <!-- 回到顶部按钮 -->
   <button
     id="back-to-top"
-    class="fixed bottom-8 right-8 z-50 flex h-10 w-10 items-center justify-center rounded-full brand-btn text-[#8a8f98] transition-[opacity,transform] duration-300 hover:text-[#f7f8f8]"
+    class="fixed bottom-8 right-8 z-50 flex h-10 w-10 items-center justify-center rounded-full brand-btn text-gray-400 dark:text-[#8a8f98] transition-[opacity,transform,color] duration-300 hover:text-indigo-600 dark:hover:text-[#f7f8f8]"
     :style="{ opacity: showBackToTop ? '1' : '0', transform: showBackToTop ? 'translateY(0)' : 'translateY(12px)', pointerEvents: showBackToTop ? 'auto' : 'none' }"
     aria-label="回到顶部"
     @click="emit('back-to-top')"

--- a/frontend/src/components/home/WorkflowStep.vue
+++ b/frontend/src/components/home/WorkflowStep.vue
@@ -26,25 +26,25 @@ const props = defineProps({
 <template>
   <div
     class="relative p-4 rounded-lg cursor-pointer transition-all duration-500"
-    :class="isActive ? 'brand-btn transform scale-105' : 'border border-transparent hover:bg-white/[0.03] hover:border-white/[0.05]'"
+    :class="isActive ? 'brand-btn transform scale-105' : 'border border-transparent hover:bg-gray-100 dark:hover:bg-white/[0.03] hover:border-gray-200 dark:hover:border-white/[0.05]'"
   >
     <div class="flex flex-col items-center text-center">
       <div
         class="relative overflow-hidden w-12 h-12 rounded-xl flex items-center justify-center mb-4 transition-all duration-500"
-        :class="isPast || isActive ? 'wf-icon--active text-white' : 'bg-white/[0.04] text-white/25 border border-white/[0.06]'"
+        :class="isPast || isActive ? 'wf-icon--active text-white' : 'bg-gray-100 dark:bg-white/[0.04] text-gray-400 dark:text-white/25 border border-gray-200 dark:border-white/[0.06]'"
       >
         <span v-if="isPast || isActive" class="wf-icon__grid absolute inset-0 pointer-events-none"></span>
         <component :is="icon" class="relative w-5 h-5" />
       </div>
       <h4
-        class="text-sm font-semibold mb-1"
-        :class="isActive ? 'text-white/90' : 'text-white/40'"
+        class="text-sm font-semibold mb-1 transition-colors duration-500"
+        :class="isActive ? 'text-gray-900 dark:text-white/90' : 'text-gray-500 dark:text-white/40'"
       >
         {{ title }}
       </h4>
       <p
-        class="text-xs"
-        :class="isActive ? 'text-white/50' : 'text-white/25'"
+        class="text-xs transition-colors duration-500"
+        :class="isActive ? 'text-gray-600 dark:text-white/50' : 'text-gray-400 dark:text-white/25'"
       >
         {{ desc }}
       </p>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -51,6 +51,12 @@
   border-bottom-color: rgba(255, 255, 255, 0.03);
 }
 
+:root:not(.dark) .brand-btn {
+  background: #ffffff;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -2px rgba(0, 0, 0, 0.05);
+}
+
 html,
 body,
 #app {

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -270,10 +270,10 @@ onUnmounted(() => {
       <HomeHero @scrollToSection="scrollToSectionSnap" />
 
       <!-- ② 滚动叠盖层（实色背景完全遮住 Hero sticky） -->
-      <div class="relative z-10 overflow-hidden" style="background: #0A0A0F;">
+      <div class="relative z-10 overflow-hidden bg-slate-50 dark:bg-[#0A0A0F] transition-colors duration-200">
 
         <!-- 背景装饰：波纹纹理 -->
-        <div class="absolute inset-0 pointer-events-none z-0">
+        <div class="absolute inset-0 pointer-events-none z-0 opacity-40 dark:opacity-20 dark:invert-0 invert">
           <div class="home-bg-topo"></div>
         </div>
 
@@ -286,20 +286,20 @@ onUnmounted(() => {
         <HomeFooter />
 
         <!-- 全局 Footer -->
-        <div class="border-t border-white/[0.06] py-4 relative z-10 bg-[#0A0A0F]/50 w-full mt-auto">
-          <div class="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-6 text-xs text-white/30 px-4">
+        <div class="border-t border-gray-200 dark:border-white/[0.06] py-4 relative z-10 bg-white/50 dark:bg-[#0A0A0F]/50 w-full mt-auto transition-colors duration-200">
+          <div class="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-6 text-xs text-gray-500 dark:text-white/30 px-4 transition-colors duration-200">
             <div class="flex items-center gap-2">
               <div class="footer-logo relative overflow-hidden p-1.5 rounded-lg flex items-center justify-center">
                 <span class="footer-logo__grid absolute inset-0 pointer-events-none"></span>
-                <img src="/logo.svg" class="relative w-4 h-4 brightness-0 invert" alt="logo" />
+                <img src="/logo.svg" class="relative w-4 h-4 brightness-0 invert transition-all" alt="logo" />
               </div>
-              <span class="font-semibold text-white/50 tracking-wide">智卷错题本</span>
+              <span class="font-semibold text-gray-600 dark:text-white/50 tracking-wide transition-colors">智卷错题本</span>
             </div>
             <p class="text-center">© 2026 Intelligent Error Book Generation System. All rights reserved.</p>
             <div class="flex gap-6 pr-12 md:pr-0">
-              <a href="#" class="hover:text-white/70 transition-colors">架构文档</a>
-              <a href="#" class="hover:text-white/70 transition-colors">隐私政策</a>
-              <a href="#" class="hover:text-white/70 transition-colors">联系我们</a>
+              <a href="#" class="hover:text-gray-900 dark:hover:text-white/70 transition-colors">架构文档</a>
+              <a href="#" class="hover:text-gray-900 dark:hover:text-white/70 transition-colors">隐私政策</a>
+              <a href="#" class="hover:text-gray-900 dark:hover:text-white/70 transition-colors">联系我们</a>
             </div>
           </div>
         </div>
@@ -389,7 +389,6 @@ html { scroll-padding-top: 80px; }
 .home-bg-topo {
   position: absolute;
   inset: 0;
-  opacity: 0.2;
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 1000 1000' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.005' numOctaves='3' stitchTiles='stitch'/%3E%3CfeColorMatrix type='matrix' values='1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 10 -4' /%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' fill='none' stroke='%23ffffff' stroke-width='1' opacity='0.3'/%3E%3Cpath d='M0,100 C200,300 300,0 500,100 C700,200 800,-100 1000,100 M0,200 C250,400 350,100 550,200 C750,300 850,0 1000,200 M0,300 C300,500 400,200 600,300 C800,400 900,100 1000,300 M0,400 C350,600 450,300 650,400 C850,500 950,200 1000,400 M0,500 C400,700 500,400 700,500 C900,600 1000,300 1000,500 M0,600 C450,800 550,500 750,600 C950,700 1000,400 1000,600 M0,700 C500,900 600,600 800,700 C1000,800 1000,500 1000,700 M0,800 C550,1000 650,700 850,800 C1000,900 1000,600 1000,800 M0,900 C600,1100 700,800 900,900 C1000,1000 1000,700 1000,900' stroke='%23ffffff' stroke-width='1' fill='none' opacity='0.15' /%3E%3C/svg%3E");
   background-size: cover;
   background-position: center;

--- a/frontend/src/views/home/HomeDemo.vue
+++ b/frontend/src/views/home/HomeDemo.vue
@@ -8,59 +8,68 @@ import BaseButton from '@/components/base/BaseButton.vue'
 </script>
 
 <template>
-  <section id="demo" class="relative z-10 py-24 overflow-hidden">
+  <section id="demo" class="relative z-10 py-24 overflow-hidden bg-white dark:bg-transparent transition-colors duration-200">
+    <!-- 顶部分割线 -->
+    <div class="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-gray-200 dark:via-white/[0.06] to-transparent transition-colors duration-200"></div>
+
     <div class="reveal max-w-5xl mx-auto px-4 sm:px-6 relative z-10">
       <div class="text-center mb-12">
-        <h2 class="reveal text-3xl font-semibold tracking-tight mb-4 text-transparent bg-clip-text animate-gradient-sweep" style="
+        <h2 class="reveal text-3xl font-semibold tracking-tight mb-4">
+          <span class="text-transparent bg-clip-text animate-gradient-sweep dark:hidden" style="
+            background-image: linear-gradient(to right, rgb(151, 137, 222) 0%, rgb(151, 137, 222) 20%, rgb(79, 70, 229) 50%, rgb(151, 137, 222) 80%, rgb(151, 137, 222) 100%);
+            background-size: 200% auto;
+          ">眼见为实的转变</span>
+          <span class="text-transparent bg-clip-text animate-gradient-sweep hidden dark:inline" style="
             background-image: linear-gradient(to right, rgb(151, 137, 222) 0%, rgb(151, 137, 222) 20%, rgb(255, 255, 255) 50%, rgb(151, 137, 222) 80%, rgb(151, 137, 222) 100%);
             background-size: 200% auto;
-          ">眼见为实的转变</h2>
-        <p class="text-white/40 text-sm">复杂的公式、凌乱的涂改，在强大的 AI 引擎面前都不值一提。</p>
+          ">眼见为实的转变</span>
+        </h2>
+        <p class="text-gray-600 dark:text-white/40 text-sm transition-colors duration-200">复杂的公式、凌乱的涂改，在强大的 AI 引擎面前都不值一提。</p>
       </div>
 
       <div class="flex flex-col lg:flex-row gap-4 items-center justify-center">
         <!-- 左侧：原图模拟 -->
-        <div class="reveal flex-1 w-full max-w-md brand-btn p-6 rounded-lg relative overflow-hidden">
-          <div class="text-xs font-medium tracking-wide text-white/25 uppercase mb-4">Input / 原生图像</div>
-          <div class="bg-[#15151e]/80 p-6 rounded-xl -rotate-1 text-white/50 border border-white/[0.02]">
+        <div class="reveal flex-1 w-full max-w-md bg-gray-50 border border-gray-200 dark:bg-transparent dark:border-none dark:brand-btn p-6 rounded-lg relative overflow-hidden transition-colors duration-200">
+          <div class="text-xs font-medium tracking-wide text-gray-400 dark:text-white/25 uppercase mb-4 transition-colors duration-200">Input / 原生图像</div>
+          <div class="bg-white border border-gray-100 shadow-sm dark:bg-[#15151e]/80 dark:border-white/[0.02] dark:shadow-none p-6 rounded-xl -rotate-1 text-gray-600 dark:text-white/50 transition-colors duration-200">
             <p class="font-[cursive] text-sm mb-2">3. 巳知函数f(x)=2sin(wx+φ)(w&gt;0,|φ|&lt;π/2)的图像...</p>
             <p class="font-[cursive] text-sm">A. w=2, φ=π/6</p>
-            <div class="mt-3 w-1/2 h-3 bg-red-400/15 rounded-full blur-[2px] -rotate-3"></div>
-            <p class="font-[cursive] text-xs mt-3 text-red-400/40 font-bold -rotate-6">看不清，选C吧</p>
+            <div class="mt-3 w-1/2 h-3 bg-red-400/20 dark:bg-red-400/15 rounded-full blur-[2px] -rotate-3 transition-colors duration-200"></div>
+            <p class="font-[cursive] text-xs mt-3 text-red-500/60 dark:text-red-400/40 font-bold -rotate-6 transition-colors duration-200">看不清，选C吧</p>
           </div>
         </div>
 
         <!-- 中间箭头 -->
         <div class="hidden lg:flex items-center justify-center w-12">
-          <ArrowRight class="w-5 h-5 text-indigo-400/50 animate-pulse" />
+          <ArrowRight class="w-5 h-5 text-indigo-500/70 dark:text-indigo-400/50 animate-pulse transition-colors duration-200" />
         </div>
         <div class="lg:hidden flex justify-center py-2">
-          <ArrowRight class="w-5 h-5 text-indigo-400/50 rotate-90 animate-pulse" />
+          <ArrowRight class="w-5 h-5 text-indigo-500/70 dark:text-indigo-400/50 rotate-90 animate-pulse transition-colors duration-200" />
         </div>
 
         <!-- 右侧：AI 结果 -->
-        <div class="reveal flex-1 w-full max-w-md brand-btn p-6 rounded-lg relative overflow-hidden text-left" style="transition-delay: 200ms;">
-          <div class="absolute top-0 right-0 w-32 h-32 bg-indigo-500/10 blur-[50px] rounded-full pointer-events-none"></div>
+        <div class="reveal flex-1 w-full max-w-md bg-indigo-50/50 border border-indigo-100/50 dark:bg-transparent dark:border-none dark:brand-btn p-6 rounded-lg relative overflow-hidden text-left transition-colors duration-200" style="transition-delay: 200ms;">
+          <div class="absolute top-0 right-0 w-32 h-32 bg-indigo-500/20 dark:bg-indigo-500/10 blur-[50px] rounded-full pointer-events-none transition-colors duration-200"></div>
           
-          <div class="text-xs font-medium tracking-wide text-indigo-400 uppercase flex items-center gap-1.5 mb-4 relative z-10">
+          <div class="text-xs font-medium tracking-wide text-indigo-600 dark:text-indigo-400 uppercase flex items-center gap-1.5 mb-4 relative z-10 transition-colors duration-200">
             <Sparkles class="w-3 h-3" /> Output / 结构化数据
           </div>
 
-          <div class="bg-[#0A0A0F]/80 border border-white/[0.04] p-4 rounded-xl text-white/70 font-mono text-sm leading-relaxed relative z-10 shadow-inner">
+          <div class="bg-white border border-indigo-100/80 shadow-sm dark:bg-[#0A0A0F]/80 dark:border-white/[0.04] dark:shadow-inner p-4 rounded-xl text-gray-700 dark:text-white/70 font-mono text-sm leading-relaxed relative z-10 transition-colors duration-200">
             <div class="flex gap-2 mb-4">
-              <span class="bg-white/[0.04] text-white/50 px-2 py-0.5 rounded-full text-xs border border-white/[0.06]">选择题</span>
-              <span class="bg-white/[0.04] text-white/50 px-2 py-0.5 rounded-full text-xs border border-white/[0.06]">三角函数</span>
+              <span class="bg-indigo-50/80 text-indigo-600/80 border border-indigo-100 dark:bg-white/[0.04] dark:text-white/50 px-2 py-0.5 rounded-full text-xs dark:border-white/[0.06] transition-colors duration-200">选择题</span>
+              <span class="bg-indigo-50/80 text-indigo-600/80 border border-indigo-100 dark:bg-white/[0.04] dark:text-white/50 px-2 py-0.5 rounded-full text-xs dark:border-white/[0.06] transition-colors duration-200">三角函数</span>
             </div>
-            <p class="text-sm"><span class="text-indigo-400/70 mr-1.5">## 3.</span> 已知函数 <span class="text-indigo-300/80 bg-indigo-500/10 px-1 rounded">$f(x) = 2\sin(\omega x + \varphi)$</span> <span class="text-indigo-300/80 bg-indigo-500/10 px-1 rounded">$(\omega &gt; 0, |\varphi| &lt; \frac{\pi}{2})$</span> 的图像...</p>
-            <div class="mt-4 pl-3 border-l border-white/[0.06] space-y-2">
-              <p class="flex gap-2"><span class="text-white/25">A.</span> <span class="text-white/60">$\omega = 2, \varphi = \frac{\pi}{6}$</span></p>
-              <p class="flex gap-2"><span class="text-white/25">B.</span> <span class="text-white/60">$\omega = 2, \varphi = -\frac{\pi}{6}$</span></p>
+            <p class="text-sm"><span class="text-indigo-600/80 dark:text-indigo-400/70 mr-1.5 transition-colors duration-200">## 3.</span> 已知函数 <span class="text-indigo-700/90 bg-indigo-100/50 dark:text-indigo-300/80 dark:bg-indigo-500/10 px-1 rounded transition-colors duration-200">$f(x) = 2\sin(\omega x + \varphi)$</span> <span class="text-indigo-700/90 bg-indigo-100/50 dark:text-indigo-300/80 dark:bg-indigo-500/10 px-1 rounded transition-colors duration-200">$(\omega &gt; 0, |\varphi| &lt; \frac{\pi}{2})$</span> 的图像...</p>
+            <div class="mt-4 pl-3 border-l border-gray-200 dark:border-white/[0.06] space-y-2 transition-colors duration-200">
+              <p class="flex gap-2"><span class="text-gray-400 dark:text-white/25 transition-colors duration-200">A.</span> <span class="text-gray-700 dark:text-white/60 transition-colors duration-200">$\omega = 2, \varphi = \frac{\pi}{6}$</span></p>
+              <p class="flex gap-2"><span class="text-gray-400 dark:text-white/25 transition-colors duration-200">B.</span> <span class="text-gray-700 dark:text-white/60 transition-colors duration-200">$\omega = 2, \varphi = -\frac{\pi}{6}$</span></p>
             </div>
-            <div class="mt-6 flex items-center justify-between border-t border-white/[0.06] pt-4">
-              <span class="text-xs text-emerald-400/70 flex items-center gap-1.5">
+            <div class="mt-6 flex items-center justify-between border-t border-gray-100 dark:border-white/[0.06] pt-4 transition-colors duration-200">
+              <span class="text-xs text-emerald-600/80 dark:text-emerald-400/70 flex items-center gap-1.5 transition-colors duration-200">
                 <CheckCircle2 class="w-3 h-3" /> 已过滤手写痕迹
               </span>
-              <BaseButton variant="secondary" size="sm" class="flex items-center gap-1.5 border-white/[0.06] bg-white/[0.06] hover:bg-white/[0.1] !px-3 !py-1.5 !h-auto">
+              <BaseButton variant="secondary" size="sm" class="flex items-center gap-1.5 !px-3 !py-1.5 !h-auto">
                 导出 MD <FileDown class="w-3 h-3" />
               </BaseButton>
             </div>

--- a/frontend/src/views/home/HomeFeatures.vue
+++ b/frontend/src/views/home/HomeFeatures.vue
@@ -51,26 +51,34 @@ const FEATURES = [
 </script>
 
 <template>
-  <section id="features" class="relative py-24 overflow-hidden">
+  <section id="features" class="relative py-24 overflow-hidden bg-slate-50 dark:bg-transparent transition-colors duration-200">
+
+    <!-- 背景装饰：复杂流体拓扑波纹 (Fluid Topography) -->
+    <div class="absolute inset-0 pointer-events-none z-0 opacity-[0.8] dark:opacity-20 dark:invert-0 invert" style="
+      background-image: url('data:image/svg+xml,%3Csvg viewBox=%220 0 1000 1000%22 xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cfilter id=%22noiseFilter%22%3E%3CfeTurbulence type=%22fractalNoise%22 baseFrequency=%220.005%22 numOctaves=%223%22 stitchTiles=%22stitch%22/%3E%3CfeColorMatrix type=%22matrix%22 values=%221 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 10 -4%22 /%3E%3C/filter%3E%3Crect width=%22100%25%22 height=%22100%25%22 filter=%22url(%23noiseFilter)%22 fill=%22none%22 stroke=%22%23ffffff%22 stroke-width=%221%22 opacity=%220.3%22/%3E%3Cpath d=%22M0,100 C200,300 300,0 500,100 C700,200 800,-100 1000,100 M0,200 C250,400 350,100 550,200 C750,300 850,0 1000,200 M0,300 C300,500 400,200 600,300 C800,400 900,100 1000,300 M0,400 C350,600 450,300 650,400 C850,500 950,200 1000,400 M0,500 C400,700 500,400 700,500 C900,600 1000,300 1000,500 M0,600 C450,800 550,500 750,600 C950,700 1000,400 1000,600 M0,700 C500,900 600,600 800,700 C1000,800 1000,500 1000,700 M0,800 C550,1000 650,700 850,800 C1000,900 1000,600 1000,800 M0,900 C600,1100 700,800 900,900 C1000,1000 1000,700 1000,900%22 stroke=%22%23ffffff%22 stroke-width=%221%22 fill=%22none%22 opacity=%220.15%22 /%3E%3C/svg%3E');
+      background-size: cover;
+      background-position: center;
+      mask-image: radial-gradient(ellipse 100% 100% at 50% 50%, black, transparent);
+      -webkit-mask-image: radial-gradient(ellipse 100% 100% at 50% 50%, black, transparent);
+    "></div>
 
     <!-- 背景装饰：模糊环境光 (Ambient Glow) -->
-    <div class="absolute top-[20%] left-[-10%] w-[500px] h-[500px] rounded-full bg-indigo-600/5 blur-[150px] pointer-events-none z-0"></div>
-    <div class="absolute bottom-[10%] right-[-5%] w-[400px] h-[400px] rounded-full bg-violet-600/5 blur-[120px] pointer-events-none z-0"></div>
+    <div class="absolute top-[20%] left-[-10%] w-[500px] h-[500px] rounded-full bg-indigo-600/10 dark:bg-indigo-600/5 blur-[150px] pointer-events-none z-0"></div>
+    <div class="absolute bottom-[10%] right-[-5%] w-[400px] h-[400px] rounded-full bg-violet-600/10 dark:bg-violet-600/5 blur-[120px] pointer-events-none z-0"></div>
 
     <!-- 顶部分割线 -->
-    <div class="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/[0.06] to-transparent"></div>
+    <div class="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-gray-200 dark:via-white/[0.06] to-transparent transition-colors duration-200"></div>
 
     <div class="relative mx-auto max-w-6xl px-4 sm:px-6">
 
       <!-- 标题区 -->
       <div class="mb-16 text-center">
-        <h2 class="reveal text-3xl font-semibold tracking-tight mb-4 text-transparent bg-clip-text animate-gradient-sweep" style="
-            background-image: linear-gradient(to right, rgb(151, 137, 222) 0%, rgb(151, 137, 222) 20%, rgb(255, 255, 255) 50%, rgb(151, 137, 222) 80%, rgb(151, 137, 222) 100%);
+        <h2 class="reveal text-3xl font-semibold tracking-tight mb-4 text-transparent bg-clip-text animate-gradient-sweep bg-[linear-gradient(to_right,rgb(151,137,222)_0%,rgb(151,137,222)_20%,rgb(79,70,229)_50%,rgb(151,137,222)_80%,rgb(151,137,222)_100%)] dark:bg-[linear-gradient(to_right,rgb(151,137,222)_0%,rgb(151,137,222)_20%,rgb(255,255,255)_50%,rgb(151,137,222)_80%,rgb(151,137,222)_100%)]" style="
             background-size: 200% auto;
           ">
           驱动学习效率的核心引擎
         </h2>
-        <p class="reveal mx-auto max-w-xl text-sm text-white/35 leading-relaxed">
+        <p class="reveal mx-auto max-w-xl text-sm text-gray-600 dark:text-white/35 leading-relaxed transition-colors duration-200">
           不仅是简单的图像识别，而是真正理解学科内在逻辑的 AI 智能体系统。
         </p>
       </div>

--- a/frontend/src/views/home/HomeHero.vue
+++ b/frontend/src/views/home/HomeHero.vue
@@ -49,10 +49,10 @@ onUnmounted(() => {
 
 <template>
   <!-- ① Sticky Hero 容器 — Linear 风格 -->
-  <div id="sticky-hero" class="sticky top-0 h-screen overflow-hidden z-0 flex flex-col justify-center bg-[#0A0A0F]" style="contain: content;">
+  <div id="sticky-hero" class="sticky top-0 h-screen overflow-hidden z-0 flex flex-col justify-center bg-slate-50 dark:bg-[#0A0A0F]" style="contain: content;">
 
     <!-- 背景装饰：复杂流体拓扑波纹 (Fluid Topography) 基础层 -->
-    <div class="absolute inset-0 pointer-events-none z-0 opacity-20" style="
+    <div class="absolute inset-0 pointer-events-none z-0 opacity-[0.4] dark:opacity-20 dark:invert-0 invert" style="
       background-image: url('data:image/svg+xml,%3Csvg viewBox=%220 0 1000 1000%22 xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cfilter id=%22noiseFilter%22%3E%3CfeTurbulence type=%22fractalNoise%22 baseFrequency=%220.005%22 numOctaves=%223%22 stitchTiles=%22stitch%22/%3E%3CfeColorMatrix type=%22matrix%22 values=%221 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 10 -4%22 /%3E%3C/filter%3E%3Crect width=%22100%25%22 height=%22100%25%22 filter=%22url(%23noiseFilter)%22 fill=%22none%22 stroke=%22%23ffffff%22 stroke-width=%221%22 opacity=%220.3%22/%3E%3Cpath d=%22M0,100 C200,300 300,0 500,100 C700,200 800,-100 1000,100 M0,200 C250,400 350,100 550,200 C750,300 850,0 1000,200 M0,300 C300,500 400,200 600,300 C800,400 900,100 1000,300 M0,400 C350,600 450,300 650,400 C850,500 950,200 1000,400 M0,500 C400,700 500,400 700,500 C900,600 1000,300 1000,500 M0,600 C450,800 550,500 750,600 C950,700 1000,400 1000,600 M0,700 C500,900 600,600 800,700 C1000,800 1000,500 1000,700 M0,800 C550,1000 650,700 850,800 C1000,900 1000,600 1000,800 M0,900 C600,1100 700,800 900,900 C1000,1000 1000,700 1000,900%22 stroke=%22%23ffffff%22 stroke-width=%221%22 fill=%22none%22 opacity=%220.15%22 /%3E%3C/svg%3E');
       background-size: cover;
       background-position: center;
@@ -69,14 +69,7 @@ onUnmounted(() => {
       aspect-ratio: 1.3 / 1;
     ">
       <!-- 椭圆本体 -->
-      <div class="absolute inset-0" style="
-        border-radius: 50%;
-        background: linear-gradient(to bottom, rgba(92,81,148,0.5), rgba(47,40,91,0.95));
-        box-shadow:
-          inset 0 -20px 24px 0 rgba(255,255,255,0.15),
-          0 16px 32px 0 rgba(97,62,210,0.32),
-          inset 0 -1px 0 0 rgba(129,115,223,0.6);
-      "></div>
+      <div class="absolute inset-0 rounded-[50%] bg-gradient-to-b from-[#8173DF]/40 to-[#6357C7]/80 shadow-[inset_0_-20px_24px_0_rgba(99,87,199,0.6),0_24px_48px_0_rgba(99,87,199,0.8),0_0_32px_0_rgba(129,115,223,0.5),inset_0_-1px_0_0_rgba(255,255,255,1),inset_0_1px_0_0_rgba(255,255,255,1)] dark:from-[rgba(92,81,148,0.5)] dark:to-[rgba(47,40,91,0.95)] dark:shadow-[inset_0_-20px_24px_0_rgba(255,255,255,0.15),0_16px_32px_0_rgba(97,62,210,0.32),inset_0_-1px_0_0_rgba(129,115,223,0.6)] backdrop-blur-md"></div>
 
       <!-- 土星光环: LaTeX 公式 -->
       <!-- 放大容器以远离"土星"本体，同时增加 Z 轴旋转(rotateX)和倾斜(rotateZ)产生悬浮交错的纵深感 -->
@@ -95,11 +88,11 @@ onUnmounted(() => {
             <path id="saturn-ring-path-1" d="M 500, 980 A 480,480 0 1,0 500,20 A 480,480 0 1,0 500,980" fill="none" />
             
             <!-- 轨道装饰线 -->
-            <path d="M 500, 500 m -488, 0 a 488,488 0 1,1 976,0 a 488,488 0 1,1 -976,0" fill="none" stroke="rgba(129,115,223,0.2)" stroke-width="1" />
-            <path d="M 500, 500 m -472, 0 a 472,472 0 1,1 944,0 a 472,472 0 1,1 -944,0" fill="none" stroke="rgba(129,115,223,0.2)" stroke-width="1" />
+            <path d="M 500, 500 m -488, 0 a 488,488 0 1,1 976,0 a 488,488 0 1,1 -976,0" fill="none" class="stroke-indigo-900/30 dark:stroke-indigo-400/20" stroke-width="1.5" />
+            <path d="M 500, 500 m -472, 0 a 472,472 0 1,1 944,0 a 472,472 0 1,1 -944,0" fill="none" class="stroke-indigo-900/30 dark:stroke-indigo-400/20" stroke-width="1.5" />
 
             <!-- 公式文本 -->
-            <text fill="currentColor" class="text-indigo-200/80" font-family="'Times New Roman', Times, serif" font-size="18" font-style="italic" letter-spacing="5">
+            <text fill="currentColor" class="text-indigo-900/70 dark:text-indigo-200/80 font-bold" font-family="'Times New Roman', Times, serif" font-size="18" font-style="italic" letter-spacing="5">
               <textPath href="#saturn-ring-path-1" startOffset="0%">
                 ∇⋅E = ρ/ε₀ &nbsp;&nbsp;&nbsp;&nbsp; ∇×B = μ₀J + μ₀ε₀(∂E/∂t) &nbsp;&nbsp;&nbsp;&nbsp; R_μν - ½Rg_μν + Λg_μν = (8πG/c⁴)T_μν &nbsp;&nbsp;&nbsp;&nbsp; iℏ(∂Ψ/∂t) = ĤΨ &nbsp;&nbsp;&nbsp;&nbsp; (iγ^μ∂_μ - m)ψ = 0 &nbsp;&nbsp;&nbsp;&nbsp; e^(iπ) + 1 = 0 &nbsp;&nbsp;&nbsp;&nbsp; S = ∫ L dt &nbsp;&nbsp;&nbsp;&nbsp; ∇⋅E = ρ/ε₀ &nbsp;&nbsp;&nbsp;&nbsp; ∇×B = μ₀J + μ₀ε₀(∂E/∂t) &nbsp;&nbsp;&nbsp;&nbsp; R_μν - ½Rg_μν + Λg_μν = (8πG/c⁴)T_μν &nbsp;&nbsp;&nbsp;&nbsp; iℏ(∂Ψ/∂t) = ĤΨ &nbsp;&nbsp;&nbsp;&nbsp; (iγ^μ∂_μ - m)ψ = 0 &nbsp;&nbsp;&nbsp;&nbsp; e^(iπ) + 1 = 0 &nbsp;&nbsp;&nbsp;&nbsp; S = ∫ L dt &nbsp;&nbsp;&nbsp;&nbsp; ∇⋅E = ρ/ε₀ &nbsp;&nbsp;&nbsp;&nbsp; ∇×B = μ₀J + μ₀ε₀(∂E/∂t) &nbsp;&nbsp;&nbsp;&nbsp; R_μν - ½Rg_μν + Λg_μν = (8πG/c⁴)T_μν &nbsp;&nbsp;&nbsp;&nbsp; iℏ(∂Ψ/∂t) = ĤΨ &nbsp;&nbsp;&nbsp;&nbsp; (iγ^μ∂_μ - m)ψ = 0 &nbsp;&nbsp;&nbsp;&nbsp; e^(iπ) + 1 = 0 &nbsp;&nbsp;&nbsp;&nbsp; S = ∫ L dt
               </textPath>
@@ -112,11 +105,11 @@ onUnmounted(() => {
             <path id="saturn-ring-path-2" d="M 500, 1040 A 540,540 0 1,0 500,-40 A 540,540 0 1,0 500,1040" fill="none" />
             
             <!-- 轨道装饰线 -->
-            <path d="M 500, 500 m -546, 0 a 546,546 0 1,1 1092,0 a 546,546 0 1,1 -1092,0" fill="none" stroke="rgba(129,115,223,0.15)" stroke-width="1" />
-            <path d="M 500, 500 m -534, 0 a 534,534 0 1,1 1068,0 a 534,534 0 1,1 -1068,0" fill="none" stroke="rgba(129,115,223,0.15)" stroke-width="1" />
+            <path d="M 500, 500 m -546, 0 a 546,546 0 1,1 1092,0 a 546,546 0 1,1 -1092,0" fill="none" class="stroke-indigo-900/25 dark:stroke-indigo-400/15" stroke-width="1.5" />
+            <path d="M 500, 500 m -534, 0 a 534,534 0 1,1 1068,0 a 534,534 0 1,1 -1068,0" fill="none" class="stroke-indigo-900/25 dark:stroke-indigo-400/15" stroke-width="1.5" />
 
             <!-- 公式文本 (换成另一组数学公式：傅里叶变换、高斯-博内定理、薛定谔、贝叶斯等) -->
-            <text fill="currentColor" class="text-indigo-200/70" font-family="'Times New Roman', Times, serif" font-size="14" font-style="italic" letter-spacing="6">
+            <text fill="currentColor" class="text-indigo-900/60 dark:text-indigo-200/70 font-bold" font-family="'Times New Roman', Times, serif" font-size="14" font-style="italic" letter-spacing="6">
               <textPath href="#saturn-ring-path-2" startOffset="0%">
                 F(ω) = ∫ f(t)e^(-iωt)dt &nbsp;&nbsp;&nbsp;&nbsp; ∫K dA + ∫k_g ds = 2πχ(M) &nbsp;&nbsp;&nbsp;&nbsp; P(A|B) = P(B|A)P(A)/P(B) &nbsp;&nbsp;&nbsp;&nbsp; dS ≥ 0 &nbsp;&nbsp;&nbsp;&nbsp; E = mc² &nbsp;&nbsp;&nbsp;&nbsp; V - E + F = 2 &nbsp;&nbsp;&nbsp;&nbsp; F(ω) = ∫ f(t)e^(-iωt)dt &nbsp;&nbsp;&nbsp;&nbsp; ∫K dA + ∫k_g ds = 2πχ(M) &nbsp;&nbsp;&nbsp;&nbsp; P(A|B) = P(B|A)P(A)/P(B) &nbsp;&nbsp;&nbsp;&nbsp; dS ≥ 0 &nbsp;&nbsp;&nbsp;&nbsp; E = mc² &nbsp;&nbsp;&nbsp;&nbsp; V - E + F = 2 &nbsp;&nbsp;&nbsp;&nbsp; F(ω) = ∫ f(t)e^(-iωt)dt &nbsp;&nbsp;&nbsp;&nbsp; ∫K dA + ∫k_g ds = 2πχ(M) &nbsp;&nbsp;&nbsp;&nbsp; P(A|B) = P(B|A)P(A)/P(B) &nbsp;&nbsp;&nbsp;&nbsp; dS ≥ 0 &nbsp;&nbsp;&nbsp;&nbsp; E = mc² &nbsp;&nbsp;&nbsp;&nbsp; V - E + F = 2 &nbsp;&nbsp;&nbsp;&nbsp; F(ω) = ∫ f(t)e^(-iωt)dt &nbsp;&nbsp;&nbsp;&nbsp; ∫K dA + ∫k_g ds = 2πχ(M) &nbsp;&nbsp;&nbsp;&nbsp; P(A|B) = P(B|A)P(A)/P(B) &nbsp;&nbsp;&nbsp;&nbsp; dS ≥ 0 &nbsp;&nbsp;&nbsp;&nbsp; E = mc² &nbsp;&nbsp;&nbsp;&nbsp; V - E + F = 2
               </textPath>
@@ -127,17 +120,17 @@ onUnmounted(() => {
     </div>
 
     <!-- 装饰: 光斑 -->
-    <div class="absolute pointer-events-none z-0 w-80 h-80 rounded-full blur-[120px] bg-indigo-600/[0.07]"
+    <div class="absolute pointer-events-none z-0 w-80 h-80 rounded-full blur-[120px] bg-indigo-600/[0.15] dark:bg-indigo-600/[0.07]"
       style="top: 25%; left: 8%;"
     ></div>
-    <div class="absolute pointer-events-none z-0 w-64 h-64 rounded-full blur-[100px] bg-violet-500/[0.05]"
+    <div class="absolute pointer-events-none z-0 w-64 h-64 rounded-full blur-[100px] bg-violet-500/[0.12] dark:bg-violet-500/[0.05]"
       style="top: 55%; right: 10%;"
     ></div>
 
     <!-- 装饰: 底部简约的环境光晕 -->
     <div class="absolute bottom-0 left-1/2 -translate-x-1/2 w-[80vw] h-[30vh] pointer-events-none z-0">
-      <div class="absolute inset-0 bg-indigo-500/10 blur-[100px] rounded-[100%] transform translate-y-1/2"></div>
-      <div class="absolute inset-0 bg-violet-500/5 blur-[120px] rounded-[100%] transform translate-y-1/2 scale-150"></div>
+      <div class="absolute inset-0 bg-indigo-500/20 dark:bg-indigo-500/10 blur-[100px] rounded-[100%] transform translate-y-1/2"></div>
+      <div class="absolute inset-0 bg-violet-500/10 dark:bg-violet-500/5 blur-[120px] rounded-[100%] transform translate-y-1/2 scale-150"></div>
     </div>
 
     <!-- 首屏区块 — 居中布局 -->
@@ -146,15 +139,14 @@ onUnmounted(() => {
         <!-- 标签 -->
         <HomePill class="mb-6" />
 
-        <h1 class="text-4xl sm:text-5xl font-semibold tracking-tight leading-tight mb-6 text-white">
+        <h1 class="text-4xl sm:text-5xl font-semibold tracking-tight leading-tight mb-6 text-gray-900 dark:text-white">
           重塑错题整理<br />
-          <span class="text-transparent bg-clip-text animate-gradient-sweep" style="
-            background-image: linear-gradient(to right, rgb(151, 137, 222) 0%, rgb(151, 137, 222) 20%, rgb(255, 255, 255) 50%, rgb(151, 137, 222) 80%, rgb(151, 137, 222) 100%);
+          <span class="text-transparent bg-clip-text animate-gradient-sweep bg-[linear-gradient(to_right,rgb(151,137,222)_0%,rgb(151,137,222)_20%,rgb(79,70,229)_50%,rgb(151,137,222)_80%,rgb(151,137,222)_100%)] dark:bg-[linear-gradient(to_right,rgb(151,137,222)_0%,rgb(151,137,222)_20%,rgb(255,255,255)_50%,rgb(151,137,222)_80%,rgb(151,137,222)_100%)]" style="
             background-size: 200% auto;
           ">一键生成知识图谱</span>
         </h1>
 
-        <p class="text-base text-white/40 mb-8 max-w-lg mx-auto leading-relaxed">
+        <p class="text-base text-gray-600 dark:text-white/40 mb-8 max-w-lg mx-auto leading-relaxed">
           上传试卷或手写笔记，AI 自动完成 OCR 识别、题目分割、公式还原、知识点标注。
         </p>
 
@@ -176,7 +168,7 @@ onUnmounted(() => {
       <div
         v-for="(s, i) in stars"
         :key="i"
-        class="absolute rounded-full bg-white"
+        class="absolute rounded-full bg-indigo-400 dark:bg-white"
         :style="{
           left: s.left + '%',
           top: s.top + '%',
@@ -190,7 +182,7 @@ onUnmounted(() => {
     <!-- 底部箭头 -->
     <button
       @click="emit('scrollToSection', 'features')"
-      class="absolute bottom-8 left-1/2 -translate-x-1/2 z-20 text-white/20 hover:text-white/50 transition-colors cursor-pointer"
+      class="absolute bottom-8 left-1/2 -translate-x-1/2 z-20 text-gray-400 hover:text-gray-700 dark:text-white/20 dark:hover:text-white/50 transition-colors cursor-pointer"
     >
       <i class="fa-solid fa-chevron-down text-lg animate-bounce"></i>
     </button>

--- a/frontend/src/views/home/HomeWorkflow.vue
+++ b/frontend/src/views/home/HomeWorkflow.vue
@@ -50,17 +50,33 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <section id="workflow" class="relative z-10 py-24 overflow-hidden">
+  <section id="workflow" class="relative z-10 py-24 overflow-hidden bg-slate-50 dark:bg-transparent transition-colors duration-200">
+    <!-- 顶部分割线 -->
+    <div class="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-gray-200 dark:via-white/[0.06] to-transparent transition-colors duration-200"></div>
+
     <div class="reveal max-w-5xl mx-auto px-4 sm:px-6 relative z-10">
       <div class="text-center mb-16">
-        <h2 class="reveal text-3xl font-semibold tracking-tight mb-4 text-transparent bg-clip-text animate-gradient-sweep" style="
+        <h2 class="reveal text-3xl font-semibold tracking-tight mb-4">
+          <span class="text-transparent bg-clip-text animate-gradient-sweep dark:hidden" style="
+            background-image: linear-gradient(to right, rgb(151, 137, 222) 0%, rgb(151, 137, 222) 20%, rgb(79, 70, 229) 50%, rgb(151, 137, 222) 80%, rgb(151, 137, 222) 100%);
+            background-size: 200% auto;
+          ">极简四步，自动运转</span>
+          <span class="text-transparent bg-clip-text animate-gradient-sweep hidden dark:inline" style="
             background-image: linear-gradient(to right, rgb(151, 137, 222) 0%, rgb(151, 137, 222) 20%, rgb(255, 255, 255) 50%, rgb(151, 137, 222) 80%, rgb(151, 137, 222) 100%);
             background-size: 200% auto;
-          ">极简四步，自动运转</h2>
-        <p class="text-white/40 text-sm">将原本需要耗费数小时的繁杂抄录，浓缩进点击之间。</p>
+          ">极简四步，自动运转</span>
+        </h2>
+        <p class="text-gray-600 dark:text-white/40 text-sm transition-colors duration-200">将原本需要耗费数小时的繁杂抄录，浓缩进点击之间。</p>
       </div>
 
       <div class="relative max-w-4xl mx-auto">
+        <!-- 连接线 -->
+        <div class="absolute top-10 left-12 right-12 h-px bg-gray-200 dark:bg-white/[0.06] hidden lg:block transition-colors duration-200 z-0">
+          <div
+            class="h-full bg-gradient-to-r from-indigo-500 to-violet-500 transition-all duration-700 ease-out"
+            :style="{ width: getProgressWidth() }"
+          ></div>
+        </div>
         <div class="grid grid-cols-1 lg:grid-cols-4 gap-4 relative z-10">
           <WorkflowStep
             v-for="(s, i) in STEPS"


### PR DESCRIPTION
## 改动范围

本次调整覆盖了首页的主要展示区域，包括：

- 顶部导航栏
- Hero 首屏区域
- 功能展示区
- 工作流说明区
- 效果演示区
- CTA / 页脚区域
- 首页公共按钮与卡片样式

## 具体改动内容

### 1. 首页主题切换能力补全
- 补齐首页主题状态初始化逻辑
- 让首页不再强制固定为深色模式
- 主题切换结果会和全局主题状态保持一致
- 主题切换入口接入首页导航栏，用户可以直接在首页进行切换

### 2. 导航栏适配浅色模式
- 调整导航栏在滚动前后两种状态下的边框、背景和文字颜色
- 优化浅色模式下的 hover / active 状态，避免出现对比度不足的问题
- 统一 GitHub 按钮、主题切换按钮和主操作按钮的视觉反馈

### 3. Hero 首屏区域双主题适配
- 保留原有 Hero 的核心视觉结构，包括顶部“土星 / 光环”构图、公式环、背景纹理和底部点状装饰
- 为浅色模式补充更柔和的光照覆盖层，避免直接切换后出现大面积沉暗背景
- 调整标题、描述文案、次按钮、星点和底部箭头在浅色模式下的可读性
- 控制浅色模式下公式环与轨道线的强度，使其仍然可见，但不会抢占主标题视觉焦点

### 4. 功能区 / 工作流 / 演示区的浅色视觉重建
- 将原本偏深色优先的区块补齐浅色模式下的背景、边框、文案与装饰线
- 优化浅色模式下卡片的玻璃态表现，避免“发灰”或“失去边界”的问题
- 调整各区块标题渐变色，使其在浅色背景下仍具备品牌感和辨识度
- 对说明文案、标签、示例卡片、流程节点等元素进行主题分层处理

### 5. 页脚与 CTA 区域适配
- 调整页脚与 CTA 区域在浅色模式下的背景、文字和光晕表现
- 保留原有氛围感，同时避免浅色模式下出现“深色残留感”
- 统一页脚链接的 hover 状态与整体主题风格

### 6. 公共样式与基础组件优化
- 扩展首页按钮在浅色模式下的 secondary / CTA 表现
- 调整首页卡片与流程步骤组件在两种主题下的边框、阴影和文本层级
- 补充首页相关样式的过渡效果，降低主题切换时的视觉突兀感

## 设计取舍

这次适配重点控制了两个方向：

1. **不破坏原有首页的视觉识别度**
   - 尤其是 Hero 的土星与公式环结构、品牌紫色渐变、整体科技感氛围，都尽量保留

2. **不做“机械式颜色反转”**
   - 浅色模式下针对不同区块分别调整了背景亮度、边框透明度、装饰纹理强度与高光表现
   - 目标是让浅色模式看起来像“同一套设计语言的另一种主题”，而不是单纯改色