### PR TITLE
feat(theme): 全局支持 App 内深浅色模式切换

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ printed-vs-handwritten/
 OmniDocBench.json
 .vscode
 .claude/
+.trae/
 
 # uv环境
 .python-version

--- a/frontend/src/components/auth/ForgotPasswordModal.vue
+++ b/frontend/src/components/auth/ForgotPasswordModal.vue
@@ -110,18 +110,18 @@ async function resetPassword() {
 
         <!-- 弹窗主体 -->
         <div
-          class="relative w-full max-w-sm rounded-2xl border border-white/[0.08] bg-[#0A0A0F]/95 backdrop-blur-xl p-6 shadow-xl"
+          class="relative w-full max-w-sm rounded-2xl border border-gray-200 dark:border-white/[0.08] bg-white/95 dark:bg-[#0A0A0F]/95 backdrop-blur-xl p-6 shadow-xl transition-colors duration-200"
           @click.stop>
           <!-- 关闭按钮 -->
           <button @click="emit('close')"
-            class="absolute right-4 top-4 text-white/25 hover:text-white/50 transition-colors">
+            class="absolute right-4 top-4 text-gray-400 hover:text-gray-600 dark:text-white/25 dark:hover:text-white/50 transition-colors">
             <i class="fas fa-xmark text-sm"></i>
           </button>
 
           <!-- Step 1: 邮箱 + 验证码 + 新密码 -->
           <template v-if="step === 1">
-            <h3 class="text-xl font-bold text-white mb-1">找回密码</h3>
-            <p class="text-sm text-white/40 mb-6">输入注册邮箱和验证码，设置新密码</p>
+            <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-1 transition-colors">找回密码</h3>
+            <p class="text-sm text-gray-500 dark:text-white/40 mb-6 transition-colors">输入注册邮箱和验证码，设置新密码</p>
 
             <div class="space-y-4">
               <BaseInput
@@ -132,10 +132,10 @@ async function resetPassword() {
               >
                 <template #append>
                   <button type="button" @click="sendCode" :disabled="codeSending || countdown > 0"
-                    class="shrink-0 h-10 px-4 rounded-xl border text-xs font-medium text-white/70 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                    class="shrink-0 h-10 px-4 rounded-xl border text-xs font-medium text-gray-700 dark:text-white/70 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
                     :class="countdown > 0
-                      ? 'bg-white/[0.02] border-white/[0.05] text-white/30'
-                      : 'bg-white/[0.03] border-white/[0.08] hover:bg-white/[0.06] hover:text-white/85'">
+                      ? 'bg-gray-100 border-gray-200 text-gray-400 dark:bg-white/[0.02] dark:border-white/[0.05] dark:text-white/30'
+                      : 'bg-white border-gray-200 hover:bg-gray-50 hover:text-gray-900 dark:bg-white/[0.03] dark:border-white/[0.08] dark:hover:bg-white/[0.06] dark:hover:text-white/85'">
                     <i v-if="codeSending" class="fas fa-spinner fa-spin"></i>
                     <template v-else-if="countdown > 0">{{ countdown }}s</template>
                     <template v-else>发送验证码</template>
@@ -167,7 +167,7 @@ async function resetPassword() {
                 placeholder="再次输入新密码"
               />
 
-              <p v-if="error" class="text-sm text-rose-400 flex items-center gap-2">
+              <p v-if="error" class="text-sm text-rose-500 dark:text-rose-400 flex items-center gap-2 transition-colors">
                 <i class="fas fa-circle-exclamation text-xs"></i>{{ error }}
               </p>
 
@@ -181,11 +181,11 @@ async function resetPassword() {
           <!-- Step 2: 完成 -->
           <template v-else>
             <div class="text-center py-4">
-              <div class="inline-flex items-center justify-center size-12 rounded-full bg-emerald-500/10 mb-4">
-                <i class="fas fa-check text-emerald-400 text-xl"></i>
+              <div class="inline-flex items-center justify-center size-12 rounded-full bg-emerald-500/10 mb-4 transition-colors">
+                <i class="fas fa-check text-emerald-500 dark:text-emerald-400 text-xl transition-colors"></i>
               </div>
-              <h3 class="text-xl font-bold text-white mb-2">密码已重置</h3>
-              <p class="text-sm text-white/40 mb-6">请使用新密码登录</p>
+              <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-2 transition-colors">密码已重置</h3>
+              <p class="text-sm text-gray-500 dark:text-white/40 mb-6 transition-colors">请使用新密码登录</p>
               <BaseButton variant="cta" class="w-full" @click="emit('close')">
                 返回登录
               </BaseButton>

--- a/frontend/src/components/base/BaseCard.vue
+++ b/frontend/src/components/base/BaseCard.vue
@@ -12,7 +12,7 @@ defineProps({
 <template>
   <div
     :class="[rounded, padding]"
-    class="border border-white/[0.06] bg-white/[0.02] transition-all hover:bg-white/[0.04] hover:border-white/[0.1]"
+    class="border border-gray-200 bg-white shadow-sm dark:border-white/[0.06] dark:bg-white/[0.02] transition-all hover:shadow-md hover:border-gray-300 dark:hover:bg-white/[0.04] dark:hover:border-white/[0.1]"
   >
     <slot />
   </div>

--- a/frontend/src/components/base/BaseDropdown.vue
+++ b/frontend/src/components/base/BaseDropdown.vue
@@ -1,0 +1,110 @@
+<script setup>
+/**
+ * BaseDropdown.vue
+ * 基础下拉菜单组件（支持自定义触发器和菜单内容）
+ */
+import { ref, onMounted, onUnmounted } from 'vue'
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false
+  },
+  position: {
+    type: String,
+    default: 'bottom' // 'top', 'bottom', 'left', 'right'
+  },
+  align: {
+    type: String,
+    default: 'right' // 'left', 'right', 'center'
+  },
+  width: {
+    type: String,
+    default: 'w-48'
+  },
+  offset: {
+    type: String,
+    default: 'mt-1' // 控制外边距
+  },
+  panelClass: {
+    type: String,
+    default: 'rounded-lg border bg-white shadow-lg dark:bg-[#15151e] dark:border-white/[0.08] py-1'
+  },
+  wrapperClass: {
+    type: String,
+    default: 'inline-block'
+  }
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const dropdownRef = ref(null)
+
+const toggle = () => {
+  emit('update:modelValue', !props.modelValue)
+}
+
+const close = () => {
+  if (props.modelValue) {
+    emit('update:modelValue', false)
+  }
+}
+
+// 点击外部关闭
+const handleClickOutside = (event) => {
+  if (dropdownRef.value && !dropdownRef.value.contains(event.target)) {
+    close()
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside)
+})
+</script>
+
+<template>
+  <div class="relative" :class="wrapperClass" ref="dropdownRef">
+    <!-- 触发器插槽 -->
+    <div @click="toggle" class="cursor-pointer h-full">
+      <slot name="trigger" :isOpen="modelValue" :toggle="toggle"></slot>
+    </div>
+
+    <!-- 菜单面板 -->
+    <Transition
+      enter-active-class="transition duration-150 ease-out"
+      enter-from-class="opacity-0 translate-y-2"
+      enter-to-class="opacity-100 translate-y-0"
+      leave-active-class="transition duration-100 ease-in"
+      leave-from-class="opacity-100 translate-y-0"
+      leave-to-class="opacity-0 translate-y-2"
+    >
+      <div
+        v-if="modelValue"
+        class="absolute z-50 overflow-hidden transition-colors duration-200"
+        :class="[
+          width,
+          offset,
+          panelClass,
+          {
+            'bottom-full mb-1': position === 'top',
+            'top-full mt-1': position === 'bottom',
+            'right-full mr-1': position === 'left',
+            'left-full ml-1': position === 'right',
+            'right-0': align === 'right',
+            'left-0': align === 'left',
+            'left-1/2 -translate-x-1/2': align === 'center',
+          }
+        ]"
+      >
+        <slot name="background"></slot>
+        <div class="relative z-10">
+          <slot :close="close"></slot>
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>

--- a/frontend/src/components/base/BaseInput.vue
+++ b/frontend/src/components/base/BaseInput.vue
@@ -62,7 +62,7 @@ const inputType = computed(() => {
 
 <template>
   <div>
-    <label v-if="label" class="block text-sm font-medium text-white/60 mb-2">{{ label }}</label>
+    <label v-if="label" class="block text-sm font-medium text-gray-700 dark:text-white/60 mb-2 transition-colors">{{ label }}</label>
     <div :class="['relative', { 'flex gap-2': $slots.append }]">
       <div class="relative flex-1 min-w-0">
         <input
@@ -75,8 +75,8 @@ const inputType = computed(() => {
           :maxlength="maxlength"
           :inputmode="inputmode"
           :class="[
-            'w-full h-10 px-4 rounded-xl border bg-white/[0.03] text-white placeholder-white/25 focus:outline-none focus:ring-0 focus:ring-offset-0 transition-all text-sm outline-none [&::-ms-reveal]:hidden [&::-ms-clear]:hidden',
-            error ? 'border-rose-500/50 focus:border-rose-500/50' : 'border-white/[0.08] focus:border-indigo-500/50',
+            'w-full h-10 px-4 rounded-xl border bg-white dark:bg-white/[0.03] text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-white/25 focus:outline-none focus:ring-0 focus:ring-offset-0 transition-all text-sm outline-none [&::-ms-reveal]:hidden [&::-ms-clear]:hidden',
+            error ? 'border-rose-500/50 focus:border-rose-500/50' : 'border-gray-200 dark:border-white/[0.08] focus:border-indigo-500/50 dark:focus:border-indigo-500/50',
             type === 'password' ? 'pr-11' : '',
             inputClass
           ]"
@@ -85,7 +85,7 @@ const inputType = computed(() => {
           v-if="type === 'password'"
           type="button"
           @click="showPwd = !showPwd"
-          class="absolute right-3 top-1/2 -translate-y-1/2 text-white/25 hover:text-white/50 transition-colors"
+          class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:text-white/25 dark:hover:text-white/50 transition-colors"
         >
           <i :class="showPwd ? 'fas fa-eye-slash' : 'fas fa-eye'" class="text-xs"></i>
         </button>

--- a/frontend/src/components/base/BaseLoading.vue
+++ b/frontend/src/components/base/BaseLoading.vue
@@ -13,10 +13,10 @@ const emit = defineEmits(['after-enter'])
 
 <template>
   <Transition name="loading-fade" @after-enter="emit('after-enter')">
-    <div v-if="visible" class="fixed inset-0 z-[200] flex flex-col items-center justify-center gap-8 bg-[#0A0A0F]">
+    <div v-if="visible" class="fixed inset-0 z-[200] flex flex-col items-center justify-center gap-8 bg-white dark:bg-[#0A0A0F] transition-colors duration-200">
       <BaseLogo size="lg" breathe />
       <div class="w-48">
-        <div class="h-0.5 w-full rounded-full bg-white/10 overflow-hidden">
+        <div class="h-0.5 w-full rounded-full bg-gray-200 dark:bg-white/10 overflow-hidden transition-colors">
           <div class="h-full rounded-full bg-gradient-to-r from-[rgba(129,115,223,0.8)] to-[rgba(99,87,199,0.8)] loading-bar"></div>
         </div>
       </div>

--- a/frontend/src/components/base/BaseSelect.vue
+++ b/frontend/src/components/base/BaseSelect.vue
@@ -46,7 +46,7 @@ const select = (val) => { emit('update:modelValue', val); open.value = false }
             type="button"
             @click.stop="select('')"
             class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-slate-100/80 dark:hover:bg-white/[0.04]"
-            :class="modelValue === '' ? 'text-slate-900 dark:text-[#f7f8f8]' : 'text-slate-600 dark:text-[#8a8f98]'"
+            :class="modelValue === '' ? 'text-slate-900 dark:text-[#f7f8f8] bg-slate-50 dark:bg-white/[0.02]' : 'text-slate-600 dark:text-[#8a8f98]'"
           >
             <span class="min-w-0 flex-1 truncate">{{ placeholder }}</span>
             <i v-if="modelValue === ''" class="fa-solid fa-check shrink-0 text-[10px] text-[rgb(129,115,223)]"></i>
@@ -56,7 +56,7 @@ const select = (val) => { emit('update:modelValue', val); open.value = false }
             type="button"
             @click.stop="select(opt)"
             class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-slate-100/80 dark:hover:bg-white/[0.04]"
-            :class="modelValue === opt ? 'text-slate-900 dark:text-[#f7f8f8]' : 'text-slate-600 dark:text-[#8a8f98]'"
+            :class="modelValue === opt ? 'text-slate-900 dark:text-[#f7f8f8] bg-slate-50 dark:bg-white/[0.02]' : 'text-slate-600 dark:text-[#8a8f98]'"
           >
             <span class="min-w-0 flex-1 truncate">{{ opt }}</span>
             <i v-if="modelValue === opt" class="fa-solid fa-check shrink-0 text-[10px] text-[rgb(129,115,223)]"></i>

--- a/frontend/src/components/base/EmptyState.vue
+++ b/frontend/src/components/base/EmptyState.vue
@@ -13,15 +13,15 @@ defineProps({
 <template>
   <div class="flex flex-1 flex-col items-center justify-center">
     <!-- 图标 -->
-    <div v-if="icon" class="mb-6 flex h-16 w-16 items-center justify-center rounded-xl border border-white/[0.06] bg-white/[0.02]">
-      <i :class="icon" class="text-2xl text-[#62666d]"></i>
+    <div v-if="icon" class="mb-6 flex h-16 w-16 items-center justify-center rounded-xl border border-gray-200 bg-white dark:border-white/[0.06] dark:bg-white/[0.02]">
+      <i :class="icon" class="text-2xl text-gray-400 dark:text-[#62666d]"></i>
     </div>
 
     <!-- 标题 -->
-    <h3 class="text-base font-medium text-[#f7f8f8]">{{ title }}</h3>
+    <h3 class="text-base font-medium text-gray-900 dark:text-[#f7f8f8]">{{ title }}</h3>
 
     <!-- 描述 -->
-    <p v-if="description" class="mt-2 max-w-sm text-center text-sm text-[#62666d] leading-relaxed">{{ description }}</p>
+    <p v-if="description" class="mt-2 max-w-sm text-center text-sm text-gray-500 dark:text-[#62666d] leading-relaxed">{{ description }}</p>
 
     <!-- 操作按钮区 -->
     <div v-if="$slots.default" class="mt-6 flex items-center gap-3">

--- a/frontend/src/components/base/SearchInput.vue
+++ b/frontend/src/components/base/SearchInput.vue
@@ -15,15 +15,15 @@ const emit = defineEmits(['update:modelValue'])
 
 <template>
   <div>
-    <label v-if="label" class="mb-1.5 block text-xs font-medium text-[#62666d]">{{ label }}</label>
+    <label v-if="label" class="mb-1.5 block text-xs font-medium text-gray-600 dark:text-[#62666d]">{{ label }}</label>
     <div class="relative group">
-      <i :class="icon" class="pointer-events-none absolute left-3 top-1/2 z-10 -translate-y-1/2 text-xs text-[#62666d] transition-colors group-focus-within:text-[#8a8f98]"></i>
+      <i :class="icon" class="pointer-events-none absolute left-3 top-1/2 z-10 -translate-y-1/2 text-xs text-gray-400 dark:text-[#62666d] transition-colors group-focus-within:text-gray-500 dark:group-focus-within:text-[#8a8f98]"></i>
       <input
         :value="modelValue"
         @input="emit('update:modelValue', $event.target.value)"
         type="text"
         :placeholder="placeholder"
-        class="h-9 w-full rounded-md border border-white/[0.08] bg-white/[0.02] pl-9 pr-3 text-sm font-medium text-[#f7f8f8] placeholder-[#62666d] outline-none transition-colors hover:border-white/[0.12] focus:border-white/[0.15] border-top-color-[rgba(255,255,255,0.12)]"
+        class="h-9 w-full rounded-md border border-gray-200 bg-white pl-9 pr-3 text-sm font-medium text-gray-900 placeholder-gray-400 outline-none transition-colors hover:border-gray-300 focus:border-indigo-500 dark:border-white/[0.08] dark:bg-white/[0.02] dark:text-[#f7f8f8] dark:placeholder-[#62666d] dark:hover:border-white/[0.12] dark:focus:border-white/[0.15] dark:border-t-white/[0.12]"
       />
     </div>
   </div>

--- a/frontend/src/components/dashboard/StatCard.vue
+++ b/frontend/src/components/dashboard/StatCard.vue
@@ -15,11 +15,11 @@ const props = defineProps({
 })
 
 const colorMap = {
-  indigo: 'text-indigo-600 bg-indigo-50 dark:text-indigo-400 dark:bg-indigo-500/10',
-  blue: 'text-blue-600 bg-blue-50 dark:text-blue-400 dark:bg-blue-500/10',
-  emerald: 'text-emerald-600 bg-emerald-50 dark:text-emerald-400 dark:bg-emerald-500/10',
-  slate: 'text-slate-600 bg-slate-50 dark:text-slate-400 dark:bg-slate-500/10',
-  rose: 'text-rose-600 bg-rose-50 dark:text-rose-400 dark:bg-rose-500/10',
+  indigo: 'text-indigo-600 bg-indigo-100 dark:text-indigo-400 dark:bg-indigo-500/10',
+  blue: 'text-blue-600 bg-blue-100 dark:text-blue-400 dark:bg-blue-500/10',
+  emerald: 'text-emerald-600 bg-emerald-100 dark:text-emerald-400 dark:bg-emerald-500/10',
+  slate: 'text-slate-600 bg-slate-100 dark:text-slate-400 dark:bg-slate-500/10',
+  rose: 'text-rose-600 bg-rose-100 dark:text-rose-400 dark:bg-rose-500/10',
 }
 
 // 数字滚动动画

--- a/frontend/src/components/question/QuestionCard.vue
+++ b/frontend/src/components/question/QuestionCard.vue
@@ -4,6 +4,7 @@
  * 题目卡片（错题库列表项）
  */
 import { ref, computed } from 'vue'
+import BaseCard from '@/components/base/BaseCard.vue'
 import { isHtml, sanitizeHtml, formatOption } from '@/utils.js'
 
 const props = defineProps({
@@ -73,42 +74,44 @@ const cancelUserAnswer = () => { editingUserAnswer.value = false }
 </script>
 
 <template>
-  <div
-    class="question-card group relative overflow-hidden rounded-2xl border bg-white/70 p-6 shadow-sm transition-shadow hover:shadow-md dark:bg-white/[0.03]"
+  <BaseCard
+    class="question-card group relative overflow-hidden transition-shadow hover:shadow-md cursor-pointer"
+    padding="p-6"
+    rounded="rounded-2xl"
     :class="
       selected
-        ? 'border-blue-500/50 shadow-blue-500/10 dark:border-indigo-500/50 dark:shadow-indigo-500/20'
-        : 'border-slate-200/60 dark:border-white/10 hover:border-blue-200 dark:hover:border-white/15'
+        ? '!border-[rgb(129,115,223)]/50 !shadow-[rgb(129,115,223)]/10 dark:!border-[rgb(129,115,223)]/50 dark:!shadow-[rgb(129,115,223)]/20'
+        : 'hover:!border-[rgb(129,115,223)]/30 dark:hover:!border-white/15'
     "
     @click="emit('toggle', question.uid)"
   >
     <!-- 选中态背景 -->
     <div
       v-if="selected"
-      class="absolute inset-0 -z-10 bg-gradient-to-br from-blue-500/[0.03] to-indigo-500/[0.03] dark:from-indigo-500/[0.05] dark:to-purple-500/[0.05]"
+      class="absolute inset-0 -z-10 bg-gradient-to-br from-[rgb(129,115,223)]/[0.03] to-[rgb(99,87,199)]/[0.03] dark:from-[rgb(129,115,223)]/[0.05] dark:to-[rgb(99,87,199)]/[0.05]"
     ></div>
 
     <!-- 大题标签 -->
     <div
       v-if="question.section_title"
-      class="mb-4 flex items-center gap-2 border-l-2 border-blue-400/60 pl-3 dark:border-indigo-400/50"
+      class="mb-4 flex items-center gap-2 border-l-2 border-[rgb(129,115,223)]/60 pl-3 dark:border-[rgb(129,115,223)]/50"
     >
-      <i class="fa-solid fa-layer-group text-xs text-blue-400 dark:text-indigo-400"></i>
-      <span class="text-xs font-bold tracking-wide text-slate-500 dark:text-slate-400">{{ question.section_title }}</span>
+      <i class="fa-solid fa-layer-group text-xs text-[rgb(129,115,223)] dark:text-[rgb(145,132,235)]"></i>
+      <span class="text-xs font-bold tracking-wide text-gray-500 dark:text-gray-400">{{ question.section_title }}</span>
     </div>
 
     <!-- 顶部状态栏 -->
     <div class="mb-6 flex items-start gap-4">
       <!-- 题型与标签 -->
       <div class="flex flex-wrap items-center gap-2">
-        <span class="text-xs font-bold tracking-widest text-slate-400 dark:text-slate-500">AI 识别标签</span>
-        <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-bold uppercase tracking-widest text-slate-500 dark:bg-white/5 dark:text-slate-400">
+        <span class="text-xs font-bold tracking-widest text-gray-400 dark:text-gray-500">AI 识别标签</span>
+        <span class="rounded-full bg-gray-100 px-3 py-1 text-xs font-bold uppercase tracking-widest text-gray-500 dark:bg-white/5 dark:text-gray-400">
           {{ question.question_type }}
         </span>
         <span
           v-for="tag in question.knowledge_tags"
           :key="tag"
-          class="rounded-full bg-blue-50 px-3 py-1 text-xs font-bold text-blue-600 dark:bg-indigo-500/10 dark:text-indigo-400"
+          class="rounded-full bg-[rgb(129,115,223)]/10 px-3 py-1 text-xs font-bold text-[rgb(129,115,223)] dark:bg-[rgb(129,115,223)]/20 dark:text-[rgb(145,132,235)]"
         >
           {{ tag }}
         </span>
@@ -116,12 +119,12 @@ const cancelUserAnswer = () => { editingUserAnswer.value = false }
 
       <!-- 右侧复选框 -->
       <div class="ml-auto flex items-center gap-4">
-        <span class="text-xs font-bold uppercase tracking-widest text-slate-400" :class="selected && 'text-blue-600 dark:text-indigo-400'">
+        <span class="text-xs font-bold uppercase tracking-widest text-gray-400" :class="selected && 'text-[rgb(129,115,223)] dark:text-[rgb(145,132,235)]'">
           {{ selected ? '已选择' : '未选择' }}
         </span>
         <div
           class="flex h-5 w-5 items-center justify-center rounded-lg border-2 transition-all"
-          :class="selected ? 'border-blue-500 bg-blue-500 text-white shadow-sm dark:border-indigo-500 dark:bg-indigo-500' : 'border-slate-200 bg-white dark:border-white/5 dark:bg-slate-800'"
+          :class="selected ? 'border-[rgb(129,115,223)] bg-[rgb(129,115,223)] text-white shadow-sm' : 'border-gray-200 bg-white dark:border-white/5 dark:bg-[#15151e]'"
         >
           <i v-if="selected" class="fa-solid fa-check text-[10px]"></i>
         </div>
@@ -132,11 +135,11 @@ const cancelUserAnswer = () => { editingUserAnswer.value = false }
     <div class="question-content relative">
       <template v-if="question.content_blocks?.length">
         <div v-for="(b, i) in question.content_blocks" :key="i">
-          <div v-if="b.block_type === 'text'" class="my-4 text-base font-medium leading-relaxed text-slate-800 dark:text-slate-200" v-html="isHtml(b.content) ? sanitizeHtml(b.content) : b.content"></div>
+          <div v-if="b.block_type === 'text'" class="my-4 text-base font-medium leading-relaxed text-gray-800 dark:text-[#d0d6e0]" v-html="isHtml(b.content) ? sanitizeHtml(b.content) : b.content"></div>
           <img
             v-else-if="b.block_type === 'image' && b.content"
             :src="b.content"
-            class="my-6 max-h-[400px] cursor-zoom-in rounded-2xl border border-slate-100 shadow-sm transition-transform hover:scale-[1.01] dark:border-white/5"
+            class="my-6 max-h-[400px] cursor-zoom-in rounded-2xl border border-gray-100 dark:border-white/5 shadow-sm transition-transform hover:scale-[1.01]"
             @click.stop="() => emit('open-image', b.content)"
           />
         </div>
@@ -147,7 +150,7 @@ const cancelUserAnswer = () => { editingUserAnswer.value = false }
         <img
           v-for="(src, i) in extraImages" :key="'extra-' + i"
           :src="src"
-          class="max-h-[200px] cursor-zoom-in rounded-2xl border border-slate-100 object-contain shadow-sm transition-transform hover:scale-[1.01] dark:border-white/5"
+          class="max-h-[200px] cursor-zoom-in rounded-2xl border border-gray-100 dark:border-white/5 object-contain shadow-sm transition-transform hover:scale-[1.01]"
           @click.stop="() => emit('open-image', src)"
         />
       </div>
@@ -157,33 +160,33 @@ const cancelUserAnswer = () => { editingUserAnswer.value = false }
         <div
           v-for="(opt, idx) in question.options"
           :key="idx"
-          class="flex items-center gap-3 rounded-xl border border-slate-100 bg-slate-50/30 p-4 text-[13px] font-bold text-slate-700 hover:bg-slate-50 dark:border-white/5 dark:bg-white/5 dark:text-slate-300 dark:hover:bg-white/10"
+          class="flex items-center gap-3 rounded-xl border border-gray-100 bg-gray-50/50 p-4 text-[13px] font-bold text-gray-700 hover:bg-gray-100/80 dark:border-white/5 dark:bg-white/5 dark:text-[#d0d6e0] dark:hover:bg-white/10 transition-colors"
         >
-          <span class="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-white text-[10px] shadow-sm dark:bg-slate-800">{{ formatOption(opt)[0] }}</span>
+          <span class="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-white text-[10px] shadow-sm dark:bg-[#15151e]">{{ formatOption(opt)[0] }}</span>
           <span class="flex-1">{{ formatOption(opt).slice(2) }}</span>
           <img
             v-if="optionImages?.[idx]"
             :src="optionImages[idx]"
-            class="max-h-[100px] max-w-[160px] shrink-0 cursor-zoom-in rounded-lg border border-slate-100 object-contain dark:border-white/5"
+            class="max-h-[100px] max-w-[160px] shrink-0 cursor-zoom-in rounded-lg border border-gray-100 object-contain dark:border-white/5"
             @click.stop="() => emit('open-image', optionImages[idx])"
           />
         </div>
       </div>
     </div>
 
-  </div>
+  </BaseCard>
 </template>
 
 <style>
 .question-content table {
-  @apply my-4 w-full border-collapse text-sm;
+  @apply my-4 w-full border-collapse text-sm transition-colors;
 }
 .question-content th,
 .question-content td {
-  @apply border border-slate-200 px-3 py-2 text-center dark:border-white/10;
+  @apply border border-gray-200 px-3 py-2 text-center dark:border-white/10 transition-colors;
 }
 .question-content th {
-  @apply bg-slate-50 font-bold dark:bg-white/[0.04];
+  @apply bg-gray-50 font-bold dark:bg-white/[0.04] transition-colors;
 }
 .question-content img {
   @apply inline-block max-h-[200px] object-contain;

--- a/frontend/src/components/question/QuestionItem.vue
+++ b/frontend/src/components/question/QuestionItem.vue
@@ -5,6 +5,7 @@
  */
 import { ref, watch, nextTick } from 'vue'
 import { getQuestionSnippet, typesetMath } from '@/utils.js'
+import BaseCard from '@/components/base/BaseCard.vue'
 
 const props = defineProps({
   question: { type: Object, required: true },
@@ -52,16 +53,16 @@ const statusIcon = (status) => {
 </script>
 
 <template>
-  <div
+  <BaseCard
     @click="selectable ? emit('toggle-select', question.id) : emit('click', question)"
-    class="group cursor-pointer rounded-lg border border-white/[0.06] bg-white/[0.02] p-4 transition-all hover:bg-white/[0.04] hover:border-white/[0.1]"
-    :class="{ 'border-[rgb(129,115,223)]/40 bg-[rgb(129,115,223)]/[0.06]': selected }"
+    class="group cursor-pointer"
+    :class="{ '!border-indigo-400 !bg-indigo-50 dark:!border-[rgb(129,115,223)]/40 dark:!bg-[rgb(129,115,223)]/[0.06]': selected }"
   >
     <div class="flex items-start gap-4">
       <!-- 选择复选框 -->
       <div v-if="selectable" class="flex shrink-0 items-center pt-1" @click.stop="emit('toggle-select', question.id)">
         <div class="flex h-5 w-5 items-center justify-center rounded-lg border-2 transition-all"
-          :class="selected ? 'border-[rgb(129,115,223)] bg-[rgb(129,115,223)] text-white' : 'border-white/[0.15]'">
+          :class="selected ? 'border-[rgb(129,115,223)] bg-[rgb(129,115,223)] text-white' : 'border-gray-200 dark:border-white/[0.15] bg-white dark:bg-transparent'">
           <i v-if="selected" class="fa-solid fa-check text-xs"></i>
         </div>
       </div>
@@ -71,13 +72,13 @@ const statusIcon = (status) => {
         <div class="mb-2 flex flex-wrap items-center gap-2">
           <!-- 复习状态图标 -->
           <i v-if="showStatus" class="fa-solid text-sm" :class="[statusIcon(question.review_status), statusColor(question.review_status)]"></i>
-          <span class="rounded-full bg-white/[0.04] px-2 py-0.5 text-xs font-medium text-[#8a8f98]">{{ question.question_type }}</span>
-          <span v-if="question.subject" class="rounded-full bg-[rgb(129,115,223)]/10 px-2 py-0.5 text-xs font-medium text-[rgb(145,132,235)]">{{ question.subject }}</span>
-          <span v-for="tag in tags()" :key="tag" class="rounded-full border border-white/[0.06] px-2 py-0.5 text-xs font-medium text-[#8a8f98]">{{ tag }}</span>
+          <span class="rounded-full bg-gray-100 dark:bg-white/[0.04] px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-[#8a8f98] transition-colors">{{ question.question_type }}</span>
+          <span v-if="question.subject" class="rounded-full bg-[rgb(129,115,223)]/10 px-2 py-0.5 text-xs font-medium text-[rgb(129,115,223)] dark:text-[rgb(145,132,235)] transition-colors">{{ question.subject }}</span>
+          <span v-for="tag in tags()" :key="tag" class="rounded-full border border-gray-200 dark:border-white/[0.06] px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-[#8a8f98] transition-colors">{{ tag }}</span>
         </div>
 
         <!-- 摘要 -->
-        <p class="line-clamp-2 text-sm font-medium leading-relaxed text-[#d0d6e0] group-hover:text-[#f7f8f8]">{{ summary() }}</p>
+        <p class="line-clamp-2 text-sm font-medium leading-relaxed text-gray-700 dark:text-[#d0d6e0] group-hover:text-gray-900 dark:group-hover:text-[#f7f8f8] transition-colors">{{ summary() }}</p>
 
         <!-- 题目图片 -->
         <div v-if="question.content_json?.some(b => b.block_type === 'image' && b.content)" class="mt-3 flex flex-wrap gap-2">
@@ -85,7 +86,7 @@ const statusIcon = (status) => {
             v-for="(b, i) in question.content_json.filter(b => b.block_type === 'image' && b.content)"
             :key="i"
             :src="b.content"
-            class="max-h-32 rounded-lg border border-white/[0.06] object-contain"
+            class="max-h-32 rounded-lg border border-gray-200 dark:border-white/[0.06] object-contain transition-colors"
             @click.stop
           />
         </div>
@@ -95,9 +96,9 @@ const statusIcon = (status) => {
           <div
             v-for="(opt, idx) in question.options_json"
             :key="idx"
-            class="flex items-start gap-2 rounded-md border border-white/[0.06] bg-white/[0.02] px-3 py-1.5 text-xs font-medium text-[#8a8f98]"
+            class="flex items-start gap-2 rounded-md border border-gray-200 dark:border-white/[0.06] bg-gray-50 dark:bg-white/[0.02] px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-[#8a8f98] transition-colors"
           >
-            <span class="shrink-0 text-[#62666d]">{{ String.fromCharCode(65 + idx) }}.</span>
+            <span class="shrink-0 text-gray-400 dark:text-[#62666d] transition-colors">{{ String.fromCharCode(65 + idx) }}.</span>
             <span class="line-clamp-1">{{ String(opt).replace(/^[A-Da-d][.、．]\s*/, '') }}</span>
           </div>
         </div>
@@ -111,5 +112,5 @@ const statusIcon = (status) => {
         <slot name="actions" :question="question" />
       </div>
     </div>
-  </div>
+  </BaseCard>
 </template>

--- a/frontend/src/components/workspace/ActionBar.vue
+++ b/frontend/src/components/workspace/ActionBar.vue
@@ -28,18 +28,18 @@ const emit = defineEmits(['split', 'export', 'save-to-db'])
       @click="emit('split')"
     >
       <!-- 按钮本体 -->
-      <span class="relative overflow-hidden inline-flex h-full w-full items-center justify-center gap-2 rounded-md px-8 text-sm font-medium text-white brand-btn">
+      <span class="relative overflow-hidden inline-flex h-full w-full items-center justify-center gap-2 rounded-md px-8 text-sm font-medium text-white brand-btn transition-colors">
         <template v-if="splitting">
-          <i class="fa-solid fa-spinner fa-spin" :class="uploadMode === 'note' ? 'text-emerald-400' : 'text-white/80'"></i>
-          <span>{{ uploadMode === 'note' ? '正在整理笔记...' : '正在智能分割...' }}</span>
+          <i class="fa-solid fa-spinner fa-spin" :class="uploadMode === 'note' ? 'text-emerald-500 dark:text-emerald-400' : 'text-gray-600 dark:text-white/80'"></i>
+          <span class="text-gray-900 dark:text-white">{{ uploadMode === 'note' ? '正在整理笔记...' : '正在智能分割...' }}</span>
         </template>
         <template v-else-if="splitCompleted">
-          <i class="fa-solid fa-check-double text-emerald-400"></i>
-          <span>{{ uploadMode === 'note' ? '整理已完成' : '解析已完成' }}</span>
+          <i class="fa-solid fa-check-double text-emerald-500 dark:text-emerald-400"></i>
+          <span class="text-gray-900 dark:text-white">{{ uploadMode === 'note' ? '整理已完成' : '解析已完成' }}</span>
         </template>
         <template v-else>
-          <i class="fa-solid text-white/80" :class="uploadMode === 'note' ? 'fa-book-open' : eraseEnabled ? 'fa-eraser' : 'fa-eye'"></i>
-          <span>{{ uploadMode === 'note' ? '启动 AI 笔记整理' : eraseEnabled ? '开始擦除笔迹' : '开始 OCR 识别' }}</span>
+          <i class="fa-solid text-gray-600 dark:text-white/80" :class="uploadMode === 'note' ? 'fa-book-open' : eraseEnabled ? 'fa-eraser' : 'fa-eye'"></i>
+          <span class="text-gray-900 dark:text-white">{{ uploadMode === 'note' ? '启动 AI 笔记整理' : eraseEnabled ? '开始擦除笔迹' : '开始 OCR 识别' }}</span>
         </template>
       </span>
     </button>
@@ -49,10 +49,10 @@ const emit = defineEmits(['split', 'export', 'save-to-db'])
       <button
         v-if="exportEnabled"
         type="button"
-        class="group relative inline-flex h-14 items-center justify-center gap-3 rounded-lg brand-btn px-8 text-sm font-medium tracking-widest text-[#f7f8f8] hover:border-white/[0.12] hover:bg-white/[0.05] disabled:cursor-not-allowed disabled:opacity-30"
+        class="group relative inline-flex h-14 items-center justify-center gap-3 rounded-lg brand-btn px-8 text-sm font-medium tracking-widest text-gray-900 dark:text-[#f7f8f8] hover:border-gray-400 dark:hover:border-white/[0.12] hover:bg-gray-100 dark:hover:bg-white/[0.05] disabled:cursor-not-allowed disabled:opacity-30 transition-colors"
         @click="emit('export')"
       >
-        <i class="fa-solid fa-file-export transition-transform group-hover:-translate-x-0.5"></i>
+        <i class="fa-solid fa-file-export transition-transform group-hover:-translate-x-0.5 text-gray-600 dark:text-white/80"></i>
         导出错题本
       </button>
     </Transition>
@@ -62,10 +62,10 @@ const emit = defineEmits(['split', 'export', 'save-to-db'])
       <button
         v-if="exportEnabled"
         type="button"
-        class="group relative inline-flex h-14 items-center justify-center gap-3 rounded-lg brand-btn px-8 text-sm font-medium tracking-widest text-[#f7f8f8] hover:border-white/[0.12] hover:bg-white/[0.05] disabled:cursor-not-allowed disabled:opacity-30"
+        class="group relative inline-flex h-14 items-center justify-center gap-3 rounded-lg brand-btn px-8 text-sm font-medium tracking-widest text-gray-900 dark:text-[#f7f8f8] hover:border-gray-400 dark:hover:border-white/[0.12] hover:bg-gray-100 dark:hover:bg-white/[0.05] disabled:cursor-not-allowed disabled:opacity-30 transition-colors"
         @click="emit('save-to-db')"
       >
-        <i class="fa-solid fa-database transition-transform group-hover:-translate-y-0.5"></i>
+        <i class="fa-solid fa-database transition-transform group-hover:-translate-y-0.5 text-gray-600 dark:text-white/80"></i>
         导入错题库
       </button>
     </Transition>

--- a/frontend/src/components/workspace/ContentPanel.vue
+++ b/frontend/src/components/workspace/ContentPanel.vue
@@ -14,11 +14,11 @@ const emit = defineEmits(['step-click'])
 </script>
 
 <template>
-  <div class="h-full flex flex-col rounded-none md:rounded-lg brand-btn overflow-hidden" style="background: rgba(255,255,255,0.04);">
+  <div class="h-full flex flex-col rounded-none md:rounded-lg brand-btn overflow-hidden dark:!bg-white/[0.04] transition-colors duration-200">
     <!-- 顶部栏 -->
-    <header class="flex items-center h-14 px-4 border-b border-white/[0.08] shrink-0 gap-4">
+    <header class="flex items-center h-14 px-4 border-b border-gray-200 dark:border-white/[0.08] shrink-0 gap-4 transition-colors">
       <!-- 标题 -->
-      <h2 class="text-sm font-medium text-[#f7f8f8] shrink-0">{{ title }}</h2>
+      <h2 class="text-sm font-medium text-gray-900 dark:text-[#f7f8f8] shrink-0 transition-colors">{{ title }}</h2>
 
       <!-- 步骤 tab（可选） -->
       <div v-if="steps.length" class="flex items-center gap-1 ml-2">
@@ -28,18 +28,18 @@ const emit = defineEmits(['step-click'])
           @click="emit('step-click', i)"
           class="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs transition-colors"
           :class="i === currentStep
-            ? 'bg-white/[0.06] text-[#f7f8f8] font-medium'
+            ? 'brand-gradient-bg text-white shadow-sm font-medium'
             : s.done
-              ? 'text-[#8a8f98] hover:bg-white/[0.04] hover:text-[#d0d6e0]'
-              : 'text-[#62666d] cursor-default'"
+              ? 'text-gray-500 dark:text-[#8a8f98] hover:bg-gray-100 dark:hover:bg-white/[0.04] hover:text-gray-700 dark:hover:text-[#d0d6e0]'
+              : 'text-gray-400 dark:text-[#62666d] cursor-default'"
         >
           <span
-            class="flex h-4 w-4 items-center justify-center rounded text-[10px]"
+            class="flex h-4 w-4 items-center justify-center rounded text-[10px] transition-colors"
             :class="s.done
               ? 'bg-[rgb(129,115,223)] text-white'
               : i === currentStep
-                ? 'bg-white/[0.08] text-[#f7f8f8]'
-                : 'bg-white/[0.04] text-[#62666d]'"
+                ? 'bg-white/20 text-white'
+                : 'bg-gray-100 dark:bg-white/[0.04] text-gray-400 dark:text-[#62666d]'"
           >
             <i v-if="s.done" class="fa-solid fa-check text-[8px]"></i>
             <span v-else>{{ i + 1 }}</span>
@@ -49,7 +49,7 @@ const emit = defineEmits(['step-click'])
       </div>
 
       <!-- 左侧附加操作 -->
-      <div v-if="$slots.actions" class="flex items-center gap-1 text-[#62666d]">
+      <div v-if="$slots.actions" class="flex items-center gap-1 text-gray-500 dark:text-[#62666d] transition-colors">
         <slot name="actions"></slot>
       </div>
 
@@ -69,9 +69,17 @@ const emit = defineEmits(['step-click'])
       </div>
 
       <!-- 右侧属性栏（可选） -->
-      <aside v-if="$slots.sidebar" class="hidden lg:flex w-80 shrink-0 flex-col border-l border-white/[0.05] overflow-y-auto">
+      <aside v-if="$slots.sidebar" class="hidden lg:flex w-80 shrink-0 flex-col border-l border-gray-200 dark:border-white/[0.05] overflow-y-auto transition-colors">
         <slot name="sidebar"></slot>
       </aside>
     </div>
   </div>
 </template>
+
+<style scoped>
+.brand-gradient-bg {
+  background: linear-gradient(to bottom, rgba(129, 115, 223, 0.9), rgba(99, 87, 199, 0.9));
+  box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.12);
+  border: none;
+}
+</style>

--- a/frontend/src/components/workspace/ErasePreview.vue
+++ b/frontend/src/components/workspace/ErasePreview.vue
@@ -47,7 +47,7 @@ function onPointerDown(event) {
 
     <!-- 无数据 -->
     <div v-else-if="!images.length" class="flex-1 flex items-center justify-center">
-      <p class="text-sm text-[#62666d]">暂无擦除数据</p>
+      <p class="text-sm text-gray-500 dark:text-[#62666d] transition-colors">暂无擦除数据</p>
     </div>
 
     <!-- 预览（单张 + 分页） -->
@@ -90,7 +90,7 @@ function onPointerDown(event) {
           :key="i"
           @click="currentPage = i; sliderPos = 50"
           class="h-2 rounded-full transition-all"
-          :class="i === currentPage ? 'w-6 bg-[rgb(129,115,223)]' : 'w-2 bg-white/20 hover:bg-white/40'"
+          :class="i === currentPage ? 'w-6 bg-[rgb(129,115,223)]' : 'w-2 bg-gray-300 dark:bg-white/20 hover:bg-gray-400 dark:hover:bg-white/40'"
         />
       </div>
     </template>

--- a/frontend/src/components/workspace/ErrorBankFilterPanel.vue
+++ b/frontend/src/components/workspace/ErrorBankFilterPanel.vue
@@ -19,36 +19,36 @@ const emit = defineEmits(['close', 'toggle-tag'])
 <template>
   <div class="p-4 space-y-4">
     <div class="flex items-center justify-between">
-      <span class="text-xs font-medium text-[#f7f8f8]">筛选设置</span>
-      <button @click="emit('close')" class="text-[#62666d] hover:text-[#8a8f98] transition-colors">
+      <span class="text-xs font-medium text-slate-700 dark:text-[#f7f8f8]">筛选设置</span>
+      <button @click="emit('close')" class="text-slate-400 hover:text-slate-600 dark:text-[#62666d] dark:hover:text-[#8a8f98] transition-colors">
         <i class="fa-solid fa-xmark text-xs"></i>
       </button>
     </div>
 
     <div>
-      <label class="mb-1.5 block text-xs font-medium text-[#62666d]">学科</label>
+      <label class="mb-1.5 block text-xs font-medium text-slate-500 dark:text-[#62666d]">学科</label>
       <BaseSelect v-model="filters.subject" :options="subjects" placeholder="全部学科" />
     </div>
 
     <div>
-      <label class="mb-1.5 block text-xs font-medium text-[#62666d]">题型</label>
+      <label class="mb-1.5 block text-xs font-medium text-slate-500 dark:text-[#62666d]">题型</label>
       <BaseSelect v-model="filters.question_type" :options="questionTypes" placeholder="全部题型" />
     </div>
 
     <div>
-      <label class="mb-1.5 block text-xs font-medium text-[#62666d]">复习状态</label>
+      <label class="mb-1.5 block text-xs font-medium text-slate-500 dark:text-[#62666d]">复习状态</label>
       <BaseSelect v-model="filters.review_status" :options="['待复习', '复习中', '已掌握']" placeholder="全部状态" />
     </div>
 
     <div v-if="tagNames?.length">
-      <label class="mb-1.5 block text-xs font-medium text-[#62666d]">知识点</label>
+      <label class="mb-1.5 block text-xs font-medium text-slate-500 dark:text-[#62666d]">知识点</label>
       <div class="flex flex-wrap gap-1.5">
         <button v-for="tag in tagNames" :key="tag"
           @click="emit('toggle-tag', tag)"
           class="rounded-md px-2 py-0.5 text-xs font-medium transition-all"
           :class="selectedTags?.has(tag)
-            ? 'bg-[rgb(129,115,223)] text-white'
-            : 'border border-white/[0.06] bg-white/[0.02] text-[#62666d] hover:text-[#8a8f98] hover:border-white/[0.1]'"
+            ? 'bg-indigo-500 text-white dark:bg-[rgb(129,115,223)]'
+            : 'border border-slate-200 bg-white text-slate-600 hover:text-slate-800 hover:border-slate-300 hover:bg-slate-50 dark:border-white/[0.06] dark:bg-white/[0.02] dark:text-[#62666d] dark:hover:text-[#8a8f98] dark:hover:border-white/[0.1] dark:hover:bg-white/[0.04]'"
         >{{ tag }}</button>
       </div>
     </div>

--- a/frontend/src/components/workspace/FileList.vue
+++ b/frontend/src/components/workspace/FileList.vue
@@ -29,7 +29,7 @@ const emit = defineEmits(['remove-file'])
         <div
           v-for="item in pendingFiles"
           :key="item.key"
-          class="relative flex items-center gap-2.5 overflow-hidden rounded-md border border-white/[0.08] bg-white/[0.02] px-3 py-2"
+          class="relative flex items-center gap-2.5 overflow-hidden rounded-md border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.02] px-3 py-2 transition-colors"
         >
           <!-- 进度条背景 -->
           <div
@@ -38,25 +38,25 @@ const emit = defineEmits(['remove-file'])
           ></div>
 
           <i
-            class="fa-solid text-sm shrink-0"
+            class="fa-solid text-sm shrink-0 transition-colors"
             :class="
               item.file.name.toLowerCase().endsWith('.pdf')
-                ? 'fa-file-pdf text-rose-400'
+                ? 'fa-file-pdf text-rose-500 dark:text-rose-400'
                 : 'fa-file-image text-[rgb(129,115,223)]'
             "
           ></i>
           <div class="flex flex-col min-w-0 pr-4 text-left">
-            <span class="truncate text-xs font-medium text-[#f7f8f8]" :title="item.file.name">
+            <span class="truncate text-xs font-medium text-gray-900 dark:text-[#f7f8f8] transition-colors" :title="item.file.name">
               {{ item.file.name }}
             </span>
-            <span class="text-[10px] text-[#62666d]">
+            <span class="text-[10px] text-gray-500 dark:text-[#62666d] transition-colors">
               {{ waitingKeys.has(item.key) && uploadBusy ? '等待中' : `${Math.round(fileProgress[item.key] ?? 0)}%` }}
             </span>
           </div>
 
           <button
             type="button"
-            class="absolute right-1.5 top-1.5 flex h-4 w-4 items-center justify-center rounded text-[#62666d] transition-colors hover:text-rose-400"
+            class="absolute right-1.5 top-1.5 flex h-4 w-4 items-center justify-center rounded text-gray-400 dark:text-[#62666d] transition-colors hover:text-rose-500 dark:hover:text-rose-400"
             :disabled="splitting || splitCompleted"
             @click.stop="() => emit('remove-file', item.key)"
           >

--- a/frontend/src/components/workspace/FileUploader.vue
+++ b/frontend/src/components/workspace/FileUploader.vue
@@ -47,8 +47,8 @@ const onClickZone = () => {
       class="group relative flex flex-col items-center justify-center rounded-md border transition-colors"
       :class="[
         uploadHover
-          ? 'border-[rgb(129,115,223)]/40 bg-white/[0.04]'
-          : 'border-dashed border-white/[0.08] hover:border-white/[0.12] hover:bg-white/[0.02]',
+          ? 'border-[rgb(129,115,223)]/40 bg-gray-100 dark:bg-white/[0.04]'
+          : 'border-dashed border-gray-300 dark:border-white/[0.08] hover:border-gray-400 dark:hover:border-white/[0.12] hover:bg-gray-50 dark:hover:bg-white/[0.02]',
         expand ? 'py-14' : 'py-8',
         disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer'
       ]"
@@ -63,16 +63,16 @@ const onClickZone = () => {
       tabindex="0"
     >
       <div class="flex flex-col items-center gap-3">
-        <i class="fa-solid fa-cloud-arrow-up text-lg text-[#62666d] group-hover:text-[#8a8f98] transition-colors"></i>
+        <i class="fa-solid fa-cloud-arrow-up text-lg text-gray-400 dark:text-[#62666d] group-hover:text-gray-500 dark:group-hover:text-[#8a8f98] transition-colors"></i>
 
         <div class="text-center">
-          <p v-if="disabled" class="text-sm text-[#62666d]">
+          <p v-if="disabled" class="text-sm text-gray-500 dark:text-[#62666d]">
             请先在 <span class="text-[rgb(145,132,235)]">系统设置</span> 中配置模型
           </p>
-          <p v-else class="text-sm text-[#8a8f98]">
+          <p v-else class="text-sm text-gray-500 dark:text-[#8a8f98]">
             拖拽文件到此处或 <span class="text-[rgb(145,132,235)] cursor-pointer">浏览文件</span>
           </p>
-          <p class="mt-1 text-xs text-[#62666d]">PDF, PNG, JPG</p>
+          <p class="mt-1 text-xs text-gray-400 dark:text-[#62666d]">PDF, PNG, JPG</p>
         </div>
       </div>
 

--- a/frontend/src/components/workspace/OcrPreview.vue
+++ b/frontend/src/components/workspace/OcrPreview.vue
@@ -113,7 +113,7 @@ const hoveredBlock = ref(null)
 
     <!-- 无数据 -->
     <div v-else-if="!pages.length" class="flex-1 flex items-center justify-center">
-      <p class="text-sm text-[#62666d]">暂无 OCR 数据</p>
+      <p class="text-sm text-gray-500 dark:text-[#62666d] transition-colors">暂无 OCR 数据</p>
     </div>
 
     <!-- 预览（单张 + 分页） -->
@@ -139,7 +139,7 @@ const hoveredBlock = ref(null)
           <span :style="tagStyle(block)">{{ block.label }}</span>
           <div
             v-if="hoveredBlock === `${currentPageData.page_index}-${bi}` && block.content"
-            class="absolute left-0 top-full z-50 mt-1 max-w-xs rounded-md bg-slate-900/95 border border-white/10 px-2 py-1 text-xs text-slate-200 shadow-lg"
+            class="absolute left-0 top-full z-50 mt-1 max-w-xs rounded-md bg-white/95 dark:bg-slate-900/95 border border-gray-200 dark:border-white/10 px-2 py-1 text-xs text-gray-700 dark:text-slate-200 shadow-lg transition-colors"
             style="pointer-events: none;"
           >
             {{ block.content }}
@@ -154,7 +154,7 @@ const hoveredBlock = ref(null)
           :key="i"
           @click="currentPage = i"
           class="h-2 rounded-full transition-all"
-          :class="i === currentPage ? 'w-6 bg-[rgb(129,115,223)]' : 'w-2 bg-white/20 hover:bg-white/40'"
+          :class="i === currentPage ? 'w-6 bg-[rgb(129,115,223)]' : 'w-2 bg-gray-300 dark:bg-white/20 hover:bg-gray-400 dark:hover:bg-white/40'"
         />
       </div>
     </template>

--- a/frontend/src/components/workspace/SidebarNav.vue
+++ b/frontend/src/components/workspace/SidebarNav.vue
@@ -5,6 +5,7 @@
  */
 import { computed } from 'vue'
 import BaseLogo from '@/components/base/BaseLogo.vue'
+import BaseDropdown from '@/components/base/BaseDropdown.vue'
 
 const props = defineProps({
   currentView: { type: String, required: true },
@@ -302,25 +303,59 @@ const userQuotaSummary = computed(() => {
 
       <!-- 底部用户区 -->
       <div class="relative p-2">
-        <!-- Dropdown 菜单 -->
-        <Transition
-          enter-active-class="transition duration-150 ease-out"
-          enter-from-class="opacity-0 translate-y-2"
-          enter-to-class="opacity-100 translate-y-0"
-          leave-active-class="transition duration-100 ease-in"
-          leave-from-class="opacity-100 translate-y-0"
-          leave-to-class="opacity-0 translate-y-2"
+        <BaseDropdown 
+          :modelValue="userMenuOpen" 
+          @update:modelValue="(val) => emit('update:userMenuOpen', val)"
+          position="top" 
+          align="center" 
+          width="w-full" 
+          offset="mb-1"
+          panelClass="rounded-md brand-btn dark:bg-[#1b1b1d] backdrop-blur-md"
+          wrapperClass="block w-full"
         >
-          <div v-if="userMenuOpen" class="absolute bottom-full left-2 right-2 mb-1 rounded-md brand-btn overflow-hidden z-50">
+          <!-- 背景噪点 -->
+          <template #background>
+            <div class="ws-bg-noise hidden dark:block"></div>
+          </template>
+
+          <template #trigger="{ toggle }">
+            <!-- 用户信息 -->
             <button
-              @click="openSettings('profile'); emit('update:userMenuOpen', false)"
+              @click.stop="toggle"
+              class="flex w-full items-center gap-2 px-2 py-1.5 rounded-md hover:bg-gray-100 dark:hover:bg-white/[0.04] transition-colors"
+            >
+              <div class="h-8 w-8 shrink-0 rounded-xl relative overflow-hidden flex items-center justify-center text-white text-sm font-medium" style="background: linear-gradient(to bottom, rgba(129,115,223,0.9), rgba(99,87,199,0.9)); box-shadow: inset 0 1px 0 0 rgba(255,255,255,0.12);">
+                <img
+                  v-if="currentUser?.avatar_url"
+                  :src="currentUser.avatar_url"
+                  alt="用户头像"
+                  class="h-full w-full object-cover"
+                />
+                <template v-else>
+                  <span class="absolute inset-0 pointer-events-none" style="background-image: linear-gradient(to right, rgba(255,255,255,0.06) 1px, transparent 1px), linear-gradient(to bottom, rgba(255,255,255,0.06) 1px, transparent 1px); background-size: 8px 8px; mask-image: radial-gradient(ellipse at center, black 30%, transparent 80%); -webkit-mask-image: radial-gradient(ellipse at center, black 30%, transparent 80%);"></span>
+                  <span class="relative z-10">{{ userInitial }}</span>
+                </template>
+              </div>
+              <div class="flex-1 min-w-0 text-left">
+                <p class="text-sm text-gray-900 dark:text-[#f7f8f8] truncate leading-tight transition-colors">{{ userDisplayName }}</p>
+                <p v-if="userQuotaSummary" class="mt-0.5 text-xs text-indigo-600 dark:text-[rgb(145,132,235)] truncate leading-tight transition-colors">{{ userQuotaSummary }}</p>
+                <p v-else class="text-xs text-gray-500 dark:text-[#62666d] truncate leading-tight transition-colors">@{{ currentUser?.username || 'guest' }}</p>
+              </div>
+              <i class="fa-solid fa-chevron-up text-[10px] text-gray-400 dark:text-[#62666d] transition-colors"></i>
+            </button>
+          </template>
+
+          <!-- Dropdown 菜单内容 -->
+          <template #default="{ close }">
+            <button
+              @click="openSettings('profile'); close()"
               class="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 hover:text-gray-900 dark:text-[#d0d6e0] dark:hover:bg-white/[0.05] transition-colors"
             >
               <i class="fa-solid fa-gear w-4 text-center text-xs text-gray-400 dark:text-[#62666d]"></i>
               系统设置
             </button>
             <button
-              @click="(e) => { emit('update:userMenuOpen', false); emit('toggle-theme', e.currentTarget) }"
+              @click="(e) => { close(); emit('toggle-theme', e.currentTarget) }"
               class="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 hover:text-gray-900 dark:text-[#d0d6e0] dark:hover:bg-white/[0.05] transition-colors"
             >
               <i class="fa-solid w-4 text-center text-xs text-gray-400 dark:text-[#62666d]" :class="isDark ? 'fa-sun' : 'fa-moon'"></i>
@@ -328,39 +363,14 @@ const userQuotaSummary = computed(() => {
             </button>
             <div class="border-t border-gray-200 dark:border-white/[0.05]"></div>
             <button
-              @click="emit('logout'); emit('update:userMenuOpen', false)"
+              @click="emit('logout'); close()"
               class="flex w-full items-center gap-3 px-4 py-3 text-sm font-bold text-rose-500 hover:bg-rose-50 dark:hover:bg-rose-500/10 transition-colors"
             >
               <i class="fas fa-right-from-bracket w-4 text-center text-xs"></i>
               退出登录
             </button>
-          </div>
-        </Transition>
-
-        <!-- 用户信息 -->
-        <button
-          @click="emit('update:userMenuOpen', !userMenuOpen)"
-          class="flex w-full items-center gap-2 px-2 py-1.5 rounded-md hover:bg-gray-100 dark:hover:bg-white/[0.04] transition-colors"
-        >
-          <div class="h-8 w-8 shrink-0 rounded-xl relative overflow-hidden flex items-center justify-center text-white text-sm font-medium" style="background: linear-gradient(to bottom, rgba(129,115,223,0.9), rgba(99,87,199,0.9)); box-shadow: inset 0 1px 0 0 rgba(255,255,255,0.12);">
-            <img
-              v-if="currentUser?.avatar_url"
-              :src="currentUser.avatar_url"
-              alt="用户头像"
-              class="h-full w-full object-cover"
-            />
-            <template v-else>
-              <span class="absolute inset-0 pointer-events-none" style="background-image: linear-gradient(to right, rgba(255,255,255,0.06) 1px, transparent 1px), linear-gradient(to bottom, rgba(255,255,255,0.06) 1px, transparent 1px); background-size: 8px 8px; mask-image: radial-gradient(ellipse at center, black 30%, transparent 80%); -webkit-mask-image: radial-gradient(ellipse at center, black 30%, transparent 80%);"></span>
-              <span class="relative z-10">{{ userInitial }}</span>
-            </template>
-          </div>
-          <div class="flex-1 min-w-0 text-left">
-            <p class="text-sm text-gray-900 dark:text-[#f7f8f8] truncate leading-tight transition-colors">{{ userDisplayName }}</p>
-            <p v-if="userQuotaSummary" class="mt-0.5 text-xs text-indigo-600 dark:text-[rgb(145,132,235)] truncate leading-tight transition-colors">{{ userQuotaSummary }}</p>
-            <p v-else class="text-xs text-gray-500 dark:text-[#62666d] truncate leading-tight transition-colors">@{{ currentUser?.username || 'guest' }}</p>
-          </div>
-          <i class="fa-solid fa-chevron-up text-[10px] text-gray-400 dark:text-[#62666d] transition-colors"></i>
-        </button>
+          </template>
+        </BaseDropdown>
       </div>
     </template>
   </aside>

--- a/frontend/src/components/workspace/SidebarNav.vue
+++ b/frontend/src/components/workspace/SidebarNav.vue
@@ -95,14 +95,14 @@ const userQuotaSummary = computed(() => {
       <div class="flex min-h-0 flex-1 flex-col px-4 py-4">
         <button
           @click="returnToApp"
-          class="mb-4 inline-flex items-center gap-2 px-3 pt-2 text-sm font-medium text-[#8a8f98] transition-colors hover:text-white"
+          class="mb-4 inline-flex items-center gap-2 px-3 pt-2 text-sm font-medium text-gray-500 dark:text-[#8a8f98] transition-colors hover:text-gray-700 dark:hover:text-white"
         >
           <i class="fa-solid fa-arrow-left text-xs"></i>
           <span>返回应用</span>
         </button>
 
         <nav :ref="(el) => $emit('update:navRef', el)" class="flex flex-col gap-1.5 relative">
-          <div class="px-3 pt-2 pb-1 text-xs font-medium uppercase tracking-[0.15em] text-[#62666d]">
+          <div class="px-3 pt-2 pb-1 text-xs font-medium uppercase tracking-[0.15em] text-gray-400 dark:text-[#62666d]">
             设置
           </div>
           <div class="flex flex-col gap-1">
@@ -112,8 +112,8 @@ const userQuotaSummary = computed(() => {
               @click="setSettingsEntry(item.id)"
               class="group relative z-10 flex items-center gap-3 rounded-lg border px-3 py-2 text-sm font-medium transition-colors duration-200"
               :class="currentSettingsSubView === item.id
-                ? 'border-white/[0.10] bg-white/[0.06] text-white'
-                : 'border-transparent text-[#8a8f98] hover:bg-white/[0.04] hover:text-[#d0d6e0]'"
+                ? 'brand-gradient-bg text-white shadow-sm border-transparent'
+                : 'border-transparent text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-[#8a8f98] dark:hover:bg-white/[0.04] dark:hover:text-[#d0d6e0]'"
             >
               <i class="fa-solid w-4 text-center text-sm" :class="item.icon"></i>
               <span>{{ item.label }}</span>
@@ -128,15 +128,15 @@ const userQuotaSummary = computed(() => {
         <div>
           <!-- Logo 标题区 -->
           <div class="flex h-20 items-center justify-between px-4 py-6">
-            <button @click="emit('navigate-home')" class="flex min-w-0 items-center gap-2 rounded-md px-1 py-1 hover:bg-white/[0.04] transition-colors" title="返回首页">
+            <button @click="emit('navigate-home')" class="flex min-w-0 items-center gap-2 rounded-md px-1 py-1 hover:bg-gray-100 dark:hover:bg-white/[0.04] transition-colors" title="返回首页">
               <BaseLogo size="sm" />
-              <span class="text-sm font-medium text-[#f7f8f8]">智卷错题本</span>
+              <span class="text-sm font-medium text-gray-900 dark:text-[#f7f8f8] transition-colors">智卷错题本</span>
             </button>
             <div class="flex items-center gap-1">
-              <button @click="openSettings('profile')" class="flex h-7 w-7 items-center justify-center rounded-md text-[#62666d] hover:bg-white/[0.04] hover:text-[#8a8f98] transition-colors" title="系统设置">
+              <button @click="openSettings('profile')" class="flex h-7 w-7 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-[#62666d] dark:hover:bg-white/[0.04] dark:hover:text-[#8a8f98] transition-colors" title="系统设置">
                 <i class="fa-solid fa-gear text-xs"></i>
               </button>
-              <button @click="emit('logout')" class="flex h-7 w-7 items-center justify-center rounded-md border border-white/[0.08] text-[#62666d] hover:bg-white/[0.04] hover:text-[#8a8f98] transition-colors" title="退出登录">
+              <button @click="emit('logout')" class="flex h-7 w-7 items-center justify-center rounded-md border border-gray-200 dark:border-white/[0.08] text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-[#62666d] dark:hover:bg-white/[0.04] dark:hover:text-[#8a8f98] transition-colors" title="退出登录">
                 <i class="fa-solid fa-right-from-bracket text-xs"></i>
               </button>
             </div>
@@ -146,7 +146,7 @@ const userQuotaSummary = computed(() => {
           <nav :ref="(el) => $emit('update:navRef', el)" class="flex flex-col gap-1.5 px-4 relative">
             <!-- 滑动指示器 -->
             <div
-              class="absolute left-4 right-4 z-0 rounded-lg overflow-hidden brand-btn"
+              class="absolute left-4 right-4 z-0 rounded-lg overflow-hidden brand-gradient-bg"
               :style="indicatorStyle"
             ></div>
 
@@ -155,13 +155,13 @@ const userQuotaSummary = computed(() => {
               <button
                 v-if="group.label"
                 @click="group.collapsible && toggleGroup(gi)"
-                class="flex items-center gap-1 px-3 pt-4 pb-1 text-xs font-medium uppercase tracking-[0.15em] text-[#62666d] hover:text-[#8a8f98] transition-colors"
+                class="flex items-center gap-1 px-3 pt-4 pb-1 text-xs font-medium uppercase tracking-[0.15em] text-gray-400 hover:text-gray-700 dark:text-[#62666d] dark:hover:text-[#8a8f98] transition-colors"
                 :class="group.collapsible ? 'cursor-pointer' : 'cursor-default'"
               >
                 <span>{{ group.label }}</span>
                 <i
                   v-if="group.collapsible"
-                  class="fa-solid fa-play text-[8px] text-[#62666d] transition-transform duration-200"
+                  class="fa-solid fa-play text-[8px] text-gray-400 dark:text-[#62666d] transition-transform duration-200"
                   :class="collapsedGroups[gi] ? '' : 'rotate-90'"
                 ></i>
               </button>
@@ -175,13 +175,13 @@ const userQuotaSummary = computed(() => {
                   <button
                     v-if="item.disabled"
                     disabled
-                    class="flex items-center justify-between rounded-lg px-3 py-3 text-sm cursor-not-allowed text-[#62666d]"
+                    class="flex items-center justify-between rounded-lg px-3 py-3 text-sm cursor-not-allowed text-gray-400 dark:text-[#62666d]"
                   >
                     <div class="flex items-center gap-3">
                       <i class="fa-solid w-4 text-center text-sm" :class="item.icon"></i>
                       <span>{{ item.label }}</span>
                     </div>
-                    <span class="text-[10px] font-medium px-2 py-0.5 rounded-md bg-white/[0.04] text-[#62666d]">敬请期待</span>
+                    <span class="text-[10px] font-medium px-2 py-0.5 rounded-md bg-gray-100 text-gray-500 dark:bg-white/[0.04] dark:text-[#62666d]">敬请期待</span>
                   </button>
                   <!-- 普通项 -->
                   <button
@@ -191,7 +191,7 @@ const userQuotaSummary = computed(() => {
                     class="group relative z-10 flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors duration-200"
                     :class="item.match(currentView)
                       ? 'text-white'
-                      : 'text-[#8a8f98] hover:bg-white/[0.04] hover:text-[#d0d6e0]'"
+                      : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-[#8a8f98] dark:hover:bg-white/[0.04] dark:hover:text-[#d0d6e0]'"
                   >
                     <i class="fa-solid w-4 text-center text-sm" :class="item.icon"></i>
                     <span>{{ item.label }}</span>
@@ -207,11 +207,11 @@ const userQuotaSummary = computed(() => {
         <!-- AI 对话历史列表 -->
         <div class="mt-4 flex min-h-0 flex-1 flex-col px-4">
           <div class="flex items-center justify-between px-3 pt-4 pb-2">
-            <button @click="emit('update:chatCollapsed', !chatCollapsed)" class="flex items-center gap-1 text-xs font-medium uppercase tracking-[0.15em] text-[#62666d] hover:text-[#8a8f98] transition-colors cursor-pointer">
+            <button @click="emit('update:chatCollapsed', !chatCollapsed)" class="flex items-center gap-1 text-xs font-medium uppercase tracking-[0.15em] text-gray-400 hover:text-gray-700 dark:text-[#62666d] dark:hover:text-[#8a8f98] transition-colors cursor-pointer">
               <span>对话</span>
-              <i class="fa-solid fa-play text-[8px] text-[#62666d] transition-transform duration-200" :class="chatCollapsed ? '' : 'rotate-90'"></i>
+              <i class="fa-solid fa-play text-[8px] text-gray-400 dark:text-[#62666d] transition-transform duration-200" :class="chatCollapsed ? '' : 'rotate-90'"></i>
             </button>
-            <button @click="emit('create-ai-chat')" class="text-[#8a8f98] hover:text-[#d0d6e0] transition-colors">
+            <button @click="emit('create-ai-chat')" class="text-gray-500 hover:text-gray-700 dark:text-[#8a8f98] dark:hover:text-[#d0d6e0] transition-colors">
               <i class="fa-solid fa-plus text-[10px]"></i>
             </button>
           </div>
@@ -221,11 +221,11 @@ const userQuotaSummary = computed(() => {
           <div :ref="(el) => $emit('update:chatListRef', el)" class="relative h-full overflow-y-auto pb-2 custom-scrollbar" @click="emit('update:chatMenuOpenId', null)">
             <!-- 对话区滑动指示器 -->
             <div
-              class="absolute left-0 right-0 z-0 rounded-lg overflow-hidden brand-btn"
+              class="absolute left-0 right-0 z-0 rounded-lg overflow-hidden brand-gradient-bg"
               :style="chatIndicatorStyle"
             ></div>
 
-            <div v-if="aiChatSessions.length === 0" class="px-3 py-4 text-center text-xs text-[#62666d]">
+            <div v-if="aiChatSessions.length === 0" class="px-3 py-4 text-center text-xs text-gray-400 dark:text-[#62666d]">
               暂无对话
             </div>
             <div
@@ -237,11 +237,11 @@ const userQuotaSummary = computed(() => {
                 chatMenuOpenId === s.id ? 'z-20' : 'z-10',
                 activeAiChatId === s.id && currentView === 'ai-chat'
                   ? 'text-white'
-                  : 'text-[#8a8f98] hover:bg-white/[0.04] hover:text-[#d0d6e0]',
+                  : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-[#8a8f98] dark:hover:bg-white/[0.04] dark:hover:text-[#d0d6e0]',
               ]"
               @click="renamingChatId !== s.id && emit('select-ai-chat', s)"
             >
-              <i class="fa-solid fa-message w-4 shrink-0 text-center text-sm" :class="activeAiChatId === s.id && currentView === 'ai-chat' ? 'text-white/60' : 'text-[#62666d]'"></i>
+              <i class="fa-solid fa-message w-4 shrink-0 text-center text-sm transition-colors"></i>
 
               <!-- 重命名输入框 -->
               <input
@@ -253,14 +253,14 @@ const userQuotaSummary = computed(() => {
                 @keydown.enter="emit('confirm-rename-chat', s)"
                 @keydown.escape="$emit('update:renamingChatId', null)"
                 @blur="emit('confirm-rename-chat', s)"
-                class="flex-1 min-w-0 bg-transparent text-xs outline-none border-b border-white/[0.12] py-0.5 text-[#f7f8f8]"
+                class="flex-1 min-w-0 bg-transparent text-xs outline-none border-b border-gray-300 py-0.5 text-gray-900 dark:border-white/[0.12] dark:text-[#f7f8f8]"
               />
               <span v-else class="relative z-10 flex-1 truncate">{{ s.title }}</span>
 
               <!-- 三个点按钮 -->
               <button
                 @click.stop="emit('toggle-chat-menu', s.id)"
-                class="shrink-0 opacity-0 group-hover:opacity-100 text-[#62666d] hover:text-[#d0d6e0] transition-all"
+                class="shrink-0 opacity-0 group-hover:opacity-100 text-gray-400 hover:text-gray-700 dark:text-[#62666d] dark:hover:text-[#d0d6e0] transition-all "
               >
                 <i class="fa-solid fa-ellipsis text-[10px]"></i>
               </button>
@@ -281,13 +281,13 @@ const userQuotaSummary = computed(() => {
                 >
                   <button
                     @click="emit('start-rename-chat', s)"
-                    class="flex w-full items-center gap-2 px-3 py-1.5 text-xs text-[#d0d6e0] hover:bg-white/[0.05] transition-colors"
+                    class="flex w-full items-center gap-2 px-3 py-1.5 text-xs text-gray-700 hover:bg-gray-50 hover:text-gray-900 dark:text-[#d0d6e0] dark:hover:bg-white/[0.05] transition-colors"
                   >
-                    <i class="fa-solid fa-pen text-[10px] w-3 text-center text-[#62666d]"></i> 重命名
+                    <i class="fa-solid fa-pen text-[10px] w-3 text-center text-gray-400 dark:text-[#62666d]"></i> 重命名
                   </button>
                   <button
                     @click="emit('update:chatMenuOpenId', null); emit('delete-ai-chat', s.id)"
-                    class="flex w-full items-center gap-2 px-3 py-1.5 text-xs text-rose-400 hover:bg-rose-500/10 transition-colors"
+                    class="flex w-full items-center gap-2 px-3 py-1.5 text-xs text-rose-500 hover:bg-rose-50 dark:text-rose-400 dark:hover:bg-rose-500/10 transition-colors"
                   >
                     <i class="fa-solid fa-trash text-[10px] w-4 text-center"></i> 删除
                   </button>
@@ -314,19 +314,19 @@ const userQuotaSummary = computed(() => {
           <div v-if="userMenuOpen" class="absolute bottom-full left-2 right-2 mb-1 rounded-md brand-btn overflow-hidden z-50">
             <button
               @click="openSettings('profile'); emit('update:userMenuOpen', false)"
-              class="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-[#d0d6e0] hover:bg-white/[0.05] transition-colors"
+              class="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 hover:text-gray-900 dark:text-[#d0d6e0] dark:hover:bg-white/[0.05] transition-colors"
             >
-              <i class="fa-solid fa-gear w-4 text-center text-xs text-[#62666d]"></i>
+              <i class="fa-solid fa-gear w-4 text-center text-xs text-gray-400 dark:text-[#62666d]"></i>
               系统设置
             </button>
             <button
               @click="(e) => { emit('update:userMenuOpen', false); emit('toggle-theme', e.currentTarget) }"
-              class="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-[#d0d6e0] hover:bg-white/[0.05] transition-colors"
+              class="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 hover:text-gray-900 dark:text-[#d0d6e0] dark:hover:bg-white/[0.05] transition-colors"
             >
-              <i class="fa-solid w-4 text-center text-xs text-[#62666d]" :class="isDark ? 'fa-sun' : 'fa-moon'"></i>
+              <i class="fa-solid w-4 text-center text-xs text-gray-400 dark:text-[#62666d]" :class="isDark ? 'fa-sun' : 'fa-moon'"></i>
               {{ isDark ? '浅色模式' : '深色模式' }}
             </button>
-            <div class="border-t border-white/[0.05]"></div>
+            <div class="border-t border-gray-200 dark:border-white/[0.05]"></div>
             <button
               @click="emit('logout'); emit('update:userMenuOpen', false)"
               class="flex w-full items-center gap-3 px-4 py-3 text-sm font-bold text-rose-500 hover:bg-rose-50 dark:hover:bg-rose-500/10 transition-colors"
@@ -340,7 +340,7 @@ const userQuotaSummary = computed(() => {
         <!-- 用户信息 -->
         <button
           @click="emit('update:userMenuOpen', !userMenuOpen)"
-          class="flex w-full items-center gap-2 px-2 py-1.5 rounded-md hover:bg-white/[0.04] transition-colors"
+          class="flex w-full items-center gap-2 px-2 py-1.5 rounded-md hover:bg-gray-100 dark:hover:bg-white/[0.04] transition-colors"
         >
           <div class="h-8 w-8 shrink-0 rounded-xl relative overflow-hidden flex items-center justify-center text-white text-sm font-medium" style="background: linear-gradient(to bottom, rgba(129,115,223,0.9), rgba(99,87,199,0.9)); box-shadow: inset 0 1px 0 0 rgba(255,255,255,0.12);">
             <img
@@ -355,44 +355,52 @@ const userQuotaSummary = computed(() => {
             </template>
           </div>
           <div class="flex-1 min-w-0 text-left">
-            <p class="text-sm text-[#f7f8f8] truncate leading-tight">{{ userDisplayName }}</p>
-            <p v-if="userQuotaSummary" class="mt-0.5 text-xs text-[rgb(145,132,235)] truncate leading-tight">{{ userQuotaSummary }}</p>
-            <p v-else class="text-xs text-[#62666d] truncate leading-tight">@{{ currentUser?.username || 'guest' }}</p>
+            <p class="text-sm text-gray-900 dark:text-[#f7f8f8] truncate leading-tight transition-colors">{{ userDisplayName }}</p>
+            <p v-if="userQuotaSummary" class="mt-0.5 text-xs text-indigo-600 dark:text-[rgb(145,132,235)] truncate leading-tight transition-colors">{{ userQuotaSummary }}</p>
+            <p v-else class="text-xs text-gray-500 dark:text-[#62666d] truncate leading-tight transition-colors">@{{ currentUser?.username || 'guest' }}</p>
           </div>
-          <i class="fa-solid fa-chevron-up text-[10px] text-[#62666d]"></i>
+          <i class="fa-solid fa-chevron-up text-[10px] text-gray-400 dark:text-[#62666d] transition-colors"></i>
         </button>
       </div>
     </template>
   </aside>
 
   <!-- ================== 移动端：底部 Tab 导航栏 ================== -->
-  <nav class="fixed bottom-0 left-0 right-0 z-50 border-t border-white/[0.06] bg-[#0A0A0F]/90 pb-2 pt-2 md:hidden">
+  <nav class="fixed bottom-0 left-0 right-0 z-50 border-t border-gray-200 bg-white/90 dark:border-white/[0.06] dark:bg-[#0A0A0F]/90 pb-2 pt-2 md:hidden transition-colors duration-200">
     <div class="flex justify-around">
-      <button @click="setView(lastWorkspaceView)" class="flex flex-col items-center p-2" :class="workspaceViews.has(currentView) ? 'text-indigo-400' : 'text-white/40'">
+      <button @click="setView(lastWorkspaceView)" class="flex flex-col items-center justify-center w-14 h-14 rounded-2xl transition-colors" :class="workspaceViews.has(currentView) ? 'brand-gradient-bg text-white' : 'text-gray-400 dark:text-white/40 hover:text-gray-600 dark:hover:text-white/70'">
         <i class="fa-solid fa-file-arrow-up text-lg"></i>
-        <span class="mt-1 text-xs font-bold">录入</span>
+        <span class="mt-1 text-[10px] font-bold">录入</span>
       </button>
-      <button @click="setView('notes')" class="flex flex-col items-center p-2" :class="currentView === 'notes' ? 'text-indigo-400' : 'text-white/40'">
+      <button @click="setView('notes')" class="flex flex-col items-center justify-center w-14 h-14 rounded-2xl transition-colors" :class="currentView === 'notes' ? 'brand-gradient-bg text-white' : 'text-gray-400 dark:text-white/40 hover:text-gray-600 dark:hover:text-white/70'">
         <i class="fa-solid fa-book-open text-lg"></i>
-        <span class="mt-1 text-xs font-bold">笔记库</span>
+        <span class="mt-1 text-[10px] font-bold">笔记库</span>
       </button>
-      <button @click="setView('dashboard')" class="flex flex-col items-center p-2" :class="currentView === 'dashboard' ? 'text-indigo-400' : 'text-white/40'">
+      <button @click="setView('dashboard')" class="flex flex-col items-center justify-center w-14 h-14 rounded-2xl transition-colors" :class="currentView === 'dashboard' ? 'brand-gradient-bg text-white' : 'text-gray-400 dark:text-white/40 hover:text-gray-600 dark:hover:text-white/70'">
         <i class="fa-solid fa-chart-pie text-lg"></i>
-        <span class="mt-1 text-xs font-bold">数据面板</span>
+        <span class="mt-1 text-[10px] font-bold">数据面板</span>
       </button>
-      <button @click="setView('error-bank')" class="flex flex-col items-center p-2" :class="currentView === 'error-bank' ? 'text-indigo-400' : 'text-white/40'">
+      <button @click="setView('error-bank')" class="flex flex-col items-center justify-center w-14 h-14 rounded-2xl transition-colors" :class="currentView === 'error-bank' ? 'brand-gradient-bg text-white' : 'text-gray-400 dark:text-white/40 hover:text-gray-600 dark:hover:text-white/70'">
         <i class="fa-solid fa-layer-group text-lg"></i>
-        <span class="mt-1 text-xs font-bold">错题本</span>
+        <span class="mt-1 text-[10px] font-bold">错题本</span>
       </button>
-      <button @click="openSettings('profile')" class="flex flex-col items-center p-2" :class="currentView === 'settings' ? 'text-indigo-400' : 'text-white/40'">
+      <button @click="openSettings('profile')" class="flex flex-col items-center justify-center w-14 h-14 rounded-2xl transition-colors" :class="currentView === 'settings' ? 'brand-gradient-bg text-white' : 'text-gray-400 dark:text-white/40 hover:text-gray-600 dark:hover:text-white/70'">
         <i class="fa-solid fa-sliders text-lg"></i>
-        <span class="mt-1 text-xs font-bold">设置</span>
+        <span class="mt-1 text-[10px] font-bold">设置</span>
       </button>
-      <button @click="(e) => emit('toggle-theme', e.currentTarget)" class="flex flex-col items-center p-2 text-white/40">
+      <button @click="(e) => emit('toggle-theme', e.currentTarget)" class="flex flex-col items-center justify-center w-14 h-14 rounded-2xl text-gray-400 dark:text-white/40 hover:text-gray-600 dark:hover:text-white/70 transition-colors">
         <i class="fa-solid text-lg" :class="theme === 'dark' ? 'fa-sun' : 'fa-moon'"></i>
-        <span class="mt-1 text-xs font-bold">主题</span>
+        <span class="mt-1 text-[10px] font-bold">主题</span>
       </button>
     </div>
   </nav>
 </template>
+
+<style scoped>
+.brand-gradient-bg {
+  background: linear-gradient(to bottom, rgba(129, 115, 223, 0.9), rgba(99, 87, 199, 0.9));
+  box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.12);
+  border: none;
+}
+</style>
 

--- a/frontend/src/components/workspace/SplitLoading.vue
+++ b/frontend/src/components/workspace/SplitLoading.vue
@@ -38,8 +38,8 @@ defineProps({
 
         <!-- 文本引导 -->
         <div class="text-container">
-          <h3 class="status-title">{{ title }}</h3>
-          <p class="status-subtitle">{{ subtitle }}</p>
+          <h3 class="status-title text-slate-900 dark:text-white transition-colors">{{ title }}</h3>
+          <p class="status-subtitle text-slate-500 dark:text-slate-400 transition-colors">{{ subtitle }}</p>
 
           <!-- 模拟进度条 -->
           <div class="progress-container">
@@ -156,19 +156,13 @@ defineProps({
 .status-title {
   font-size: 1.125rem;
   font-weight: 900;
-  color: #0f172a;
   letter-spacing: 0.05em;
   margin-bottom: 0.5rem;
-}
-
-:root.dark .status-title {
-  color: white;
 }
 
 .status-subtitle {
   font-size: 0.75rem;
   font-weight: 600;
-  color: #64748b;
   line-height: 1.5;
 }
 

--- a/frontend/src/components/workspace/StatusBar.vue
+++ b/frontend/src/components/workspace/StatusBar.vue
@@ -121,18 +121,18 @@ const modelStatusError = computed(() => {
     class="relative z-20 flex flex-wrap items-center gap-4 text-sm shrink-0"
   >
     <div class="flex items-center gap-2.5">
-      <span class="text-xs font-medium uppercase tracking-[0.15em] text-[#62666d]">
+      <span class="text-xs font-medium uppercase tracking-[0.15em] text-gray-500 dark:text-[#62666d] transition-colors">
         引擎状态
       </span>
     </div>
 
     <!-- 分隔符 -->
-    <div class="h-4 w-px bg-white/[0.08]"></div>
+    <div class="h-4 w-px bg-gray-300 dark:bg-white/[0.08] transition-colors"></div>
 
     <!-- 全局系统错误 -->
     <span
       v-if="statusError"
-      class="inline-flex items-center gap-2 rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-1.5 text-xs font-medium text-rose-400"
+      class="inline-flex items-center gap-2 rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-1.5 text-xs font-medium text-rose-500 dark:text-rose-400 transition-colors"
     >
       <i class="fa-solid fa-circle-exclamation animate-pulse"></i>
       {{ statusError }}
@@ -143,15 +143,15 @@ const modelStatusError = computed(() => {
       <span
         v-for="p in statusPills"
         :key="p.key"
-        class="inline-flex items-center gap-2 rounded-lg border px-3 py-1.5 text-xs font-medium"
+        class="inline-flex items-center gap-2 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors"
         :class="
           p.loading
-            ? 'border-amber-500/20 bg-amber-500/10 text-amber-400'
+            ? 'border-amber-500/20 bg-amber-500/10 text-amber-600 dark:text-amber-400'
             : p.isPlaceholder
-              ? 'border-white/[0.05] bg-white/[0.03] text-[#62666d]'
+              ? 'border-gray-200 bg-gray-100 text-gray-500 dark:border-white/[0.05] dark:bg-white/[0.03] dark:text-[#62666d]'
               : p.ok
-                ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-400'
-                : 'border-rose-500/20 bg-rose-500/10 text-rose-400'
+                ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
+                : 'border-rose-500/20 bg-rose-500/10 text-rose-500 dark:text-rose-400'
         "
       >
         <div class="relative h-2.5 w-2.5 shrink-0">
@@ -172,11 +172,11 @@ const modelStatusError = computed(() => {
       <Listbox :model-value="selectedModel" @update:model-value="(v) => emit('update:selectedModel', v)" :disabled="disabled || noModels">
         <div class="relative w-56 min-w-0">
           <ListboxButton
-            class="group relative flex w-full cursor-pointer items-center justify-between gap-4 rounded-md border border-white/[0.08] bg-white/[0.02] px-3 py-1.5 text-left text-xs font-medium text-[#d0d6e0] transition-colors hover:bg-white/[0.05] hover:border-white/[0.12]"
+            class="group relative flex w-full cursor-pointer items-center justify-between gap-4 rounded-md border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.02] px-3 py-1.5 text-left text-xs font-medium text-gray-900 dark:text-[#d0d6e0] transition-colors hover:bg-gray-50 dark:hover:bg-white/[0.05] hover:border-gray-300 dark:hover:border-white/[0.12]"
             :disabled="disabled"
           >
             <div class="flex items-center gap-2.5 min-w-0 flex-1">
-              <div class="relative flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-white/[0.05] text-[rgb(145,132,235)]">
+              <div class="relative flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-gray-100 dark:bg-white/[0.05] text-[rgb(145,132,235)] transition-colors">
                 <Transition name="fade" mode="out-in">
                   <img
                     v-if="currentProvider && modelLogos[currentProvider.value]"
@@ -190,12 +190,12 @@ const modelStatusError = computed(() => {
                 <!-- 状态指示点 -->
                 <div
                   v-if="currentProvider || statusLoading"
-                  class="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full border border-[#0f1011]"
+                  class="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full border border-white dark:border-[#0f1011] transition-colors"
                   :class="(statusLoading || isChecking) ? 'bg-amber-400 animate-pulse' : (!currentProvider.configured || currentProvider.key_valid === false) ? 'bg-rose-500' : 'bg-emerald-500'"
                 ></div>
               </div>
               <span
-                class="block min-w-0 flex-1 truncate text-xs font-medium tracking-tight text-[#d0d6e0]"
+                class="block min-w-0 flex-1 truncate text-xs font-medium tracking-tight text-gray-900 dark:text-[#d0d6e0] transition-colors"
                 @mouseenter="showTooltip($event, selectedLabel)"
                 @mouseleave="hideTooltip"
               >
@@ -210,7 +210,7 @@ const modelStatusError = computed(() => {
                   <i v-else-if="currentProvider" key="ok" class="fa-solid fa-check absolute inset-0 flex items-center justify-center text-[10px] text-emerald-500"></i>
                 </Transition>
               </div>
-              <i class="fa-solid fa-chevron-down shrink-0 text-[10px] text-[#62666d] transition-transform duration-300 group-aria-expanded:rotate-180"></i>
+              <i class="fa-solid fa-chevron-down shrink-0 text-[10px] text-gray-400 dark:text-[#62666d] transition-all duration-300 group-aria-expanded:rotate-180"></i>
             </div>
           </ListboxButton>
 
@@ -223,14 +223,14 @@ const modelStatusError = computed(() => {
             leave-to-class="transform scale-95 opacity-0 -translate-y-2"
           >
             <ListboxOptions
-              class="absolute right-0 z-50 mt-2 max-h-72 w-full overflow-auto rounded-md border border-white/[0.08] bg-white/[0.02] text-base focus:outline-none sm:text-sm"
+              class="absolute right-0 z-50 mt-2 max-h-72 w-full overflow-auto rounded-md border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-[#15151e] text-base shadow-lg focus:outline-none sm:text-sm transition-colors"
             >
               <template v-for="(item, idx) in modelOptions" :key="idx">
                 <!-- 分组标题 -->
                 <li
                   v-if="item.type === 'group'"
-                  class="select-none px-4 text-[10px] font-medium uppercase tracking-widest text-[#62666d]"
-                  :class="idx > 0 ? 'mt-1 border-t border-white/[0.05] pt-2' : ''"
+                  class="select-none px-4 text-[10px] font-medium uppercase tracking-widest text-gray-500 dark:text-[#62666d] transition-colors"
+                  :class="idx > 0 ? 'mt-1 border-t border-gray-100 dark:border-white/[0.05] pt-2' : ''"
                 >
                   <div class="flex items-center gap-2">
                     <img v-if="modelLogos[item.provider]" :src="modelLogos[item.provider]" class="h-3 w-3 object-contain opacity-60" alt="" />
@@ -248,22 +248,22 @@ const modelStatusError = computed(() => {
                   <li
                     class="relative cursor-pointer select-none py-2.5 pl-10 pr-4 transition-colors"
                     :class="[
-                      active ? 'bg-white/[0.05]' : '',
+                      active ? 'bg-gray-100 dark:bg-white/[0.05]' : '',
                       optDisabled ? 'opacity-40 cursor-not-allowed' : ''
                     ]"
                   >
                     <span
                   class="block truncate text-sm transition-colors min-w-0"
-                  :class="[selected ? 'font-medium text-white' : 'font-medium text-[#d0d6e0]']"
+                  :class="[selected ? 'font-medium text-indigo-600 dark:text-white' : 'font-medium text-gray-700 dark:text-[#d0d6e0]']"
                   @mouseenter="showTooltip($event, item.model)"
                   @mouseleave="hideTooltip"
                 >
                   {{ item.model }}
-                  <span v-if="item.isDefault" class="ml-1 text-[10px] text-[#62666d]">默认</span>
+                  <span v-if="item.isDefault" class="ml-1 text-[10px] text-gray-400 dark:text-[#62666d] transition-colors">默认</span>
                 </span>
                     <span
                       v-if="selected"
-                      class="absolute inset-y-0 left-0 flex items-center pl-3 text-white"
+                      class="absolute inset-y-0 left-0 flex items-center pl-3 text-indigo-600 dark:text-white transition-colors"
                     >
                       <i class="fa-solid fa-check text-sm"></i>
                     </span>

--- a/frontend/src/components/workspace/UploadStage.vue
+++ b/frontend/src/components/workspace/UploadStage.vue
@@ -45,39 +45,39 @@ const emit = defineEmits([
   <!-- 工具栏：状态 + 模式切换 + 擦除开关 -->
   <div class="flex flex-wrap items-center gap-3">
     <!-- 模式切换 -->
-    <div class="flex items-center rounded-md brand-btn p-0.5">
+    <div class="flex items-center rounded-md brand-btn p-0.5 transition-colors">
       <button
         @click="emit('update:upload-mode', 'exam')"
         class="h-7 rounded px-3 text-xs font-medium transition-all"
-        :class="uploadMode === 'exam' ? 'bg-white/[0.06] text-[#f7f8f8]' : 'text-[#62666d] hover:text-[#8a8f98]'"
+        :class="uploadMode === 'exam' ? 'brand-gradient-bg text-white shadow-sm' : 'text-gray-500 dark:text-[#62666d] hover:text-gray-700 dark:hover:text-[#8a8f98]'"
       >
         <i class="fa-solid fa-file-lines mr-1.5"></i>试卷分割
       </button>
       <button
         @click="emit('update:upload-mode', 'note')"
         class="h-7 rounded px-3 text-xs font-medium transition-all"
-        :class="uploadMode === 'note' ? 'bg-white/[0.06] text-[#f7f8f8]' : 'text-[#62666d] hover:text-[#8a8f98]'"
+        :class="uploadMode === 'note' ? 'brand-gradient-bg text-white shadow-sm' : 'text-gray-500 dark:text-[#62666d] hover:text-gray-700 dark:hover:text-[#8a8f98]'"
       >
         <i class="fa-solid fa-book-open mr-1.5"></i>笔记整理
       </button>
     </div>
 
-    <div class="h-4 w-px bg-white/[0.08]"></div>
+    <div class="h-4 w-px bg-gray-300 dark:bg-white/[0.08] transition-colors"></div>
 
     <!-- 擦除开关 -->
     <label class="flex cursor-pointer items-center gap-2" @click="emit('update:erase-enabled', !eraseEnabled)">
       <div
         class="relative h-4 w-7 rounded-full transition-colors"
-        :class="eraseEnabled ? 'bg-[rgb(129,115,223)]' : 'bg-white/[0.08]'"
+        :class="eraseEnabled ? 'bg-[rgb(129,115,223)]' : 'bg-gray-300 dark:bg-white/[0.08]'"
       >
         <div
           class="absolute top-0.5 h-3 w-3 rounded-full bg-white transition-transform"
           :class="eraseEnabled ? 'translate-x-3' : 'translate-x-0.5'"
         ></div>
       </div>
-      <span class="text-xs text-[#8a8f98]">擦除笔迹</span>
+      <span class="text-xs text-gray-500 dark:text-[#8a8f98] transition-colors">擦除笔迹</span>
       <BaseTooltip text="上传后自动擦除图片中的手写笔迹" placement="bottom" align="center">
-        <i class="fa-solid fa-circle-question cursor-help text-[10px] text-[#62666d]"></i>
+        <i class="fa-solid fa-circle-question cursor-help text-[10px] text-gray-400 dark:text-[#62666d] transition-colors"></i>
       </BaseTooltip>
     </label>
 
@@ -99,11 +99,11 @@ const emit = defineEmits([
   <!-- 上传区 -->
   <div class="flex flex-1 min-h-0 flex-col items-center justify-center gap-6 overflow-y-auto custom-scrollbar py-8">
     <!-- 引导信息 -->
-    <div class="w-full max-w-2xl text-center">
-      <h3 class="mb-2 text-base font-medium text-[#f7f8f8]">
+    <div class="w-full max-w-2xl text-center transition-colors">
+      <h3 class="mb-2 text-base font-medium text-gray-900 dark:text-[#f7f8f8]">
         {{ uploadMode === 'note' ? '上传手写笔记' : '上传试卷图片' }}
       </h3>
-      <p class="text-sm leading-relaxed text-[#62666d] md:whitespace-nowrap">
+      <p class="text-sm leading-relaxed text-gray-500 dark:text-[#62666d] md:whitespace-nowrap">
         {{ uploadMode === 'note'
           ? '支持拍照或扫描件，AI 将自动识别内容并整理为结构化笔记'
           : '支持 PDF 和图片格式，AI 将自动完成 OCR 识别、题目分割和知识点标注'
@@ -112,30 +112,30 @@ const emit = defineEmits([
     </div>
 
     <!-- 流程步骤卡片 -->
-    <div class="grid w-full max-w-2xl grid-cols-4 gap-4">
+    <div class="grid w-full max-w-2xl grid-cols-4 gap-4 transition-colors">
       <div class="flex flex-col items-center gap-3 rounded-lg brand-btn p-4 text-center">
-        <div class="flex h-12 w-12 items-center justify-center rounded-lg bg-white/[0.04]">
+        <div class="flex h-12 w-12 items-center justify-center rounded-lg bg-gray-100 dark:bg-white/[0.04]">
           <i class="fa-solid fa-cloud-arrow-up text-xl text-[rgb(129,115,223)]"></i>
         </div>
-        <span class="text-sm text-[#8a8f98]">{{ uploadMode === 'note' ? '上传笔记' : '上传文件' }}</span>
+        <span class="text-sm text-gray-500 dark:text-[#8a8f98]">{{ uploadMode === 'note' ? '上传笔记' : '上传文件' }}</span>
       </div>
       <div class="flex flex-col items-center gap-3 rounded-lg brand-btn p-4 text-center">
-        <div class="flex h-12 w-12 items-center justify-center rounded-lg bg-white/[0.04]">
+        <div class="flex h-12 w-12 items-center justify-center rounded-lg bg-gray-100 dark:bg-white/[0.04]">
           <i class="fa-solid fa-eye text-xl text-[rgb(129,115,223)]"></i>
         </div>
-        <span class="text-sm text-[#8a8f98]">AI 识别</span>
+        <span class="text-sm text-gray-500 dark:text-[#8a8f98]">AI 识别</span>
       </div>
       <div class="flex flex-col items-center gap-3 rounded-lg brand-btn p-4 text-center">
-        <div class="flex h-12 w-12 items-center justify-center rounded-lg bg-white/[0.04]">
+        <div class="flex h-12 w-12 items-center justify-center rounded-lg bg-gray-100 dark:bg-white/[0.04]">
           <i class="fa-solid text-xl text-[rgb(129,115,223)]" :class="uploadMode === 'note' ? 'fa-wand-magic-sparkles' : 'fa-scissors'"></i>
         </div>
-        <span class="text-sm text-[#8a8f98]">{{ uploadMode === 'note' ? '智能整理' : '分割纠错' }}</span>
+        <span class="text-sm text-gray-500 dark:text-[#8a8f98]">{{ uploadMode === 'note' ? '智能整理' : '分割纠错' }}</span>
       </div>
       <div class="flex flex-col items-center gap-3 rounded-lg brand-btn p-4 text-center">
-        <div class="flex h-12 w-12 items-center justify-center rounded-lg bg-white/[0.04]">
+        <div class="flex h-12 w-12 items-center justify-center rounded-lg bg-gray-100 dark:bg-white/[0.04]">
           <i class="fa-solid text-xl text-[rgb(129,115,223)]" :class="uploadMode === 'note' ? 'fa-bookmark' : 'fa-file-export'"></i>
         </div>
-        <span class="text-sm text-[#8a8f98]">{{ uploadMode === 'note' ? '保存笔记' : '导出归档' }}</span>
+        <span class="text-sm text-gray-500 dark:text-[#8a8f98]">{{ uploadMode === 'note' ? '保存笔记' : '导出归档' }}</span>
       </div>
     </div>
 
@@ -181,3 +181,11 @@ const emit = defineEmits([
     />
   </div>
 </template>
+
+<style scoped>
+.brand-gradient-bg {
+  background: linear-gradient(to bottom, rgba(129, 115, 223, 0.9), rgba(99, 87, 199, 0.9));
+  box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.12);
+  border: none;
+}
+</style>

--- a/frontend/src/components/workspace/WorkspaceBackground.vue
+++ b/frontend/src/components/workspace/WorkspaceBackground.vue
@@ -23,7 +23,7 @@ const bgStars = (() => {
     <div
       v-for="(s, i) in bgStars"
       :key="i"
-      class="absolute rounded-full bg-white ws-star"
+      class="absolute rounded-full bg-indigo-400 dark:bg-white ws-star transition-colors duration-200"
       :style="{
         left: s.left + '%',
         top: s.top + '%',

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -22,24 +22,43 @@
   padding: 4px 10px;
   font-size: 13px;
   font-weight: 500;
-  color: #8a8f98;
+  color: #62666d;
   border-radius: 6px;
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  background: #ffffff;
   transition: all 0.15s;
   cursor: pointer;
 }
 .filter-pill:hover {
+  background: #f7f8f8;
+  border-color: rgba(0, 0, 0, 0.12);
+  color: #111827;
+}
+.filter-pill--active {
+  background: rgba(129, 115, 223, 0.08);
+  border-color: rgba(129, 115, 223, 0.2);
+  color: rgb(129, 115, 223);
+}
+.filter-pill--active:hover {
+  background: rgba(129, 115, 223, 0.12);
+}
+
+.dark .filter-pill {
+  color: #8a8f98;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.02);
+}
+.dark .filter-pill:hover {
   background: rgba(255, 255, 255, 0.04);
   border-color: rgba(255, 255, 255, 0.1);
   color: #d0d6e0;
 }
-.filter-pill--active {
+.dark .filter-pill--active {
   background: rgba(129, 115, 223, 0.12);
   border-color: rgba(129, 115, 223, 0.3);
   color: rgb(145, 132, 235);
 }
-.filter-pill--active:hover {
+.dark .filter-pill--active:hover {
   background: rgba(129, 115, 223, 0.18);
 }
 

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -2,10 +2,7 @@
 import { ref, onMounted, onUnmounted, nextTick } from 'vue'
 import { useTheme } from '@/composables/useTheme.js'
 
-const { initTheme, setTheme, isDark } = useTheme()
-
-// 首页固定深色：记住用户原始主题，离开时恢复
-let savedTheme = null
+const { initTheme } = useTheme()
 
 import HomeHeader from '@/components/home/HomeHeader.vue'
 import HomeSideNav from '@/components/home/HomeSideNav.vue'
@@ -201,10 +198,6 @@ function setupRevealObserver() {
 onMounted(async () => {
   initTheme()
 
-  // 首页强制深色模式
-  savedTheme = isDark.value ? 'dark' : 'light'
-  if (!isDark.value) setTheme(true)
-
   // 不再锁定 body overflow，中间页面允许正常滚动
 
   await nextTick()
@@ -236,9 +229,6 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
-  // 离开首页时恢复用户原有主题
-  if (savedTheme === 'light') setTheme(false)
-
   if (wheelUnlisten) wheelUnlisten()
   if (scrollUnlisten) scrollUnlisten()
   if (revealObserver) revealObserver.disconnect()
@@ -312,8 +302,6 @@ onUnmounted(() => {
 </template>
 
 <style>
-/* Home page always uses dark mode class - set in onMounted */
-
 @keyframes pageEnter {
   from { opacity: 0; }
   to   { opacity: 1; }

--- a/frontend/src/views/app/AppLayout.vue
+++ b/frontend/src/views/app/AppLayout.vue
@@ -141,7 +141,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="flex h-screen w-full overflow-hidden bg-[#0c0c0e] font-sans text-slate-300 relative">
+  <div class="flex h-screen w-full overflow-hidden bg-slate-50 dark:bg-[#0c0c0e] font-sans text-slate-900 dark:text-slate-300 relative transition-colors duration-200">
 
     <WorkspaceBackground />
 

--- a/frontend/src/views/app/ChatPageView.vue
+++ b/frontend/src/views/app/ChatPageView.vue
@@ -174,10 +174,10 @@ function autoResize() {
 
         <!-- 空状态：居中问候 -->
         <div v-if="messages.length === 0 && !streaming" class="flex flex-col items-center justify-center" style="min-height: calc(100vh - 200px)">
-          <p class="text-2xl font-bold text-[#f7f8f8]">
+          <p class="text-2xl font-bold text-gray-900 dark:text-[#f7f8f8]">
             Hi，{{ username || '同学' }}
           </p>
-          <p class="mt-2 text-sm text-[#62666d]">有问题，尽管问</p>
+          <p class="mt-2 text-sm text-gray-500 dark:text-[#62666d]">有问题，尽管问</p>
         </div>
 
         <!-- 消息列表 -->
@@ -186,16 +186,16 @@ function autoResize() {
             <div
               class="max-w-[85%] rounded-2xl px-4 py-3 text-sm leading-relaxed"
               :class="msg.role === 'user'
-                ? 'brand-btn text-white rounded-br-lg'
-                : 'brand-btn text-[#d0d6e0] rounded-bl-lg'"
+                ? 'bg-indigo-500 text-white rounded-br-lg shadow-sm dark:bg-[rgb(129,115,223)] dark:text-white dark:border-none'
+                : 'bg-white border border-gray-200 text-gray-800 rounded-bl-lg shadow-sm dark:bg-white/[0.05] dark:text-[#d0d6e0] dark:border-white/[0.08]'"
             >
               <!-- 思考过程折叠面板 -->
               <div v-if="msg.role === 'assistant' && msg.reasoning" class="mb-3">
                 <button
                   @click="msg.reasoningOpen = !msg.reasoningOpen"
-                  class="flex items-center gap-2 text-xs font-bold text-[#8a8f98] hover:text-[#d0d6e0] transition-colors"
+                  class="flex items-center gap-2 text-xs font-bold text-gray-500 hover:text-gray-700 dark:text-[#8a8f98] dark:hover:text-[#d0d6e0] transition-colors"
                 >
-                  <i class="fa-solid fa-brain text-[rgb(129,115,223)]"></i>
+                  <i class="fa-solid fa-brain text-indigo-500 dark:text-[rgb(129,115,223)]"></i>
                   <span>{{ streaming && i === messages.length - 1 && !msg.content ? '思考中...' : '已深度思考' }}</span>
                   <i class="fa-solid text-[10px] transition-transform" :class="msg.reasoningOpen ? 'fa-chevron-up' : 'fa-chevron-down'"></i>
                 </button>
@@ -207,22 +207,22 @@ function autoResize() {
                   leave-from-class="opacity-100 max-h-[400px]"
                   leave-to-class="opacity-0 max-h-0"
                 >
-                  <div v-if="msg.reasoningOpen" class="mt-2 overflow-auto max-h-[400px] rounded-xl bg-white/[0.03] p-3 text-xs text-[#8a8f98] leading-relaxed custom-scrollbar whitespace-pre-wrap">{{ msg.reasoning }}</div>
+                  <div v-if="msg.reasoningOpen" class="mt-2 overflow-auto max-h-[400px] rounded-xl bg-gray-50 border border-gray-100 p-3 text-xs text-gray-600 leading-relaxed custom-scrollbar whitespace-pre-wrap dark:bg-white/[0.03] dark:border-none dark:text-[#8a8f98]">{{ msg.reasoning }}</div>
                 </Transition>
               </div>
               <!-- 正文内容 -->
               <div
                 v-if="msg.role === 'assistant' && !(streaming && i === messages.length - 1 && !msg.content)"
                 v-html="renderMarkdown(msg.content)"
-                class="prose prose-sm prose-invert max-w-none"
+                class="prose prose-sm max-w-none dark:prose-invert"
               ></div>
               <div
                 v-else-if="msg.role === 'assistant' && streaming && i === messages.length - 1 && !msg.content"
                 class="flex gap-1"
               >
-                <span class="w-2 h-2 rounded-full bg-[#62666d] animate-bounce" style="animation-delay: 0ms"></span>
-                <span class="w-2 h-2 rounded-full bg-[#62666d] animate-bounce" style="animation-delay: 150ms"></span>
-                <span class="w-2 h-2 rounded-full bg-[#62666d] animate-bounce" style="animation-delay: 300ms"></span>
+                <span class="w-2 h-2 rounded-full bg-gray-400 dark:bg-[#62666d] animate-bounce" style="animation-delay: 0ms"></span>
+                <span class="w-2 h-2 rounded-full bg-gray-400 dark:bg-[#62666d] animate-bounce" style="animation-delay: 150ms"></span>
+                <span class="w-2 h-2 rounded-full bg-gray-400 dark:bg-[#62666d] animate-bounce" style="animation-delay: 300ms"></span>
               </div>
               <div v-else class="whitespace-pre-wrap">{{ msg.content }}</div>
             </div>
@@ -235,7 +235,7 @@ function autoResize() {
     <!-- 底部输入区域 -->
     <div class="shrink-0 px-4 pb-4 pt-2 sm:px-8">
       <div class="mx-auto max-w-5xl">
-        <div class="rounded-xl brand-btn overflow-hidden">
+        <div class="rounded-xl border border-gray-200 bg-white shadow-sm overflow-hidden dark:border-white/[0.08] dark:bg-white/[0.03]">
           <!-- 文本输入 -->
           <textarea
             ref="textareaRef"
@@ -245,7 +245,7 @@ function autoResize() {
             :disabled="streaming || !sessionId"
             rows="1"
             :placeholder="sessionId ? '有问题，尽管问，shift+enter 换行' : '请先新建或选择一个对话'"
-            class="w-full resize-none bg-transparent px-4 pt-3 pb-1 text-sm outline-none text-[#f7f8f8] placeholder-[#62666d]"
+            class="w-full resize-none bg-transparent px-4 pt-3 pb-1 text-sm outline-none text-gray-900 placeholder-gray-400 dark:text-[#f7f8f8] dark:placeholder-[#62666d]"
             style="min-height: 24px; max-height: 200px;"
           ></textarea>
 
@@ -257,8 +257,8 @@ function autoResize() {
                 @click="deepThink = !deepThink"
                 class="h-8 px-2.5 rounded-lg text-xs font-bold flex items-center gap-1.5 transition-colors"
                 :class="deepThink
-                  ? 'bg-[rgb(129,115,223)]/15 text-[rgb(145,132,235)]'
-                  : 'text-[#62666d] hover:text-[#8a8f98]'"
+                  ? 'bg-indigo-50 text-indigo-600 dark:bg-[rgb(129,115,223)]/15 dark:text-[rgb(145,132,235)]'
+                  : 'text-gray-500 hover:text-gray-700 hover:bg-gray-50 dark:text-[#62666d] dark:hover:text-[#8a8f98] dark:hover:bg-transparent'"
                 title="深度思考"
               >
                 <i class="fa-solid fa-brain text-sm"></i>
@@ -266,7 +266,7 @@ function autoResize() {
               </button>
               <button
                 disabled
-                class="h-8 px-2.5 rounded-lg text-xs font-bold flex items-center gap-1.5 text-[#62666d] cursor-not-allowed"
+                class="h-8 px-2.5 rounded-lg text-xs font-bold flex items-center gap-1.5 text-gray-400 dark:text-[#62666d] cursor-not-allowed"
                 title="联网搜索（敬请期待）"
               >
                 <i class="fa-solid fa-globe text-sm"></i>
@@ -278,7 +278,7 @@ function autoResize() {
             <div class="flex items-center gap-1.5">
               <button
                 disabled
-                class="h-8 w-8 rounded-lg flex items-center justify-center text-[#62666d] hover:bg-white/[0.04] transition-colors cursor-not-allowed"
+                class="h-8 w-8 rounded-lg flex items-center justify-center text-gray-400 hover:bg-gray-50 dark:text-[#62666d] dark:hover:bg-white/[0.04] transition-colors cursor-not-allowed"
                 title="附件（敬请期待）"
               >
                 <i class="fa-solid fa-plus text-sm"></i>
@@ -288,15 +288,15 @@ function autoResize() {
                 :disabled="sessionId ? (!inputText.trim() || streaming) : false"
                 class="h-8 w-8 rounded-full flex items-center justify-center transition-all"
                 :class="inputText.trim() && sessionId
-                  ? 'brand-btn text-white'
-                  : 'bg-white/[0.06] text-[#62666d] opacity-50'"
+                  ? 'bg-indigo-500 text-white shadow-sm dark:bg-[rgb(129,115,223)]'
+                  : 'bg-gray-100 text-gray-400 dark:bg-white/[0.06] dark:text-[#62666d]'"
               >
                 <i class="fa-solid fa-arrow-up text-xs"></i>
               </button>
             </div>
           </div>
         </div>
-        <p class="mt-2 text-center text-xs text-[#62666d]">内容由 AI 生成，仅供参考</p>
+        <p class="mt-2 text-center text-xs text-gray-400 dark:text-[#62666d]">内容由 AI 生成，仅供参考</p>
       </div>
     </div>
   </div>

--- a/frontend/src/views/app/DashboardView.vue
+++ b/frontend/src/views/app/DashboardView.vue
@@ -202,7 +202,7 @@ onBeforeUnmount(() => {
   <ContentPanel title="数据面板">
     <template #toolbar>
       <BaseSelect v-if="subjects.length" v-model="selectedSubject" :options="subjects" placeholder="全部学科" width-class="min-w-[140px]" />
-      <button @click="currentView = 'workspace'" class="inline-flex items-center gap-2 rounded-md brand-btn px-3 py-1.5 text-xs font-medium text-[#f7f8f8]">
+      <button @click="currentView = 'workspace'" class="inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium text-white transition-colors bg-[rgb(129,115,223)] hover:bg-[rgb(145,132,235)] shadow-sm dark:brand-btn">
         <i class="fa-solid fa-plus-circle text-[10px]"></i> 录入新题目
       </button>
     </template>

--- a/frontend/src/views/app/ErrorBankView.vue
+++ b/frontend/src/views/app/ErrorBankView.vue
@@ -324,7 +324,7 @@ onBeforeUnmount(() => {
 <template>
   <ContentPanel title="错题库">
     <template #toolbar>
-      <button @click="currentView = 'workspace'" class="flex h-7 items-center gap-1.5 rounded-md border border-white/[0.06] bg-white/[0.03] px-2.5 text-xs font-medium text-[#8a8f98] hover:bg-white/[0.06] hover:text-[#d0d6e0] transition-colors" title="录入新题目">
+      <button @click="currentView = 'workspace'" class="flex h-7 items-center gap-1.5 rounded-md border border-gray-200 dark:border-white/[0.06] bg-white dark:bg-white/[0.03] px-2.5 text-xs font-medium text-gray-500 dark:text-[#8a8f98] hover:bg-gray-50 dark:hover:bg-white/[0.06] hover:text-gray-700 dark:hover:text-[#d0d6e0] transition-colors" title="录入新题目">
         <i class="fa-solid fa-plus text-[10px]"></i> 录入
       </button>
     </template>
@@ -345,21 +345,21 @@ onBeforeUnmount(() => {
       <div class="relative z-20 mb-4 flex items-center gap-2 flex-wrap">
         <!-- 搜索框 -->
         <div class="relative">
-          <i class="fa-solid fa-magnifying-glass pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-xs text-[#62666d]"></i>
+          <i class="fa-solid fa-magnifying-glass pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-xs text-gray-400 dark:text-[#62666d] transition-colors"></i>
           <input
             v-model="filters.keyword"
             type="text"
             placeholder="搜索题目..."
-            class="h-8 w-52 rounded-md border border-white/[0.08] bg-white/[0.02] pl-8 pr-3 text-xs font-medium text-[#f7f8f8] placeholder-[#62666d] outline-none transition-colors hover:border-white/[0.12] focus:border-white/[0.15]"
+            class="h-8 w-52 rounded-md border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.02] pl-8 pr-3 text-xs font-medium text-gray-900 dark:text-[#f7f8f8] placeholder-gray-400 dark:placeholder-[#62666d] outline-none transition-colors hover:border-gray-300 dark:hover:border-white/[0.12] focus:border-indigo-500 dark:focus:border-white/[0.15]"
           />
         </div>
 
         <!-- 操作按钮（推到右侧） -->
         <div class="ml-auto flex items-center gap-1">
-          <button @click="toggleFilterPanel" class="flex h-7 w-7 items-center justify-center rounded-md border border-white/[0.06] bg-white/[0.03] transition-colors" :class="filterPanelOpen ? 'bg-white/[0.08] text-[#f7f8f8] border-white/[0.12]' : 'text-[#8a8f98] hover:bg-white/[0.06] hover:text-[#d0d6e0]'" title="筛选设置">
+          <button @click="toggleFilterPanel" class="flex h-7 w-7 items-center justify-center rounded-md border transition-colors" :class="filterPanelOpen ? 'bg-indigo-50 dark:bg-white/[0.08] text-indigo-600 dark:text-[#f7f8f8] border-indigo-200 dark:border-white/[0.12]' : 'border-gray-200 dark:border-white/[0.06] bg-white dark:bg-white/[0.03] text-gray-500 dark:text-[#8a8f98] hover:bg-gray-50 dark:hover:bg-white/[0.06] hover:text-gray-700 dark:hover:text-[#d0d6e0]'" title="筛选设置">
             <i class="fa-solid fa-sliders text-xs"></i>
           </button>
-          <button @click="toggleSelectMode" class="flex h-7 w-7 items-center justify-center rounded-md border border-white/[0.06] bg-white/[0.03] transition-colors" :class="selectMode ? 'bg-white/[0.08] text-[#f7f8f8] border-white/[0.12]' : 'text-[#8a8f98] hover:bg-white/[0.06] hover:text-[#d0d6e0]'" title="导出题目">
+          <button @click="toggleSelectMode" class="flex h-7 w-7 items-center justify-center rounded-md border transition-colors" :class="selectMode ? 'bg-indigo-50 dark:bg-white/[0.08] text-indigo-600 dark:text-[#f7f8f8] border-indigo-200 dark:border-white/[0.12]' : 'border-gray-200 dark:border-white/[0.06] bg-white dark:bg-white/[0.03] text-gray-500 dark:text-[#8a8f98] hover:bg-gray-50 dark:hover:bg-white/[0.06] hover:text-gray-700 dark:hover:text-[#d0d6e0]'" title="导出题目">
             <i class="fa-solid fa-file-export text-xs"></i>
           </button>
         </div>
@@ -382,7 +382,7 @@ onBeforeUnmount(() => {
         <button
           v-if="filters.subject || filters.question_type || filters.review_status || selectedTags.size"
           @click="filters.subject = ''; filters.question_type = ''; filters.review_status = ''; clearTagSelection()"
-          class="text-xs text-[#62666d] hover:text-rose-400 transition-colors"
+          class="text-xs text-gray-500 dark:text-[#62666d] hover:text-rose-500 dark:hover:text-rose-400 transition-colors"
         >清除筛选</button>
       </div>
 
@@ -399,7 +399,7 @@ onBeforeUnmount(() => {
           title="暂无匹配记录"
           description="调整筛选条件，或者开始新的录入"
         >
-          <button @click="currentView = 'workspace'" class="inline-flex items-center gap-2 rounded-md brand-btn px-4 py-2 text-sm font-medium text-[#f7f8f8]">
+          <button @click="currentView = 'workspace'" class="inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium text-white transition-colors bg-[rgb(129,115,223)] hover:bg-[rgb(145,132,235)] shadow-sm dark:brand-btn">
             <i class="fa-solid fa-plus"></i> 录入新题目
           </button>
         </EmptyState>
@@ -516,6 +516,8 @@ onBeforeUnmount(() => {
       @export="doExport"
       @clear="clearSelection"
     />
+
+
 
     <EditNoteDialog
       :open="dialogOpen"

--- a/frontend/src/views/app/NoteView.vue
+++ b/frontend/src/views/app/NoteView.vue
@@ -195,7 +195,7 @@ async function doDelete(noteId) {
 <template>
   <ContentPanel title="笔记库">
     <template #toolbar>
-      <button @click="triggerUpload" class="flex h-7 items-center gap-1.5 rounded-md border border-white/[0.06] bg-white/[0.03] px-2.5 text-xs font-medium text-[#8a8f98] hover:bg-white/[0.06] hover:text-[#d0d6e0] transition-colors" title="上传笔记">
+      <button @click="triggerUpload" class="flex h-7 items-center gap-1.5 rounded-md border border-gray-200 bg-white px-2.5 text-xs font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:border-white/[0.06] dark:bg-white/[0.03] dark:text-[#8a8f98] dark:hover:bg-white/[0.06] dark:hover:text-[#d0d6e0] transition-colors" title="上传笔记">
         <i class="fa-solid fa-upload text-[10px]"></i> 上传笔记
       </button>
     </template>
@@ -213,8 +213,8 @@ async function doDelete(noteId) {
             <BaseSelect v-model="filterSubject" :options="subjects" label="学科" placeholder="全部学科" />
             <BaseSelect v-model="filterTag" :options="tagNames" label="知识点" placeholder="全部知识点" />
             <div>
-              <label class="mb-1.5 block text-xs font-medium text-[#62666d]">统计</label>
-              <div class="flex h-9 items-center rounded-md border border-white/[0.08] bg-white/[0.02] px-3 text-sm text-[#8a8f98]">
+              <label class="mb-1.5 block text-xs font-medium text-gray-600 dark:text-[#62666d]">统计</label>
+              <div class="flex h-9 items-center rounded-md border border-gray-200 bg-gray-50 px-3 text-sm text-gray-500 dark:border-white/[0.08] dark:bg-white/[0.02] dark:text-[#8a8f98]">
                 共 {{ total }} 条笔记
               </div>
             </div>
@@ -222,10 +222,10 @@ async function doDelete(noteId) {
 
           <!-- 进度条 -->
           <div v-if="creating" class="mt-4">
-            <div class="h-1 rounded-full bg-white/[0.06]">
-              <div class="h-full rounded-full bg-[rgb(129,115,223)] transition-all duration-300" :style="{ width: createProgress + '%' }"></div>
+            <div class="h-1 rounded-full bg-gray-200 dark:bg-white/[0.06]">
+              <div class="h-full rounded-full bg-indigo-500 dark:bg-[rgb(129,115,223)] transition-all duration-300" :style="{ width: createProgress + '%' }"></div>
             </div>
-            <p class="mt-1 text-xs text-[#62666d]">OCR 识别 + AI 整理中... {{ createProgress }}%</p>
+            <p class="mt-1 text-xs text-gray-500 dark:text-[#62666d]">OCR 识别 + AI 整理中... {{ createProgress }}%</p>
           </div>
         </div>
 
@@ -237,28 +237,29 @@ async function doDelete(noteId) {
             title="还没有笔记"
             description="上传手写笔记或板书照片，AI 自动整理为结构化知识点"
           >
-            <button @click="triggerUpload" class="inline-flex items-center gap-2 rounded-md brand-btn px-4 py-2 text-sm font-medium text-[#f7f8f8]">
+            <button @click="triggerUpload" class="inline-flex items-center gap-2 rounded-md bg-indigo-500 hover:bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm dark:brand-btn dark:text-[#f7f8f8]">
               <i class="fa-solid fa-plus"></i> 上传笔记
             </button>
           </EmptyState>
 
           <div v-else class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            <div
+            <BaseCard
               v-for="note in notes"
               :key="note.id"
               @click="openNote(note)"
-              class="group cursor-pointer rounded-lg border border-white/[0.06] bg-white/[0.02] p-4 transition-all hover:bg-white/[0.04] hover:border-white/[0.1]"
+              class="group cursor-pointer"
+              padding="p-4"
             >
-              <h3 class="mb-2 text-sm font-medium text-[#f7f8f8] line-clamp-2">{{ note.title }}</h3>
-              <p class="mb-3 text-xs text-[#8a8f98] line-clamp-3">
+              <h3 class="mb-2 text-sm font-medium text-gray-900 dark:text-[#f7f8f8] line-clamp-2">{{ note.title }}</h3>
+              <p class="mb-3 text-xs text-gray-500 dark:text-[#8a8f98] line-clamp-3">
                 {{ note.content_markdown?.replace(/[#*`>\-]/g, '').slice(0, 120) }}...
               </p>
               <div class="flex flex-wrap items-center gap-2">
-                <span v-if="note.subject" class="rounded-md bg-[rgb(129,115,223)]/10 px-2 py-0.5 text-xs font-medium text-[rgb(145,132,235)]">{{ note.subject }}</span>
-                <span v-for="tag in (note.knowledge_tags || []).slice(0, 3)" :key="tag" class="rounded-md border border-white/[0.06] px-2 py-0.5 text-xs text-[#8a8f98]">{{ tag }}</span>
-                <span class="ml-auto text-xs text-[#62666d]">{{ note.updated_at?.slice(0, 10) }}</span>
+                <span v-if="note.subject" class="rounded-md bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-600 dark:bg-[rgb(129,115,223)]/10 dark:text-[rgb(145,132,235)]">{{ note.subject }}</span>
+                <span v-for="tag in (note.knowledge_tags || []).slice(0, 3)" :key="tag" class="rounded-md border border-gray-200 px-2 py-0.5 text-xs text-gray-500 dark:border-white/[0.06] dark:text-[#8a8f98]">{{ tag }}</span>
+                <span class="ml-auto text-xs text-gray-400 dark:text-[#62666d]">{{ note.updated_at?.slice(0, 10) }}</span>
               </div>
-            </div>
+            </BaseCard>
           </div>
 
           <!-- 分页 -->
@@ -268,7 +269,7 @@ async function doDelete(noteId) {
               :key="p"
               @click="page = p"
               class="size-8 rounded-md text-xs font-medium transition-all"
-              :class="p === page ? 'brand-btn text-[#f7f8f8]' : 'border border-white/[0.06] text-[#8a8f98] hover:bg-white/[0.04]'"
+              :class="p === page ? 'bg-indigo-500 text-white shadow-sm dark:brand-btn dark:text-[#f7f8f8]' : 'border border-gray-200 bg-white text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:border-white/[0.06] dark:bg-transparent dark:text-[#8a8f98] dark:hover:bg-white/[0.04]'"
             >
               {{ p }}
             </button>
@@ -280,15 +281,15 @@ async function doDelete(noteId) {
       <div v-else>
         <!-- 详情工具栏 -->
         <div class="mb-6 flex items-center justify-between">
-          <h3 class="text-base font-medium text-[#f7f8f8]">{{ selectedNote.title }}</h3>
+          <h3 class="text-base font-medium text-gray-900 dark:text-[#f7f8f8]">{{ selectedNote.title }}</h3>
           <div class="flex items-center gap-2">
-            <button @click="closeDetail" class="inline-flex items-center gap-2 rounded-md border border-white/[0.08] bg-white/[0.02] px-3 py-1.5 text-xs font-medium text-[#d0d6e0] hover:bg-white/[0.05] transition-colors">
+            <button @click="closeDetail" class="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 hover:text-gray-800 dark:border-white/[0.08] dark:bg-white/[0.02] dark:text-[#d0d6e0] dark:hover:bg-white/[0.05] transition-colors">
               <i class="fa-solid fa-arrow-left text-[10px]"></i> 返回
             </button>
-            <button v-if="!editing" @click="startEdit" class="inline-flex items-center gap-2 rounded-md border border-white/[0.08] bg-white/[0.02] px-3 py-1.5 text-xs font-medium text-[#d0d6e0] hover:bg-white/[0.05] transition-colors">
+            <button v-if="!editing" @click="startEdit" class="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 hover:text-gray-800 dark:border-white/[0.08] dark:bg-white/[0.02] dark:text-[#d0d6e0] dark:hover:bg-white/[0.05] transition-colors">
               <i class="fa-solid fa-pen text-[10px]"></i> 编辑
             </button>
-            <button @click="doDelete(selectedNote.id)" class="inline-flex items-center gap-2 rounded-md border border-white/[0.08] bg-white/[0.02] px-3 py-1.5 text-xs font-medium text-rose-400 hover:bg-rose-500/10 transition-colors">
+            <button @click="doDelete(selectedNote.id)" class="inline-flex items-center gap-2 rounded-md border border-red-200 bg-red-50 px-3 py-1.5 text-xs font-medium text-red-600 hover:bg-red-100 hover:text-red-700 dark:border-white/[0.08] dark:bg-white/[0.02] dark:text-rose-400 dark:hover:bg-rose-500/10 transition-colors">
               <i class="fa-solid fa-trash text-[10px]"></i> 删除
             </button>
           </div>

--- a/frontend/src/views/app/SplitHistoryView.vue
+++ b/frontend/src/views/app/SplitHistoryView.vue
@@ -151,12 +151,12 @@ defineExpose({ refresh: loadRecords })
   <div v-show="visible" class="flex h-full flex-col overflow-hidden">
     <div class="relative flex h-full flex-col">
       <!-- 页头 -->
-      <div class="flex items-center justify-between px-4 py-3 border-b border-white/[0.05] shrink-0">
-        <span class="text-xs font-medium text-[#f7f8f8]">分割历史</span>
+      <div class="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-white/[0.05] shrink-0 transition-colors">
+        <span class="text-xs font-medium text-gray-900 dark:text-[#f7f8f8] transition-colors">分割历史</span>
         <button
           @click="loadRecords"
           :disabled="loading"
-          class="text-xs text-[#8a8f98] hover:text-[#d0d6e0] transition-colors disabled:opacity-50"
+          class="text-xs text-gray-500 dark:text-[#8a8f98] hover:text-gray-700 dark:hover:text-[#d0d6e0] transition-colors disabled:opacity-50"
         >
           <i class="fa-solid fa-arrows-rotate text-[10px]" :class="{ 'animate-spin': loading }"></i>
         </button>
@@ -167,13 +167,13 @@ defineExpose({ refresh: loadRecords })
 
         <!-- 加载状态 -->
         <div v-if="loading && !records.length" class="flex items-center justify-center py-10">
-          <div class="h-5 w-5 animate-spin rounded-full border-2 border-white/10 border-t-[rgb(129,115,223)]"></div>
+          <div class="h-5 w-5 animate-spin rounded-full border-2 border-gray-200 dark:border-white/10 border-t-[rgb(129,115,223)] transition-colors"></div>
         </div>
 
         <!-- 空状态 -->
-        <div v-else-if="!loading && !records.length" class="px-4 py-10 text-center">
-          <i class="fa-solid fa-clock-rotate-left text-lg text-[#62666d] mb-2"></i>
-          <p class="text-xs text-[#62666d]">暂无记录</p>
+        <div v-else-if="!loading && !records.length" class="px-4 py-10 text-center transition-colors">
+          <i class="fa-solid fa-clock-rotate-left text-lg text-gray-400 dark:text-[#62666d] mb-2 transition-colors"></i>
+          <p class="text-xs text-gray-400 dark:text-[#62666d] transition-colors">暂无记录</p>
         </div>
 
         <!-- 记录列表 -->
@@ -181,17 +181,17 @@ defineExpose({ refresh: loadRecords })
           <div
             v-for="(r, idx) in records"
             :key="r.id"
-            class="group cursor-pointer border-b border-white/[0.05] px-4 py-3 transition-colors hover:bg-white/[0.03]"
-            :class="activeRecord?.id === r.id ? 'bg-white/[0.04]' : ''"
+            class="group cursor-pointer border-b border-gray-200 dark:border-white/[0.05] px-4 py-3 transition-colors hover:bg-gray-50 dark:hover:bg-white/[0.03]"
+            :class="activeRecord?.id === r.id ? 'bg-gray-100 dark:bg-white/[0.04]' : ''"
             @click="openDetail(r)"
           >
             <!-- 一行：科目 + 时间 + 题数 -->
             <div class="flex items-center justify-between mb-1">
-              <span class="text-sm font-medium text-[#f7f8f8] truncate">{{ r.subject || '未识别' }}</span>
+              <span class="text-sm font-medium text-gray-900 dark:text-[#f7f8f8] truncate transition-colors">{{ r.subject || '未识别' }}</span>
               <span class="text-xs tabular-nums text-[rgb(129,115,223)]">{{ r.question_count }} 题</span>
             </div>
             <!-- 二行：文件数 + 时间 -->
-            <div class="flex items-center gap-2 text-xs text-[#62666d]">
+            <div class="flex items-center gap-2 text-xs text-gray-500 dark:text-[#62666d] transition-colors">
               <span>{{ (r.file_names || []).length }} 个文件</span>
               <span>·</span>
               <span :title="formatFullDate(r.created_at)">{{ formatDate(r.created_at) }}</span>

--- a/frontend/src/views/app/WorkspaceView.vue
+++ b/frontend/src/views/app/WorkspaceView.vue
@@ -127,8 +127,8 @@ onBeforeUnmount(() => {
             @click="showSplitHistory = !showSplitHistory"
             class="inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium transition-colors"
             :class="showSplitHistory
-              ? 'bg-white/[0.06] text-[#f7f8f8] border border-white/[0.12]'
-              : 'border border-white/[0.08] bg-white/[0.02] text-[#d0d6e0] hover:bg-white/[0.05] hover:border-white/[0.12]'"
+              ? 'bg-gray-200 dark:bg-white/[0.06] text-gray-900 dark:text-[#f7f8f8] border border-gray-300 dark:border-white/[0.12]'
+              : 'border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.02] text-gray-700 dark:text-[#d0d6e0] hover:bg-gray-50 dark:hover:bg-white/[0.05] hover:border-gray-300 dark:hover:border-white/[0.12]'"
           >
             <i class="fa-solid fa-clock-rotate-left text-[10px]"></i>
             分割历史
@@ -183,13 +183,13 @@ onBeforeUnmount(() => {
         <template #toolbar>
           <button
             @click="handleBack"
-            class="group inline-flex items-center gap-2 rounded-md border border-white/[0.08] bg-white/[0.02] px-3 py-1.5 text-xs font-medium text-[#d0d6e0] hover:bg-white/[0.05] hover:border-white/[0.12] transition-colors"
+            class="group inline-flex items-center gap-2 rounded-md border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.02] px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-[#d0d6e0] hover:bg-gray-50 dark:hover:bg-white/[0.05] hover:border-gray-300 dark:hover:border-white/[0.12] transition-colors"
           >
             <i class="fa-solid fa-arrow-left-long text-xs transition-transform group-hover:-translate-x-0.5"></i>
             返回
           </button>
           <template v-if="eraseDone && !ocrLoading && !ocrDone">
-            <button @click="doErase" class="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.02] px-3 py-1.5 text-xs font-medium text-[#d0d6e0] hover:bg-white/[0.05] transition-colors">
+            <button @click="doErase" class="inline-flex items-center gap-1.5 rounded-md border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.02] px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-[#d0d6e0] hover:bg-gray-50 dark:hover:bg-white/[0.05] transition-colors">
               <i class="fa-solid fa-arrows-rotate text-[10px]"></i> 重新擦除
             </button>
             <button @click="doOcr" class="inline-flex items-center gap-1.5 rounded-md bg-[rgb(129,115,223)] px-3 py-1.5 text-xs font-medium text-white hover:bg-[rgb(145,132,235)] transition-colors">
@@ -197,7 +197,7 @@ onBeforeUnmount(() => {
             </button>
           </template>
           <template v-else-if="ocrDone && !splitCompleted && !splitting">
-            <button @click="doOcr" class="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.02] px-3 py-1.5 text-xs font-medium text-[#d0d6e0] hover:bg-white/[0.05] transition-colors">
+            <button @click="doOcr" class="inline-flex items-center gap-1.5 rounded-md border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.02] px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-[#d0d6e0] hover:bg-gray-50 dark:hover:bg-white/[0.05] transition-colors">
               <i class="fa-solid fa-arrows-rotate text-[10px]"></i> 重新识别
             </button>
             <button @click="doSplit" class="inline-flex items-center gap-1.5 rounded-md bg-[rgb(129,115,223)] px-3 py-1.5 text-xs font-medium text-white hover:bg-[rgb(145,132,235)] transition-colors">

--- a/frontend/src/views/auth/AuthLayout.vue
+++ b/frontend/src/views/auth/AuthLayout.vue
@@ -75,14 +75,14 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="min-h-screen flex bg-[#0A0A0F]">
+  <div class="min-h-screen flex bg-slate-50 dark:bg-[#0A0A0F] transition-colors duration-200">
 
     <!-- 左侧品牌区（大屏显示） -->
-    <div ref="brandRef" class="hidden lg:flex flex-col justify-between w-[52%] relative overflow-hidden p-12 bg-gradient-to-br from-[#12121a] to-[#0A0A0F]">
+    <div ref="brandRef" class="hidden lg:flex flex-col justify-between w-[52%] relative overflow-hidden p-12 bg-gradient-to-br from-indigo-50 to-white dark:from-[#12121a] dark:to-[#0A0A0F] transition-colors duration-200">
       <!-- 底层：紫色曲线（暗态） -->
       <svg class="absolute inset-0 w-full h-full pointer-events-none" viewBox="0 0 600 800" preserveAspectRatio="none" fill="none">
-        <path d="M-50,250 C120,400 280,100 420,280 C560,460 600,180 700,350" stroke="rgba(129,115,223,0.12)" stroke-width="2.5" />
-        <path d="M-80,500 C80,650 240,340 400,520 C560,700 620,400 720,580" stroke="rgba(129,115,223,0.08)" stroke-width="2" />
+        <path d="M-50,250 C120,400 280,100 420,280 C560,460 600,180 700,350" stroke="rgba(129,115,223,0.12)" class="dark:stroke-indigo-400/10 stroke-indigo-600/10" stroke-width="2.5" />
+        <path d="M-80,500 C80,650 240,340 400,520 C560,700 620,400 720,580" stroke="rgba(129,115,223,0.08)" class="dark:stroke-indigo-400/10 stroke-indigo-600/10" stroke-width="2" />
       </svg>
       <!-- 亮层：鼠标跟随发光的紫色曲线（通过 mask 只显示鼠标附近） -->
       <div class="auth-glow-layer absolute inset-0 pointer-events-none">
@@ -92,14 +92,14 @@ onMounted(() => {
         </svg>
       </div>
       <!-- 底部紫色光晕 -->
-      <div class="absolute bottom-0 left-1/2 -translate-x-1/2 w-[80%] h-[200px] pointer-events-none rounded-full bg-indigo-500/[0.08] blur-[80px]"></div>
+      <div class="absolute bottom-0 left-1/2 -translate-x-1/2 w-[80%] h-[200px] pointer-events-none rounded-full bg-indigo-500/10 dark:bg-indigo-500/[0.08] blur-[80px] transition-colors"></div>
 
       <!-- 不规则星星 -->
       <div class="absolute inset-0 pointer-events-none">
         <div
           v-for="(s, i) in stars"
           :key="i"
-          class="absolute rounded-full bg-white star-twinkle"
+          class="absolute rounded-full bg-indigo-400 dark:bg-white star-twinkle transition-colors"
           :style="{
             left: s.left + '%',
             top: s.top + '%',
@@ -113,42 +113,46 @@ onMounted(() => {
       </div>
 
       <!-- 右侧分割线 -->
-      <div class="absolute top-0 right-0 bottom-0 w-px pointer-events-none bg-gradient-to-b from-transparent via-white/[0.08] to-transparent"></div>
+      <div class="absolute top-0 right-0 bottom-0 w-px pointer-events-none bg-gradient-to-b from-transparent via-gray-200 dark:via-white/[0.08] to-transparent transition-colors"></div>
 
       <!-- 顶部 Logo -->
       <div class="relative flex items-center gap-3">
         <BaseLogo breathe />
-        <span class="text-base font-semibold text-white/80 tracking-wide">智卷错题本</span>
+        <span class="text-base font-semibold text-gray-900 dark:text-white/80 tracking-wide transition-colors">智卷错题本</span>
       </div>
 
       <!-- 中部主文案 -->
       <div class="relative">
         <HomePill class="mb-6" />
-        <h2 class="text-4xl font-semibold text-white leading-tight mb-4 tracking-tight">
+        <h2 class="text-4xl font-semibold text-gray-900 dark:text-white leading-tight mb-4 tracking-tight transition-colors">
           重塑错题整理<br />
-          <span class="text-transparent bg-clip-text animate-gradient-sweep" style="
+          <span class="text-transparent bg-clip-text animate-gradient-sweep dark:hidden" style="
+            background-image: linear-gradient(to right, rgb(151, 137, 222) 0%, rgb(151, 137, 222) 20%, rgb(79, 70, 229) 50%, rgb(151, 137, 222) 80%, rgb(151, 137, 222) 100%);
+            background-size: 200% auto;
+          ">一键生成知识图谱</span>
+          <span class="text-transparent bg-clip-text animate-gradient-sweep hidden dark:inline" style="
             background-image: linear-gradient(to right, rgb(151, 137, 222) 0%, rgb(151, 137, 222) 20%, rgb(255, 255, 255) 50%, rgb(151, 137, 222) 80%, rgb(151, 137, 222) 100%);
             background-size: 200% auto;
           ">一键生成知识图谱</span>
         </h2>
-        <p class="text-sm text-white/45 leading-relaxed max-w-sm">
+        <p class="text-sm text-gray-500 dark:text-white/45 leading-relaxed max-w-sm transition-colors">
           专为中学生与大学生研发。上传凌乱试卷，AI 自动完成图片分割、OCR 纠错及 LaTeX 公式还原。
         </p>
 
         <!-- 特性列表 — 鼠标跟随染色图标 -->
         <ul class="mt-8 space-y-4">
-          <li v-for="(f, i) in FEATURES" :key="f.text" :ref="el => featureRefs[i] = el" class="flex items-center gap-3 text-sm text-white/60">
+          <li v-for="(f, i) in FEATURES" :key="f.text" :ref="el => featureRefs[i] = el" class="flex items-center gap-3 text-sm text-gray-600 dark:text-white/60 transition-colors">
             <!-- 图标容器: 双层结构 -->
             <div class="relative flex h-8 w-8 shrink-0 items-center justify-center rounded-xl p-px overflow-hidden">
               <!-- 默认边框 -->
-              <div class="absolute inset-0 bg-white/[0.08] rounded-xl"></div>
+              <div class="absolute inset-0 bg-gray-200 dark:bg-white/[0.08] rounded-xl transition-colors"></div>
               <!-- 鼠标跟随边框高光 -->
               <div class="pointer-events-none absolute inset-0"
                 style="background: radial-gradient(80px circle at var(--ix, -500px) var(--iy, -500px), rgba(151,137,222,0.7), transparent 50%);"></div>
               <!-- 图标内部 -->
-              <div class="relative h-full w-full bg-[#15151e] rounded-[11px] flex items-center justify-center">
+              <div class="relative h-full w-full bg-white dark:bg-[#15151e] rounded-[11px] flex items-center justify-center transition-colors">
                 <!-- 白色底层图标 -->
-                <i :class="`fas ${f.icon} text-xs text-white/50 absolute`"></i>
+                <i :class="`fas ${f.icon} text-xs text-gray-400 dark:text-white/50 absolute transition-colors`"></i>
                 <!-- 鼠标跟随染色图标 -->
                 <div class="absolute inset-0 flex items-center justify-center"
                   style="mask-image: radial-gradient(80px circle at var(--ix, -500px) var(--iy, -500px), black 0%, transparent 100%);
@@ -163,17 +167,17 @@ onMounted(() => {
       </div>
 
       <!-- 底部版权 -->
-      <div class="relative text-xs text-white/20">
+      <div class="relative text-xs text-gray-400 dark:text-white/20 transition-colors">
         © {{ new Date().getFullYear() }} 智卷错题本 · All rights reserved
       </div>
     </div>
 
     <!-- 右侧表单区 -->
-    <div class="flex-1 flex flex-col items-center justify-center px-4 py-12 lg:px-16 relative bg-[#0e0e16]">
+    <div class="flex-1 flex flex-col items-center justify-center px-4 py-12 lg:px-16 relative bg-white dark:bg-[#0e0e16] transition-colors duration-200">
 
       <!-- 返回主页 -->
       <div class="absolute top-6 right-6 z-10">
-        <BaseButton href="/" variant="secondary" size="sm" class="flex items-center gap-2 !px-4 !py-2 !h-auto text-white/50 hover:text-white/70 bg-white/[0.03] border-white/[0.06] hover:bg-white/[0.06] !rounded-lg">
+        <BaseButton href="/" variant="secondary" size="sm" class="flex items-center gap-2 !px-4 !py-2 !h-auto !rounded-lg">
           <i class="fas fa-arrow-left text-xs"></i>
           返回主页
         </BaseButton>
@@ -182,39 +186,39 @@ onMounted(() => {
       <!-- 移动端 Logo（小屏显示） -->
       <div class="lg:hidden text-center mb-8">
         <div class="relative inline-flex mb-4">
-          <div class="bg-white/[0.04] border border-white/[0.08] p-2.5 rounded-xl">
-            <img src="/logo.svg" class="w-7 h-7 brightness-0 invert opacity-70" alt="logo" />
+          <div class="bg-gray-50 dark:bg-white/[0.04] border border-gray-200 dark:border-white/[0.08] p-2.5 rounded-xl transition-colors">
+            <img src="/logo.svg" class="w-7 h-7 brightness-0 dark:invert opacity-70 transition-all" alt="logo" />
           </div>
         </div>
-        <h1 class="text-2xl font-semibold text-white tracking-wide">智卷错题本</h1>
+        <h1 class="text-2xl font-semibold text-gray-900 dark:text-white tracking-wide transition-colors">智卷错题本</h1>
       </div>
 
       <div class="w-full max-w-sm">
         <!-- 标题 -->
         <div class="mb-8">
-          <h3 class="text-2xl font-semibold text-white">
+          <h3 class="text-2xl font-semibold text-gray-900 dark:text-white transition-colors">
             {{ route.path === '/auth/login' ? '欢迎回来' : '创建账户' }}
           </h3>
-          <p class="text-sm text-white/35 mt-1">
+          <p class="text-sm text-gray-500 dark:text-white/35 mt-1 transition-colors">
             {{ route.path === '/auth/login' ? '登录以继续使用你的错题本' : '免费注册，开始智能错题整理' }}
           </p>
         </div>
 
         <!-- Tab 切换 -->
-        <div class="flex rounded-xl bg-white/[0.03] border border-white/[0.06] p-1 mb-6">
+        <div class="flex rounded-xl bg-gray-100 dark:bg-white/[0.03] border border-gray-200 dark:border-white/[0.06] p-1 mb-6 transition-colors">
           <RouterLink
             to="/auth/login"
             class="flex-1 py-2 text-sm font-medium rounded-lg text-center transition-all"
             :class="route.path === '/auth/login'
-              ? 'bg-white/[0.08] text-white'
-              : 'text-white/35 hover:text-white/60'"
+              ? 'bg-white text-gray-900 shadow-sm dark:bg-white/[0.08] dark:text-white'
+              : 'text-gray-500 hover:text-gray-700 dark:text-white/35 dark:hover:text-white/60'"
           >登录</RouterLink>
           <RouterLink
             to="/auth/register"
             class="flex-1 py-2 text-sm font-medium rounded-lg text-center transition-all"
             :class="route.path === '/auth/register'
-              ? 'bg-white/[0.08] text-white'
-              : 'text-white/35 hover:text-white/60'"
+              ? 'bg-white text-gray-900 shadow-sm dark:bg-white/[0.08] dark:text-white'
+              : 'text-gray-500 hover:text-gray-700 dark:text-white/35 dark:hover:text-white/60'"
           >注册</RouterLink>
         </div>
 
@@ -226,7 +230,7 @@ onMounted(() => {
         </RouterView>
 
         <!-- 底部版权（移动端） -->
-        <p class="lg:hidden text-center text-xs text-white/20 mt-8">
+        <p class="lg:hidden text-center text-xs text-gray-400 dark:text-white/20 mt-8 transition-colors">
           © {{ new Date().getFullYear() }} 智卷错题本
         </p>
       </div>

--- a/frontend/src/views/auth/AuthLayout.vue
+++ b/frontend/src/views/auth/AuthLayout.vue
@@ -245,6 +245,13 @@ input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus {
   transition: background-color 9999s ease;
+  -webkit-text-fill-color: #111827;
+  caret-color: #111827;
+}
+
+.dark input:-webkit-autofill,
+.dark input:-webkit-autofill:hover,
+.dark input:-webkit-autofill:focus {
   -webkit-text-fill-color: #e2e8f0;
   caret-color: #e2e8f0;
 }

--- a/frontend/src/views/auth/LoginView.vue
+++ b/frontend/src/views/auth/LoginView.vue
@@ -60,11 +60,11 @@ async function handleLogin() {
 
     <div class="flex justify-end">
       <button type="button" @click="fpOpen = true"
-        class="text-xs text-white/40 hover:text-indigo-400 transition-colors">
+        class="text-xs text-gray-500 dark:text-white/40 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
         忘记密码？
       </button>
     </div>
-    <p v-if="error" class="text-sm text-rose-400 flex items-center gap-2">
+    <p v-if="error" class="text-sm text-rose-500 dark:text-rose-400 flex items-center gap-2 transition-colors">
       <i class="fas fa-circle-exclamation text-xs"></i>{{ error }}
     </p>
 

--- a/frontend/src/views/auth/RegisterView.vue
+++ b/frontend/src/views/auth/RegisterView.vue
@@ -173,10 +173,10 @@ onBeforeUnmount(() => {
             type="button"
             @click="handleSendCode"
             :disabled="sendingCode || countdown > 0"
-            class="shrink-0 h-10 px-4 rounded-xl border text-xs font-medium text-white/70 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+            class="shrink-0 h-10 px-4 rounded-xl border text-xs font-medium text-gray-700 dark:text-white/70 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
             :class="countdown > 0
-              ? 'bg-white/[0.02] border-white/[0.05] text-white/30'
-              : 'bg-white/[0.03] border-white/[0.08] hover:bg-white/[0.06] hover:text-white/85'"
+              ? 'bg-gray-100 border-gray-200 text-gray-400 dark:bg-white/[0.02] dark:border-white/[0.05] dark:text-white/30'
+              : 'bg-white border-gray-200 hover:bg-gray-50 hover:text-gray-900 dark:bg-white/[0.03] dark:border-white/[0.08] dark:hover:bg-white/[0.06] dark:hover:text-white/85'"
           >
             <i v-if="sendingCode" class="fas fa-spinner fa-spin"></i>
             <template v-else-if="countdown > 0">{{ countdown }}s</template>
@@ -217,13 +217,13 @@ onBeforeUnmount(() => {
         placeholder="再次输入密码"
         :error="passwordMismatch()"
       />
-      <p v-if="passwordMismatch()" class="text-xs text-rose-400 mt-1">两次密码不一致</p>
+      <p v-if="passwordMismatch()" class="text-xs text-rose-500 dark:text-rose-400 mt-1 transition-colors">两次密码不一致</p>
     </div>
 
-    <p v-if="error" class="text-sm text-rose-400 flex items-center gap-2">
+    <p v-if="error" class="text-sm text-rose-500 dark:text-rose-400 flex items-center gap-2 transition-colors">
       <i class="fas fa-circle-exclamation text-xs"></i>{{ error }}
     </p>
-    <p v-if="success" class="text-sm text-emerald-400 flex items-center gap-2">
+    <p v-if="success" class="text-sm text-emerald-500 dark:text-emerald-400 flex items-center gap-2 transition-colors">
       <i class="fas fa-circle-check text-xs"></i>{{ success }}
     </p>
 


### PR DESCRIPTION
feat(theme): 全局支持 App 内深浅色模式切换

- 修复了 SidebarNav 和 WorkspaceView 的背景与边框，实现浅色模式下的浅灰白视觉
- 重构登录注册表单和全局 SearchInput，确保浅色模式下输入框无白字问题
- 将各页面卡片统一替换为 BaseCard，共享一致的浅色底色与悬浮阴影
- 修复 EmptyState 和 ErrorBank 左侧过滤按钮在浅色模式下过暗不可见的问题
- 优化 ChatPageView 的气泡及输入框，确保深浅色模式下背景色、文字色均准确映射