### PR TITLE
fix(settings): 修复 Provider 选中状态持久化和操作按钮显示问题

### DIFF
--- a/backend/db/crud/providers.py
+++ b/backend/db/crud/providers.py
@@ -172,6 +172,17 @@ def save_user_providers(db: Session, user_id: int, data: dict) -> None:
                 "use_chart_recognition": item.get("use_chart_recognition", False),
             })
 
+    valid_ids_by_category = {
+        category: {item["id"] for item in items_to_save if item["category"] == category}
+        for category in active_ids
+    }
+    for category, active_id in list(active_ids.items()):
+        if active_id not in valid_ids_by_category.get(category, set()):
+            active_ids[category] = None
+
+    for item in items_to_save:
+        item["is_active"] = item["id"] == active_ids.get(item["category"])
+
     # 删除已移除的 provider
     for pid in set(existing.keys()) - submitted_ids:
         db.delete(existing[pid])
@@ -231,6 +242,17 @@ def save_system_providers(db: Session, data: dict) -> None:
                 "use_doc_unwarping": item.get("use_doc_unwarping", False),
                 "use_chart_recognition": item.get("use_chart_recognition", False),
             })
+
+    valid_ids_by_category = {
+        category: {item["id"] for item in items_to_save if item["category"] == category}
+        for category in active_ids
+    }
+    for category, active_id in list(active_ids.items()):
+        if active_id not in valid_ids_by_category.get(category, set()):
+            active_ids[category] = None
+
+    for item in items_to_save:
+        item["is_active"] = item["id"] == active_ids.get(item["category"])
 
     for pid in set(existing.keys()) - submitted_ids:
         db.delete(existing[pid])

--- a/backend/tests/test_crud.py
+++ b/backend/tests/test_crud.py
@@ -21,7 +21,9 @@ import pytest
 from tests.conftest import make_question
 from db.crud import (
     compute_content_hash,
+    get_active_provider,
     save_questions_to_db,
+    save_user_providers,
     get_existing_subjects,
     get_existing_tag_names,
     get_or_create_tag,
@@ -38,6 +40,7 @@ from db.crud import (
     get_review_status_stats,
     get_daily_counts,
 )
+from db.models import ProviderConfig, User
 
 
 # ═══════════════════════════════════════════════════════════
@@ -607,3 +610,71 @@ class TestGetDailyCounts:
         # 今天应该有 1 条
         total = sum(d['count'] for d in result)
         assert total == 1
+
+
+class TestProviderSelection:
+    def test_save_user_providers_allows_clearing_active_provider(self, db):
+        user = User(id=1, username="test", email="test@example.com", password_hash="x")
+        db.add(user)
+        db.add(ProviderConfig(
+            id="openai-1",
+            user_id=user.id,
+            category="openai",
+            name="OpenAI",
+            is_active=True,
+            api_key="sk-test",
+            base_url="https://example.com",
+            model_name="gpt-5.4",
+        ))
+        db.commit()
+
+        save_user_providers(db, user.id, {
+            "openai_providers": [{
+                "id": "openai-1",
+                "name": "OpenAI",
+                "base_url": "https://example.com",
+                "model_name": "gpt-5.4",
+            }],
+            "anthropic_providers": [],
+            "paddleocr_providers": [],
+            "active_openai_id": None,
+            "active_anthropic_id": None,
+            "active_paddleocr_id": None,
+        })
+
+        provider = db.query(ProviderConfig).filter(ProviderConfig.id == "openai-1").one()
+        assert provider.is_active is False
+        assert get_active_provider(db, user.id, "openai") is None
+
+    def test_save_user_providers_ignores_invalid_active_provider_id(self, db):
+        user = User(id=1, username="test", email="test@example.com", password_hash="x")
+        db.add(user)
+        db.add(ProviderConfig(
+            id="openai-1",
+            user_id=user.id,
+            category="openai",
+            name="OpenAI",
+            is_active=True,
+            api_key="sk-test",
+            base_url="https://example.com",
+            model_name="gpt-5.4",
+        ))
+        db.commit()
+
+        save_user_providers(db, user.id, {
+            "openai_providers": [{
+                "id": "openai-1",
+                "name": "OpenAI",
+                "base_url": "https://example.com",
+                "model_name": "gpt-5.4",
+            }],
+            "anthropic_providers": [],
+            "paddleocr_providers": [],
+            "active_openai_id": "missing-id",
+            "active_anthropic_id": None,
+            "active_paddleocr_id": None,
+        })
+
+        provider = db.query(ProviderConfig).filter(ProviderConfig.id == "openai-1").one()
+        assert provider.is_active is False
+        assert get_active_provider(db, user.id, "openai") is None

--- a/frontend/src/components/base/BaseListItem.vue
+++ b/frontend/src/components/base/BaseListItem.vue
@@ -62,8 +62,10 @@ defineProps({
         </span>
         
         <!-- 当存在默认插槽（如 input）时，让其占据合理的宽度并靠右对齐 -->
-        <div v-if="$slots.default" class="w-44 max-w-full">
-          <slot />
+        <div v-if="$slots.right || $slots.default" class="w-44 max-w-full">
+          <slot name="right">
+            <slot />
+          </slot>
         </div>
 
         <i v-if="showArrow" class="fa-solid fa-chevron-right text-[10px] text-gray-400 dark:text-[#62666d] ml-1 shrink-0"></i>

--- a/frontend/src/components/settings/ProviderSection.vue
+++ b/frontend/src/components/settings/ProviderSection.vue
@@ -70,7 +70,7 @@ const emit = defineEmits(['add', 'toggle-active', 'edit', 'remove'])
         </template>
 
         <template #right>
-          <div class="flex items-center gap-4 px-3 py-1.5">
+          <div class="ml-auto flex items-center justify-end gap-4 px-3 py-1.5">
             <!-- 状态标签 -->
             <div class="flex items-center gap-2">
               <span v-if="activeId === provider.id" class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-bold text-gray-700 ring-1 ring-inset ring-gray-500/10 dark:bg-white/10 dark:text-[#f7f8f8] dark:ring-white/20">

--- a/frontend/src/views/app/SettingsView.vue
+++ b/frontend/src/views/app/SettingsView.vue
@@ -400,7 +400,7 @@ const loadConfig = async () => {
     } else {
       openaiProviders.value = []
     }
-    activeOpenaiId.value = cfg.active_openai_id || openaiProviders.value[0]?.id || null
+    activeOpenaiId.value = cfg.active_openai_id ?? null
 
     if (cfg.anthropic_providers && cfg.anthropic_providers.length > 0) {
       anthropicProviders.value = cfg.anthropic_providers.map(p => makeAnthropicProvider(p))
@@ -409,7 +409,7 @@ const loadConfig = async () => {
     } else {
       anthropicProviders.value = []
     }
-    activeAnthropicId.value = cfg.active_anthropic_id || anthropicProviders.value[0]?.id || null
+    activeAnthropicId.value = cfg.active_anthropic_id ?? null
 
     if (cfg.paddleocr_providers && cfg.paddleocr_providers.length > 0) {
       paddleocrProviders.value = cfg.paddleocr_providers.map(p => makePaddleOCRProvider(p))
@@ -418,7 +418,7 @@ const loadConfig = async () => {
     } else {
       paddleocrProviders.value = []
     }
-    activePaddleocrId.value = cfg.active_paddleocr_id || paddleocrProviders.value[0]?.id || null
+    activePaddleocrId.value = cfg.active_paddleocr_id ?? null
   } catch (e) {
     pushToast('error', '加载配置失败: ' + (e instanceof Error ? e.message : String(e)))
   } finally {
@@ -472,9 +472,9 @@ const loadSystemConfig = async () => {
     systemOpenaiProviders.value = (cfg.openai_providers || []).map(p => makeOpenAIProvider(p))
     systemAnthropicProviders.value = (cfg.anthropic_providers || []).map(p => makeAnthropicProvider(p))
     systemPaddleocrProviders.value = (cfg.paddleocr_providers || []).map(p => makePaddleOCRProvider(p))
-    systemActiveOpenaiId.value = cfg.active_openai_id || systemOpenaiProviders.value[0]?.id || null
-    systemActiveAnthropicId.value = cfg.active_anthropic_id || systemAnthropicProviders.value[0]?.id || null
-    systemActivePaddleocrId.value = cfg.active_paddleocr_id || systemPaddleocrProviders.value[0]?.id || null
+    systemActiveOpenaiId.value = cfg.active_openai_id ?? null
+    systemActiveAnthropicId.value = cfg.active_anthropic_id ?? null
+    systemActivePaddleocrId.value = cfg.active_paddleocr_id ?? null
     systemConfigLoaded.value = true
   } catch (e) {
     pushToast('error', '加载系统托管配置失败: ' + (e instanceof Error ? e.message : String(e)))


### PR DESCRIPTION
## Summary

- 修复 API 设置页在 active provider 为空时被前端自动回填第一项的问题
- 支持用户取消某个 provider 的选中状态，并在刷新后保持未选中
- 为用户配置和系统配置补充后端兜底，非法或缺失的 active id 会被清空
- 修复 Provider 编辑和删除按钮未显示的问题
- 调整 Provider 操作区布局，使状态标签和操作按钮靠右对齐
- 补充 CRUD 测试，覆盖清空 active provider 和非法 active id 场景

## Test plan

- 在 API 设置页选中某个 provider 后再次点击，取消选中并刷新页面，确认仍保持未选中
- 分别验证 OpenAI / Anthropic / PaddleOCR 的取消选中行为
- 验证系统配置页的 provider 取消选中后刷新仍保持未选中
- 构造非法 active provider id，确认不会保留旧的 active 状态
- 打开 API 设置页，确认每个 provider 项右侧正常显示编辑和删除按钮
- 验证 Provider 状态标签与操作按钮整体靠右对齐
- 点击编辑按钮，确认可正常打开编辑弹窗
- 点击删除按钮，确认可正常触发删除逻辑
