### PR TITLE
feat(theme): 实现主题颜色变量与显式外观配置支持

### DIFF
--- a/frontend/src/components/base/BaseButton.vue
+++ b/frontend/src/components/base/BaseButton.vue
@@ -51,16 +51,16 @@ const bindProps = computed(() => {
 <style scoped>
 /* ── Primary: 品牌色渐变，微光 hover ── */
 .home-btn--primary {
-  background: linear-gradient(to bottom, rgba(129, 115, 223, 0.9), rgba(99, 87, 199, 0.9));
+  background: linear-gradient(to bottom, rgb(var(--accent-rgb) / 0.9), rgb(var(--accent-strong-rgb) / 0.9));
   color: #fff;
   border: none;
   box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.12);
 }
 .home-btn--primary:hover {
-  background: linear-gradient(to bottom, rgba(145, 132, 235, 0.95), rgba(113, 100, 212, 0.95));
+  background: linear-gradient(to bottom, rgb(var(--accent-hover-rgb) / 0.95), rgb(var(--accent-rgb) / 0.95));
   box-shadow:
     inset 0 1px 0 0 rgba(255, 255, 255, 0.15),
-    0 0 20px 0 rgba(129, 115, 223, 0.25);
+    0 0 20px 0 rgb(var(--accent-rgb) / 0.25);
 }
 
 /* ── Secondary: 白玻璃按钮（与 brand-btn 一致） ── */
@@ -101,16 +101,16 @@ const bindProps = computed(() => {
 
 /* ── CTA: 更强的品牌色，用于转化区 ── */
 .home-btn--cta {
-  background: linear-gradient(to bottom, rgba(109, 92, 214, 1), rgba(88, 72, 194, 1));
+  background: linear-gradient(to bottom, rgb(var(--accent-rgb)), rgb(var(--accent-strong-rgb)));
   color: #fff;
   border: none;
   box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.12);
 }
 .home-btn--cta:hover {
-  background: linear-gradient(to bottom, rgba(125, 108, 228, 1), rgba(102, 86, 208, 1));
+  background: linear-gradient(to bottom, rgb(var(--accent-hover-rgb)), rgb(var(--accent-rgb)));
   box-shadow:
     inset 0 1px 0 0 rgba(255, 255, 255, 0.15),
-    0 0 24px 0 rgba(109, 92, 214, 0.3);
+    0 0 24px 0 rgb(var(--accent-rgb) / 0.3);
 }
 
 /* ── Ghost: 幽灵按钮，用于无背景仅边框/字体的操作 ── */

--- a/frontend/src/components/base/BaseInput.vue
+++ b/frontend/src/components/base/BaseInput.vue
@@ -78,7 +78,7 @@ const inputType = computed(() => {
           data-gramm="false"
           :class="[
             'w-full h-10 px-4 rounded-xl border bg-white dark:bg-white/[0.03] text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-white/25 focus:outline-none focus:ring-0 focus:ring-offset-0 transition-all text-sm outline-none [&::-ms-reveal]:hidden [&::-ms-clear]:hidden',
-            error ? 'border-rose-500/50 focus:border-rose-500/50' : 'border-gray-200 dark:border-white/[0.08] focus:border-indigo-500/50 dark:focus:border-indigo-500/50',
+            error ? 'border-rose-500/50 focus:border-rose-500/50' : 'border-gray-200 dark:border-white/[0.08] focus:border-[rgb(var(--accent-rgb)/0.4)] dark:focus:border-[rgb(var(--accent-rgb)/0.4)]',
             type === 'password' ? 'pr-11' : '',
             inputClass
           ]"

--- a/frontend/src/components/base/BaseLoading.vue
+++ b/frontend/src/components/base/BaseLoading.vue
@@ -17,7 +17,7 @@ const emit = defineEmits(['after-enter'])
       <BaseLogo size="lg" breathe />
       <div class="w-48">
         <div class="h-0.5 w-full rounded-full bg-gray-200 dark:bg-white/10 overflow-hidden transition-colors">
-          <div class="h-full rounded-full bg-gradient-to-r from-[rgba(129,115,223,0.8)] to-[rgba(99,87,199,0.8)] loading-bar"></div>
+          <div class="h-full rounded-full accent-gradient-bg loading-bar"></div>
         </div>
       </div>
     </div>

--- a/frontend/src/components/base/BaseLogo.vue
+++ b/frontend/src/components/base/BaseLogo.vue
@@ -37,7 +37,7 @@ defineProps({
 
 <style scoped>
 .brand-logo {
-  background: linear-gradient(to bottom, rgba(129, 115, 223, 0.9), rgba(99, 87, 199, 0.9));
+  background: linear-gradient(to bottom, rgb(var(--accent-rgb) / 0.9), rgb(var(--accent-strong-rgb) / 0.9));
   box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.12);
 }
 
@@ -55,14 +55,14 @@ defineProps({
   0%, 100% {
     box-shadow:
       inset 0 1px 0 0 rgba(255, 255, 255, 0.12),
-      0 0 12px rgba(129, 115, 223, 0.3),
-      0 0 24px rgba(129, 115, 223, 0.15);
+      0 0 12px rgb(var(--accent-rgb) / 0.3),
+      0 0 24px rgb(var(--accent-rgb) / 0.15);
   }
   50% {
     box-shadow:
       inset 0 1px 0 0 rgba(255, 255, 255, 0.15),
-      0 0 24px rgba(129, 115, 223, 0.5),
-      0 0 48px rgba(129, 115, 223, 0.25);
+      0 0 24px rgb(var(--accent-rgb) / 0.5),
+      0 0 48px rgb(var(--accent-rgb) / 0.25);
   }
 }
 

--- a/frontend/src/components/base/BaseSelect.vue
+++ b/frontend/src/components/base/BaseSelect.vue
@@ -49,7 +49,7 @@ const select = (val) => { emit('update:modelValue', val); open.value = false }
             :class="modelValue === '' ? 'text-slate-900 dark:text-[#f7f8f8] bg-slate-50 dark:bg-white/[0.02]' : 'text-slate-600 dark:text-[#8a8f98]'"
           >
             <span class="min-w-0 flex-1 truncate">{{ placeholder }}</span>
-            <i v-if="modelValue === ''" class="fa-solid fa-check shrink-0 text-[10px] text-[rgb(129,115,223)]"></i>
+            <i v-if="modelValue === ''" class="fa-solid fa-check shrink-0 text-[10px] accent-text"></i>
           </button>
           <button
             v-for="opt in options" :key="opt"
@@ -59,7 +59,7 @@ const select = (val) => { emit('update:modelValue', val); open.value = false }
             :class="modelValue === opt ? 'text-slate-900 dark:text-[#f7f8f8] bg-slate-50 dark:bg-white/[0.02]' : 'text-slate-600 dark:text-[#8a8f98]'"
           >
             <span class="min-w-0 flex-1 truncate">{{ opt }}</span>
-            <i v-if="modelValue === opt" class="fa-solid fa-check shrink-0 text-[10px] text-[rgb(129,115,223)]"></i>
+            <i v-if="modelValue === opt" class="fa-solid fa-check shrink-0 text-[10px] accent-text"></i>
           </button>
         </div>
       </div>

--- a/frontend/src/components/base/BaseViewSettingsPopover.vue
+++ b/frontend/src/components/base/BaseViewSettingsPopover.vue
@@ -75,7 +75,7 @@ const labelClass = "font-medium text-gray-500 dark:text-[#8a8f98] shrink-0 w-16"
                         @click="filters.review_status = status.v"
                         class="flex-1 flex items-center justify-center py-1 rounded-[6px] text-[12px] font-medium transition-all duration-200"
                         :class="filters.review_status === status.v
-                            ? 'bg-white dark:bg-white/[0.08] text-indigo-600 dark:text-[#f7f8f8] shadow-[0_1px_3px_rgba(0,0,0,0.1)] dark:shadow-none border border-gray-200/50 dark:border-white/[0.1]'
+                            ? 'bg-white dark:bg-white/[0.08] accent-text dark:text-[#f7f8f8] shadow-[0_1px_3px_rgba(0,0,0,0.1)] dark:shadow-none border border-gray-200/50 dark:border-white/[0.1]'
                             : 'text-gray-500 dark:text-[#8a8f98] hover:text-gray-700 dark:hover:text-[#d0d6e0] border border-transparent'">
                         {{ status.l }}
                     </button>
@@ -113,7 +113,7 @@ const labelClass = "font-medium text-gray-500 dark:text-[#8a8f98] shrink-0 w-16"
                     <button v-for="tag in tagNames" :key="tag" @click="emit('toggle-tag', tag)"
                         class="rounded-[5px] px-2 py-0.5 text-[12px] font-medium transition-all active:scale-95 flex items-center gap-1 cursor-pointer"
                         :class="selectedTags?.has(tag)
-                            ? 'bg-[rgba(129,115,223,0.15)] text-[rgb(129,115,223)] border border-[rgba(129,115,223,0.3)] dark:bg-[rgba(129,115,223,0.2)] dark:text-[rgb(165,155,245)]'
+                            ? 'accent-bg-soft accent-text border accent-border'
                             : 'bg-white border border-gray-200 text-gray-600 hover:border-gray-300 hover:bg-gray-50 active:bg-gray-100 dark:bg-white/[0.02] dark:border-white/[0.06] dark:text-[#8a8f98] dark:hover:border-white/[0.12] dark:hover:bg-white/[0.04] dark:active:bg-white/[0.06]'">
                         {{ tag }}
                     </button>

--- a/frontend/src/components/base/SearchInput.vue
+++ b/frontend/src/components/base/SearchInput.vue
@@ -23,7 +23,7 @@ const emit = defineEmits(['update:modelValue'])
         @input="emit('update:modelValue', $event.target.value)"
         type="text"
         :placeholder="placeholder"
-        class="h-9 w-full rounded-md border border-gray-200 bg-white pl-9 pr-3 text-sm font-medium text-gray-900 placeholder-gray-400 outline-none transition-colors hover:border-gray-300 focus:border-indigo-500 dark:border-white/[0.08] dark:bg-white/[0.02] dark:text-[#f7f8f8] dark:placeholder-[#62666d] dark:hover:border-white/[0.12] dark:focus:border-white/[0.15] dark:border-t-white/[0.12]"
+        class="h-9 w-full rounded-md border border-gray-200 bg-white pl-9 pr-3 text-sm font-medium text-gray-900 placeholder-gray-400 outline-none transition-colors hover:border-gray-300 focus:border-[rgb(var(--accent-rgb)/0.4)] dark:border-white/[0.08] dark:bg-white/[0.02] dark:text-[#f7f8f8] dark:placeholder-[#62666d] dark:hover:border-white/[0.12] dark:focus:border-[rgb(var(--accent-rgb)/0.4)] dark:border-t-white/[0.12]"
       />
     </div>
   </div>

--- a/frontend/src/components/base/ToastContainer.vue
+++ b/frontend/src/components/base/ToastContainer.vue
@@ -39,7 +39,7 @@ const onLeave = (el) => {
               ? 'border-rose-500/20 bg-rose-50/90 text-rose-900 dark:border-rose-500/20 dark:bg-rose-500/10 dark:text-rose-300'
               : t.type === 'warning'
                 ? 'border-amber-500/20 bg-amber-50/90 text-amber-900 dark:border-amber-500/20 dark:bg-amber-500/10 dark:text-amber-300'
-                : 'border-blue-500/20 bg-blue-50/90 text-blue-900 dark:border-indigo-500/20 dark:bg-indigo-500/10 dark:text-indigo-300'
+                : 'border-[rgb(var(--accent-rgb)/0.2)] bg-[rgb(var(--accent-rgb)/0.1)] text-[rgb(var(--accent-strong-rgb))] dark:border-[rgb(var(--accent-rgb)/0.2)] dark:bg-[rgb(var(--accent-rgb)/0.1)] dark:text-[rgb(var(--accent-hover-rgb))]'
         "
       >
         <!-- 背景流体装饰 -->
@@ -48,7 +48,7 @@ const onLeave = (el) => {
           :class="
             t.type === 'success' ? 'bg-emerald-500' : 
             t.type === 'error' ? 'bg-rose-500' : 
-            t.type === 'warning' ? 'bg-amber-500' : 'bg-blue-500'
+            t.type === 'warning' ? 'bg-amber-500' : 'accent-bg'
           "
         ></div>
 
@@ -59,7 +59,7 @@ const onLeave = (el) => {
             t.type === 'success' ? 'bg-emerald-500/10 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-400' : 
             t.type === 'error' ? 'bg-rose-500/10 text-rose-600 dark:bg-rose-500/20 dark:text-rose-400' : 
             t.type === 'warning' ? 'bg-amber-500/10 text-amber-600 dark:bg-amber-500/20 dark:text-amber-400' : 
-            'bg-blue-500/10 text-blue-600 dark:bg-indigo-500/20 dark:text-indigo-400'
+            'accent-bg-soft accent-text'
           "
         >
           <i 

--- a/frontend/src/components/dashboard/StatCard.vue
+++ b/frontend/src/components/dashboard/StatCard.vue
@@ -11,11 +11,11 @@ const props = defineProps({
   icon: { type: String, required: true },
   value: { type: [Number, String], default: 0 },
   unit: { type: String, default: '' },
-  color: { type: String, default: 'indigo' },
+  color: { type: String, default: 'accent' },
 })
 
 const colorMap = {
-  indigo: 'text-indigo-600 bg-indigo-100 dark:text-indigo-400 dark:bg-indigo-500/10',
+  accent: 'accent-text accent-bg-soft',
   blue: 'text-blue-600 bg-blue-100 dark:text-blue-400 dark:bg-blue-500/10',
   emerald: 'text-emerald-600 bg-emerald-100 dark:text-emerald-400 dark:bg-emerald-500/10',
   slate: 'text-slate-600 bg-slate-100 dark:text-slate-400 dark:bg-slate-500/10',
@@ -59,7 +59,7 @@ watch(() => props.value, (v) => { animateTo(v) })
     <div class="flex items-center gap-4">
       <div
         class="flex size-12 shrink-0 items-center justify-center rounded-lg transition-transform duration-500 group-hover:scale-110"
-        :class="colorMap[color] || colorMap.indigo"
+        :class="colorMap[color] || colorMap.accent"
       >
         <i :class="[icon, 'text-xl']"></i>
       </div>

--- a/frontend/src/components/home/FeatureCard.vue
+++ b/frontend/src/components/home/FeatureCard.vue
@@ -35,7 +35,7 @@ const props = defineProps({
     <div class="absolute inset-0 bg-transparent dark:bg-gradient-to-br dark:from-white/[0.12] dark:via-white/[0.04] dark:to-transparent transition-colors duration-300"></div>
 
     <!-- Hover 状态下的发光背景层 (浅色模式下增加主题色微光) -->
-    <div class="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 bg-gradient-to-br from-indigo-500/15 via-violet-500/5 to-transparent dark:from-indigo-500/10 dark:via-violet-500/5 dark:to-transparent z-0"></div>
+    <div class="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 bg-gradient-to-br from-[rgb(var(--accent-rgb)/0.15)] via-[rgb(var(--accent-hover-rgb)/0.05)] to-transparent dark:from-[rgb(var(--accent-rgb)/0.1)] dark:via-[rgb(var(--accent-hover-rgb)/0.05)] dark:to-transparent z-0"></div>
 
     <!-- 卡片主体背景层 — brand-btn 风格白玻璃 -->
     <div class="feature-card-inner relative h-full w-full rounded-[19px] p-6 flex flex-col items-start text-left transition-all duration-500 overflow-hidden">
@@ -77,8 +77,8 @@ const props = defineProps({
 
 .feature-card:hover .feature-card-inner {
   background: rgba(255,255,255,0.9);
-  border-color: rgba(129, 115, 223, 0.4);
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.05), 0 8px 10px -6px rgba(0, 0, 0, 0.01), 0 0 0 1px rgba(129, 115, 223, 0.2);
+  border-color: rgb(var(--accent-rgb) / 0.4);
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.05), 0 8px 10px -6px rgba(0, 0, 0, 0.01), 0 0 0 1px rgb(var(--accent-rgb) / 0.2);
 }
 :root.dark .feature-card:hover .feature-card-inner {
   background: rgba(255,255,255,0.08);
@@ -89,7 +89,7 @@ const props = defineProps({
 }
 
 .feature-icon {
-  background: linear-gradient(to bottom, rgba(129, 115, 223, 0.9), rgba(99, 87, 199, 0.9));
+  background: linear-gradient(to bottom, rgb(var(--accent-rgb) / 0.9), rgb(var(--accent-strong-rgb) / 0.9));
   box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.12);
 }
 

--- a/frontend/src/components/home/HomeFooter.vue
+++ b/frontend/src/components/home/HomeFooter.vue
@@ -10,25 +10,23 @@ import BaseButton from '@/components/base/BaseButton.vue'
   <section id="cta" class="relative z-10 flex flex-col items-center justify-center py-32 px-6 overflow-hidden min-h-[70vh] bg-slate-50 dark:bg-transparent transition-colors duration-200">
     <!-- 底部中心光晕 -->
     <div class="absolute bottom-0 left-1/2 -translate-x-1/2 w-[80vw] h-[50vh] pointer-events-none z-0">
-      <div class="absolute inset-0 bg-indigo-500/20 dark:bg-indigo-500/10 blur-[120px] rounded-[100%] transform translate-y-1/2 transition-colors duration-200"></div>
-      <div class="absolute inset-0 bg-violet-500/10 dark:bg-violet-500/5 blur-[150px] rounded-[100%] transform translate-y-1/2 scale-150 transition-colors duration-200"></div>
+      <div class="absolute inset-0 bg-[rgb(var(--accent-rgb)/0.2)] dark:bg-[rgb(var(--accent-rgb)/0.1)] blur-[120px] rounded-[100%] transform translate-y-1/2 transition-colors duration-200"></div>
+      <div class="absolute inset-0 bg-[rgb(var(--accent-hover-rgb)/0.1)] dark:bg-[rgb(var(--accent-hover-rgb)/0.05)] blur-[150px] rounded-[100%] transform translate-y-1/2 scale-150 transition-colors duration-200"></div>
     </div>
 
     <!-- CTA -->
     <div class="flex-1 flex flex-col items-center justify-center text-center relative z-10 w-full">
       <h2 class="reveal text-4xl sm:text-5xl font-semibold tracking-tight mb-6">
-        <span class="text-transparent bg-clip-text animate-gradient-sweep dark:hidden" style="
-          background-image: linear-gradient(to right, rgb(151, 137, 222) 0%, rgb(151, 137, 222) 20%, rgb(79, 70, 229) 50%, rgb(151, 137, 222) 80%, rgb(151, 137, 222) 100%);
+        <span class="text-transparent bg-clip-text animate-gradient-sweep home-title-accent" style="
           background-size: 200% auto;
         ">即刻开启高效学习模式</span>
-        <span class="text-transparent bg-clip-text animate-gradient-sweep hidden dark:inline" style="
-          background-image: linear-gradient(to right, rgb(151, 137, 222) 0%, rgb(151, 137, 222) 20%, rgb(255, 255, 255) 50%, rgb(151, 137, 222) 80%, rgb(151, 137, 222) 100%);
+        <span class="hidden" style="
           background-size: 200% auto;
         ">即刻开启高效学习模式</span>
       </h2>
       <p class="reveal text-gray-600 dark:text-white/40 text-base mb-10 max-w-md mx-auto leading-relaxed transition-colors duration-200">告别低效抄录，让 AI 成为你的超级助教。注册即享完整试卷解析体验。</p>
       <div class="reveal">
-        <BaseButton variant="cta" to="/auth" class="shadow-[0_0_30px_rgba(129,115,223,0.3)] hover:shadow-[0_0_50px_rgba(129,115,223,0.5)] transform hover:-translate-y-1 transition-all duration-300">
+        <BaseButton variant="cta" to="/auth" class="shadow-[0_0_30px_rgb(var(--accent-rgb)/0.3)] hover:shadow-[0_0_50px_rgb(var(--accent-rgb)/0.5)] transform hover:-translate-y-1 transition-all duration-300">
           免费创建错题库
         </BaseButton>
       </div>

--- a/frontend/src/components/home/HomeHeader.vue
+++ b/frontend/src/components/home/HomeHeader.vue
@@ -34,7 +34,7 @@ const emit = defineEmits(['scrollToSection'])
         <div class="hidden md:flex items-center gap-1">
           <button v-for="s in sections" :key="s.id" @click="emit('scrollToSection', s.id)"
             class="px-3 py-1.5 text-[13px] font-medium rounded-md transition-colors"
-            :class="activeSection === s.id ? 'text-gray-900 bg-gray-200 dark:text-white dark:bg-white/[0.06]' : 'text-gray-800 hover:text-black hover:bg-transparent dark:text-white/40 dark:hover:text-white/70 dark:hover:bg-transparent'">{{
+            :class="activeSection === s.id ? 'text-white accent-bg shadow-sm' : 'text-gray-800 hover:text-black hover:bg-transparent dark:text-white/40 dark:hover:text-white/70 dark:hover:bg-transparent'">{{
               s.label }}</button>
         </div>
 

--- a/frontend/src/components/home/HomePill.vue
+++ b/frontend/src/components/home/HomePill.vue
@@ -14,7 +14,7 @@
 
 <style scoped>
 .pill-fill {
-  background: linear-gradient(to bottom, rgba(129, 115, 223, 0.9), rgba(99, 87, 199, 0.9));
+  background: linear-gradient(to bottom, rgb(var(--accent-rgb) / 0.9), rgb(var(--accent-strong-rgb) / 0.9));
   box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.12);
 }
 

--- a/frontend/src/components/home/HomeSideNav.vue
+++ b/frontend/src/components/home/HomeSideNav.vue
@@ -22,8 +22,8 @@ const emit = defineEmits(['scrollToSection', 'back-to-top'])
       class="relative flex items-center justify-center w-6 h-6 focus:outline-none group" :title="s.label"
       @click="emit('scrollToSection', s.id)">
       <div class="w-1 h-1 rounded-full transition-all duration-200" :class="activeSection === s.id
-        ? 'bg-indigo-600 dark:bg-white scale-150'
-        : 'bg-gray-300 dark:bg-white/20 group-hover:bg-indigo-400 dark:group-hover:bg-white/50'"></div>
+        ? 'accent-bg dark:bg-white scale-150'
+        : 'bg-gray-300 dark:bg-white/20 group-hover:bg-[rgb(var(--accent-hover-rgb))] dark:group-hover:bg-white/50'"></div>
       <span
         class="absolute right-10 px-2 py-1 rounded-md bg-white dark:bg-[#111118] border border-gray-200 dark:border-white/[0.06] text-[11px] font-medium text-gray-700 dark:text-white/70 whitespace-nowrap pointer-events-none opacity-0 translate-x-1 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-200 shadow-sm dark:shadow-none">
         {{ s.label }}
@@ -33,7 +33,7 @@ const emit = defineEmits(['scrollToSection', 'back-to-top'])
 
   <!-- 回到顶部按钮 -->
   <button id="back-to-top"
-    class="fixed bottom-8 right-8 z-50 flex h-10 w-10 items-center justify-center rounded-full brand-btn text-gray-400 dark:text-[#8a8f98] transition-[opacity,transform,color] duration-300 hover:text-indigo-600 dark:hover:text-[#f7f8f8]"
+    class="fixed bottom-8 right-8 z-50 flex h-10 w-10 items-center justify-center rounded-full brand-btn text-gray-400 dark:text-[#8a8f98] transition-[opacity,transform,color] duration-300 hover:accent-text dark:hover:text-[#f7f8f8]"
     :style="{ opacity: showBackToTop ? '1' : '0', transform: showBackToTop ? 'translateY(0)' : 'translateY(12px)', pointerEvents: showBackToTop ? 'auto' : 'none' }"
     aria-label="回到顶部" @click="emit('back-to-top')">
     <ArrowUp class="h-4 w-4" />

--- a/frontend/src/components/home/WorkflowStep.vue
+++ b/frontend/src/components/home/WorkflowStep.vue
@@ -54,7 +54,7 @@ const props = defineProps({
 
 <style scoped>
 .wf-icon--active {
-  background: linear-gradient(to bottom, rgba(129, 115, 223, 0.9), rgba(99, 87, 199, 0.9));
+  background: linear-gradient(to bottom, rgb(var(--accent-rgb) / 0.9), rgb(var(--accent-strong-rgb) / 0.9));
   box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.12);
 }
 

--- a/frontend/src/components/question/EditNoteDialog.vue
+++ b/frontend/src/components/question/EditNoteDialog.vue
@@ -96,9 +96,9 @@ const config = () => {
     return {
       title: '编辑题目',
       icon: 'fa-pen-to-square',
-      iconBg: 'bg-indigo-50 dark:bg-indigo-500/10',
-      iconCls: 'text-indigo-600 dark:text-indigo-400',
-      btnCls: 'bg-indigo-600 hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600',
+      iconBg: 'accent-bg-soft',
+      iconCls: 'accent-text',
+      btnCls: 'accent-bg hover:bg-[rgb(var(--accent-hover-rgb))]',
     }
   }
   return {
@@ -122,10 +122,10 @@ const config = () => {
           <p class="text-xs font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500">题目内容</p>
           <div class="flex items-center gap-1 rounded-lg bg-slate-100 p-1 dark:bg-white/5">
             <button @click="previewMode = false"
-              :class="!previewMode ? 'bg-white text-indigo-600 shadow-sm dark:bg-indigo-500/20 dark:text-indigo-300' : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-300'"
+              :class="!previewMode ? 'bg-white accent-text shadow-sm dark:bg-white/[0.08]' : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-300'"
               class="rounded-md px-3 py-1 text-[10px] font-black uppercase tracking-wider transition-all">编辑</button>
             <button @click="previewMode = true; onDraftChange()"
-              :class="previewMode ? 'bg-white text-indigo-600 shadow-sm dark:bg-indigo-500/20 dark:text-indigo-300' : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-300'"
+              :class="previewMode ? 'bg-white accent-text shadow-sm dark:bg-white/[0.08]' : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-300'"
               class="rounded-md px-3 py-1 text-[10px] font-black uppercase tracking-wider transition-all">预览</button>
           </div>
         </div>
@@ -133,7 +133,7 @@ const config = () => {
         <!-- 编辑区 -->
         <div v-show="!previewMode">
           <textarea v-model="draft" @input="onDraftChange" rows="6"
-            class="w-full resize-none rounded-xl border border-slate-200/60 bg-slate-50/60 px-4 py-3 text-sm font-mono leading-relaxed text-slate-700 outline-none transition-all focus:border-indigo-300 focus:ring-2 focus:ring-indigo-200/60 dark:border-white/10 dark:bg-white/[0.03] dark:text-slate-200 dark:focus:border-white/20 dark:focus:ring-white/5"
+            class="w-full resize-none rounded-xl border border-slate-200/60 bg-slate-50/60 px-4 py-3 text-sm font-mono leading-relaxed text-slate-700 outline-none transition-all focus:border-[rgb(var(--accent-rgb)/0.4)] focus:ring-2 focus:ring-[rgb(var(--accent-rgb)/0.18)] dark:border-white/10 dark:bg-white/[0.03] dark:text-slate-200 dark:focus:border-[rgb(var(--accent-rgb)/0.4)] dark:focus:ring-[rgb(var(--accent-rgb)/0.18)]"
             placeholder="输入题目内容，支持富文本 HTML 标签..."></textarea>
           <p v-if="htmlError" class="mt-2 text-xs font-medium text-rose-500 flex items-center gap-1"><i
               class="fa-solid fa-triangle-exclamation"></i> {{ htmlError }}</p>

--- a/frontend/src/components/question/QuestionCard.vue
+++ b/frontend/src/components/question/QuestionCard.vue
@@ -76,18 +76,18 @@ const cancelUserAnswer = () => { editingUserAnswer.value = false }
 <template>
   <BaseCard class="question-card group relative overflow-hidden transition-shadow hover:shadow-md cursor-pointer"
     padding="p-6" rounded="rounded-2xl" :class="selected
-      ? '!border-[rgb(129,115,223)]/50 !shadow-[rgb(129,115,223)]/10 dark:!border-[rgb(129,115,223)]/50 dark:!shadow-[rgb(129,115,223)]/20'
-      : 'hover:!border-[rgb(129,115,223)]/30 dark:hover:!border-white/15'
+      ? 'accent-border shadow-[rgb(var(--accent-rgb)/0.1)] dark:shadow-[rgb(var(--accent-rgb)/0.2)]'
+      : 'hover:border-[rgb(var(--accent-rgb)/0.4)] dark:hover:!border-white/15'
       " @click="emit('toggle', question.uid)">
     <!-- 选中态背景 -->
     <div v-if="selected"
-      class="absolute inset-0 -z-10 bg-gradient-to-br from-[rgb(129,115,223)]/[0.03] to-[rgb(99,87,199)]/[0.03] dark:from-[rgb(129,115,223)]/[0.05] dark:to-[rgb(99,87,199)]/[0.05]">
+      class="absolute inset-0 -z-10 bg-gradient-to-br from-[rgb(var(--accent-rgb)/0.03)] to-[rgb(var(--accent-strong-rgb)/0.03)] dark:from-[rgb(var(--accent-rgb)/0.05)] dark:to-[rgb(var(--accent-strong-rgb)/0.05)]">
     </div>
 
     <!-- 大题标签 -->
     <div v-if="question.section_title"
-      class="mb-4 flex items-center gap-2 border-l-2 border-[rgb(129,115,223)]/60 pl-3 dark:border-[rgb(129,115,223)]/50">
-      <i class="fa-solid fa-layer-group text-xs text-[rgb(129,115,223)] dark:text-[rgb(145,132,235)]"></i>
+      class="mb-4 flex items-center gap-2 border-l-2 border-[rgb(var(--accent-rgb)/0.6)] pl-3 dark:border-[rgb(var(--accent-rgb)/0.5)]">
+      <i class="fa-solid fa-layer-group text-xs accent-text"></i>
       <span class="text-xs font-bold tracking-wide text-gray-500 dark:text-gray-400">{{ question.section_title }}</span>
     </div>
 
@@ -101,7 +101,7 @@ const cancelUserAnswer = () => { editingUserAnswer.value = false }
           {{ question.question_type }}
         </span>
         <span v-for="tag in question.knowledge_tags" :key="tag"
-          class="rounded-full bg-[rgb(129,115,223)]/10 px-3 py-1 text-xs font-bold text-[rgb(129,115,223)] dark:bg-[rgb(129,115,223)]/20 dark:text-[rgb(145,132,235)]">
+          class="rounded-full accent-bg-soft px-3 py-1 text-xs font-bold accent-text">
           {{ tag }}
         </span>
       </div>
@@ -109,11 +109,11 @@ const cancelUserAnswer = () => { editingUserAnswer.value = false }
       <!-- 右侧复选框 -->
       <div class="ml-auto flex items-center gap-4">
         <span class="text-xs font-bold uppercase tracking-widest text-gray-400"
-          :class="selected && 'text-[rgb(129,115,223)] dark:text-[rgb(145,132,235)]'">
+          :class="selected && 'accent-text'">
           {{ selected ? '已选择' : '未选择' }}
         </span>
         <div class="flex h-5 w-5 items-center justify-center rounded-lg border-2 transition-all"
-          :class="selected ? 'border-[rgb(129,115,223)] bg-[rgb(129,115,223)] text-white shadow-sm' : 'border-gray-200 bg-white dark:border-white/5 dark:bg-[#15151e]'">
+          :class="selected ? 'accent-border accent-bg text-white shadow-sm' : 'border-gray-200 bg-white dark:border-white/5 dark:bg-[#15151e]'">
           <i v-if="selected" class="fa-solid fa-check text-[10px]"></i>
         </div>
       </div>

--- a/frontend/src/components/question/QuestionDetailModal.vue
+++ b/frontend/src/components/question/QuestionDetailModal.vue
@@ -182,7 +182,7 @@ const reviewStatusOptions = [
             class="flex shrink-0 items-center justify-between border-b border-slate-100 bg-slate-50/50 px-8 py-5 dark:border-white/5 dark:bg-white/5">
             <div class="flex items-center gap-4">
               <div
-                class="flex h-10 w-10 items-center justify-center rounded-xl bg-blue-600 text-white shadow-lg shadow-blue-500/30">
+                class="flex h-10 w-10 items-center justify-center rounded-xl accent-bg text-white shadow-lg">
                 <i class="fa-solid fa-file-lines text-lg"></i>
               </div>
               <div>
@@ -256,10 +256,10 @@ const reviewStatusOptions = [
               <div class="flex shrink-0 border-b border-slate-100 dark:border-white/5">
                 <button @click="activeTab = 'content'"
                   class="flex-1 py-4 text-xs font-black uppercase tracking-widest transition-all"
-                  :class="activeTab === 'content' ? 'border-b-2 border-blue-600 text-blue-600 dark:text-indigo-400' : 'text-slate-400'">我的笔记</button>
+                  :class="activeTab === 'content' ? 'border-b-2 border-[rgb(var(--accent-rgb))] accent-text' : 'text-slate-400'">我的笔记</button>
                 <button @click="activeTab = 'analysis'"
                   class="flex-1 py-4 text-xs font-black uppercase tracking-widest transition-all"
-                  :class="activeTab === 'analysis' ? 'border-b-2 border-blue-600 text-blue-600 dark:text-indigo-400' : 'text-slate-400'">AI
+                  :class="activeTab === 'analysis' ? 'border-b-2 border-[rgb(var(--accent-rgb))] accent-text' : 'text-slate-400'">AI
                   深度解析</button>
               </div>
 
@@ -296,11 +296,11 @@ const reviewStatusOptions = [
                     {{ isSaving ? '同步中...' : '保存学习笔记' }}
                   </button>
                   <button @click="triggerAiAnalysis"
-                    class="group flex w-full items-center justify-center gap-2 rounded-2xl border border-blue-500/20 bg-blue-500/5 py-4 text-sm font-black text-blue-600 transition-all hover:bg-blue-500/10 dark:text-indigo-400">
+                    class="group flex w-full items-center justify-center gap-2 rounded-2xl border accent-border accent-bg-muted py-4 text-sm font-black accent-text transition-all hover:bg-[rgb(var(--accent-rgb)/0.12)]">
                     <i class="fa-solid fa-wand-magic-sparkles animate-pulse"></i> 召唤 AI 助教分析
                   </button>
                   <button @click="emit('start-chat', question); emit('close')"
-                    class="group flex w-full items-center justify-center gap-2 rounded-2xl border border-indigo-500/20 bg-indigo-500/5 py-4 text-sm font-black text-indigo-600 transition-all hover:bg-indigo-500/10 dark:text-indigo-300">
+                    class="group flex w-full items-center justify-center gap-2 rounded-2xl border accent-border accent-bg-muted py-4 text-sm font-black accent-text transition-all hover:bg-[rgb(var(--accent-rgb)/0.12)]">
                     <i class="fa-solid fa-comments"></i> AI 辅导对话
                   </button>
                 </div>
@@ -309,20 +309,20 @@ const reviewStatusOptions = [
                 <div v-else class="space-y-6">
                   <div v-if="isAnalyzing" class="flex flex-col items-center justify-center py-20">
                     <div
-                      class="mb-4 h-12 w-12 animate-bounce rounded-full bg-indigo-500/20 flex items-center justify-center">
-                      <i class="fa-solid fa-brain text-indigo-500"></i>
+                      class="mb-4 h-12 w-12 animate-bounce rounded-full accent-bg-soft flex items-center justify-center">
+                      <i class="fa-solid fa-brain accent-text"></i>
                     </div>
-                    <p class="text-xs font-black uppercase tracking-widest text-indigo-500 animate-pulse">分析中...</p>
+                    <p class="text-xs font-black uppercase tracking-widest accent-text animate-pulse">分析中...</p>
                   </div>
                   <div v-else-if="aiReport" class="space-y-8 animate-in slide-in-from-bottom-4 duration-500">
-                    <div class="rounded-2xl border border-indigo-500/20 bg-indigo-500/5 p-5">
+                    <div class="rounded-2xl border accent-border accent-bg-muted p-5">
                       <h4
-                        class="mb-3 flex items-center gap-2 text-xs font-black uppercase text-indigo-600 dark:text-indigo-400">
+                        class="mb-3 flex items-center gap-2 text-xs font-black uppercase accent-text">
                         <i class="fa-solid fa-microchip"></i> 认知诊断诊断报告
                       </h4>
                       <p class="text-sm font-medium leading-relaxed text-slate-700 dark:text-slate-300">
                         {{ typedText }}<span
-                          class="inline-block h-4 w-1 animate-blink bg-indigo-500 align-middle ml-1"></span>
+                          class="inline-block h-4 w-1 animate-blink accent-bg align-middle ml-1"></span>
                       </p>
                     </div>
 
@@ -331,7 +331,7 @@ const reviewStatusOptions = [
                       <div class="space-y-4 border-l-2 border-slate-200 pl-6 dark:border-white/10">
                         <div v-for="(step, idx) in aiReport.steps" :key="idx" class="relative">
                           <span
-                            class="absolute -left-[31px] flex h-[14px] w-[14px] items-center justify-center rounded-full bg-blue-600 text-[8px] font-black text-white outline outline-4 outline-white dark:outline-[#0F111A]">
+                            class="absolute -left-[31px] flex h-[14px] w-[14px] items-center justify-center rounded-full accent-bg text-[8px] font-black text-white outline outline-4 outline-white dark:outline-[#0F111A]">
                             {{ idx + 1 }}
                           </span>
                           <p class="text-sm font-bold text-slate-700 dark:text-slate-300">{{ step }}</p>

--- a/frontend/src/components/question/QuestionItem.vue
+++ b/frontend/src/components/question/QuestionItem.vue
@@ -56,13 +56,13 @@ const statusIcon = (status) => {
   <BaseCard
     @click="selectable ? emit('toggle-select', question.id) : emit('click', question)"
     class="group cursor-pointer"
-    :class="{ '!border-indigo-400 !bg-indigo-50 dark:!border-[rgb(129,115,223)]/40 dark:!bg-[rgb(129,115,223)]/[0.06]': selected }"
+    :class="{ 'accent-border accent-bg-muted': selected }"
   >
     <div class="flex items-start gap-4">
       <!-- 选择复选框 -->
       <div v-if="selectable" class="flex shrink-0 items-center pt-1" @click.stop="emit('toggle-select', question.id)">
         <div class="flex h-5 w-5 items-center justify-center rounded-lg border-2 transition-all"
-          :class="selected ? 'border-[rgb(129,115,223)] bg-[rgb(129,115,223)] text-white' : 'border-gray-200 dark:border-white/[0.15] bg-white dark:bg-transparent'">
+          :class="selected ? 'accent-border accent-bg text-white' : 'border-gray-200 dark:border-white/[0.15] bg-white dark:bg-transparent'">
           <i v-if="selected" class="fa-solid fa-check text-xs"></i>
         </div>
       </div>
@@ -73,7 +73,7 @@ const statusIcon = (status) => {
           <!-- 复习状态图标 -->
           <i v-if="showStatus" class="fa-solid text-sm" :class="[statusIcon(question.review_status), statusColor(question.review_status)]"></i>
           <span class="rounded-full bg-gray-100 dark:bg-white/[0.04] px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-[#8a8f98] transition-colors">{{ question.question_type }}</span>
-          <span v-if="question.subject" class="rounded-full bg-[rgb(129,115,223)]/10 px-2 py-0.5 text-xs font-medium text-[rgb(129,115,223)] dark:text-[rgb(145,132,235)] transition-colors">{{ question.subject }}</span>
+          <span v-if="question.subject" class="rounded-full accent-bg-soft px-2 py-0.5 text-xs font-medium accent-text transition-colors">{{ question.subject }}</span>
           <span v-for="tag in tags()" :key="tag" class="rounded-full border border-gray-200 dark:border-white/[0.06] px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-[#8a8f98] transition-colors">{{ tag }}</span>
         </div>
 

--- a/frontend/src/components/review/AiAnalysisModal.vue
+++ b/frontend/src/components/review/AiAnalysisModal.vue
@@ -23,9 +23,9 @@ const emit = defineEmits(['close'])
         <div class="relative flex max-h-[85vh] w-full max-w-3xl flex-col overflow-hidden rounded-[2rem] border border-white/10 bg-white shadow-2xl dark:bg-[#0F111A]">
 
           <!-- 头部 -->
-          <div class="flex items-center justify-between border-b border-slate-100 bg-gradient-to-r from-indigo-50 to-blue-50 px-8 py-5 dark:border-white/5 dark:from-indigo-500/5 dark:to-blue-500/5">
+          <div class="flex items-center justify-between border-b border-slate-100 bg-[rgb(var(--accent-rgb)/0.08)] px-8 py-5 dark:border-white/5 dark:bg-[rgb(var(--accent-rgb)/0.06)]">
             <div class="flex items-center gap-4">
-              <div class="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-blue-600 text-white shadow-lg shadow-indigo-500/30">
+              <div class="flex h-10 w-10 items-center justify-center rounded-xl accent-gradient-bg text-white shadow-lg">
                 <i class="fa-solid fa-brain text-lg"></i>
               </div>
               <div>
@@ -43,8 +43,8 @@ const emit = defineEmits(['close'])
             <!-- 加载状态 -->
             <div v-if="loading" class="flex flex-col items-center justify-center py-20">
               <div class="relative mb-6">
-                <div class="h-16 w-16 animate-spin rounded-full border-4 border-indigo-200 border-t-indigo-500"></div>
-                <i class="fa-solid fa-brain absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-xl text-indigo-500 animate-pulse"></i>
+                <div class="h-16 w-16 animate-spin rounded-full border-4 border-[rgb(var(--accent-rgb)/0.18)] border-t-[rgb(var(--accent-rgb))]"></div>
+                <i class="fa-solid fa-brain absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-xl accent-text animate-pulse"></i>
               </div>
               <p class="text-sm font-black text-slate-600 dark:text-slate-300">AI 正在分析你的错题...</p>
               <p class="mt-1 text-xs text-slate-400">分析知识薄弱点、归纳错因模式</p>
@@ -52,8 +52,8 @@ const emit = defineEmits(['close'])
             <!-- 分析结果 -->
             <div v-else-if="analysis" class="space-y-8">
               <!-- 综合诊断 -->
-              <div class="rounded-2xl border border-indigo-500/20 bg-gradient-to-br from-indigo-500/5 to-blue-500/5 p-6">
-                <h4 class="mb-3 flex items-center gap-2 text-xs font-black uppercase tracking-widest text-indigo-600 dark:text-indigo-400">
+              <div class="rounded-2xl border accent-border accent-bg-muted p-6">
+                <h4 class="mb-3 flex items-center gap-2 text-xs font-black uppercase tracking-widest accent-text">
                   <i class="fa-solid fa-stethoscope"></i> 综合诊断
                 </h4>
                 <p class="text-sm font-medium leading-relaxed text-slate-700 dark:text-slate-300">{{ analysis.summary }}</p>

--- a/frontend/src/components/workspace/AnswerInputModal.vue
+++ b/frontend/src/components/workspace/AnswerInputModal.vue
@@ -38,7 +38,7 @@ const emit = defineEmits(['update:open', 'update:text', 'confirm'])
         <button
           @click="emit('confirm')"
           :disabled="saving"
-          class="rounded-md bg-[#5e6ad2] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#7170ff] disabled:opacity-50"
+          class="rounded-md accent-gradient-bg px-4 py-2 text-sm font-medium text-white transition-colors disabled:opacity-50"
         >
           {{ saving ? '保存中...' : '保存并开始辅导' }}
         </button>

--- a/frontend/src/components/workspace/ContentPanel.vue
+++ b/frontend/src/components/workspace/ContentPanel.vue
@@ -51,7 +51,7 @@ const { sidebarMode, isMobile, toggleSidebar } = useWorkspaceNav()
               ? 'text-gray-500 dark:text-[#8a8f98] hover:bg-gray-100 dark:hover:bg-white/[0.04] hover:text-gray-700 dark:hover:text-[#d0d6e0]'
               : 'text-gray-400 dark:text-[#62666d] cursor-default'">
           <span class="flex h-4 w-4 items-center justify-center rounded text-[10px] transition-colors" :class="s.done
-            ? 'bg-[rgb(129,115,223)] text-white'
+            ? 'accent-bg text-white'
             : i === currentStep
               ? 'bg-white/20 text-white'
               : 'bg-gray-100 dark:bg-white/[0.04] text-gray-400 dark:text-[#62666d]'">

--- a/frontend/src/components/workspace/ErasePreview.vue
+++ b/frontend/src/components/workspace/ErasePreview.vue
@@ -70,12 +70,12 @@ function onPointerDown(event) {
         <!-- 滑块线 -->
         <div
           class="absolute top-0 bottom-0 w-0.5 z-10"
-          style="background: rgb(129,115,223);"
+          style="background: rgb(var(--accent-rgb));"
           :style="{ left: sliderPos + '%' }"
         >
           <div
             class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex h-8 w-8 cursor-ew-resize items-center justify-center rounded-full shadow-lg"
-            style="background: rgb(129,115,223);"
+            style="background: rgb(var(--accent-rgb));"
             @pointerdown.prevent="onPointerDown"
           >
             <i class="fa-solid fa-arrows-left-right text-xs text-white"></i>
@@ -90,7 +90,7 @@ function onPointerDown(event) {
           :key="i"
           @click="currentPage = i; sliderPos = 50"
           class="h-2 rounded-full transition-all"
-          :class="i === currentPage ? 'w-6 bg-[rgb(129,115,223)]' : 'w-2 bg-gray-300 dark:bg-white/20 hover:bg-gray-400 dark:hover:bg-white/40'"
+          :class="i === currentPage ? 'w-6 accent-bg' : 'w-2 bg-gray-300 dark:bg-white/20 hover:bg-gray-400 dark:hover:bg-white/40'"
         />
       </div>
     </template>

--- a/frontend/src/components/workspace/FileList.vue
+++ b/frontend/src/components/workspace/FileList.vue
@@ -33,7 +33,7 @@ const emit = defineEmits(['remove-file'])
         >
           <!-- 进度条背景 -->
           <div
-            class="absolute inset-0 -z-10 bg-[rgba(129,115,223,0.12)] transition-[width] duration-500 ease-out"
+            class="absolute inset-0 -z-10 accent-bg-soft transition-[width] duration-500 ease-out"
             :style="{ width: `${fileProgress[item.key] ?? 0}%` }"
           ></div>
 
@@ -42,7 +42,7 @@ const emit = defineEmits(['remove-file'])
             :class="
               item.file.name.toLowerCase().endsWith('.pdf')
                 ? 'fa-file-pdf text-rose-500 dark:text-rose-400'
-                : 'fa-file-image text-[rgb(129,115,223)]'
+                : 'fa-file-image accent-text'
             "
           ></i>
           <div class="flex flex-col min-w-0 pr-4 text-left">

--- a/frontend/src/components/workspace/FileUploader.vue
+++ b/frontend/src/components/workspace/FileUploader.vue
@@ -47,7 +47,7 @@ const onClickZone = () => {
       class="group relative flex flex-col items-center justify-center rounded-md border transition-colors"
       :class="[
         uploadHover
-          ? 'border-[rgb(129,115,223)]/40 bg-gray-100 dark:bg-white/[0.04]'
+          ? 'accent-border bg-gray-100 dark:bg-white/[0.04]'
           : 'border-dashed border-gray-300 dark:border-white/[0.08] hover:border-gray-400 dark:hover:border-white/[0.12] hover:bg-gray-50 dark:hover:bg-white/[0.02]',
         expand ? 'py-14' : 'py-8',
         disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer'
@@ -67,10 +67,10 @@ const onClickZone = () => {
 
         <div class="text-center">
           <p v-if="disabled" class="text-sm text-gray-500 dark:text-[#62666d]">
-            请先在 <span class="text-[rgb(145,132,235)]">系统设置</span> 中配置模型
+            请先在 <span class="accent-text">系统设置</span> 中配置模型
           </p>
           <p v-else class="text-sm text-gray-500 dark:text-[#8a8f98]">
-            拖拽文件到此处或 <span class="text-[rgb(145,132,235)] cursor-pointer">浏览文件</span>
+            拖拽文件到此处或 <span class="accent-text cursor-pointer">浏览文件</span>
           </p>
           <p class="mt-1 text-xs text-gray-400 dark:text-[#62666d]">PDF, PNG, JPG</p>
         </div>

--- a/frontend/src/components/workspace/OcrPreview.vue
+++ b/frontend/src/components/workspace/OcrPreview.vue
@@ -154,7 +154,7 @@ const hoveredBlock = ref(null)
           :key="i"
           @click="currentPage = i"
           class="h-2 rounded-full transition-all"
-          :class="i === currentPage ? 'w-6 bg-[rgb(129,115,223)]' : 'w-2 bg-gray-300 dark:bg-white/20 hover:bg-gray-400 dark:hover:bg-white/40'"
+          :class="i === currentPage ? 'w-6 accent-bg' : 'w-2 bg-gray-300 dark:bg-white/20 hover:bg-gray-400 dark:hover:bg-white/40'"
         />
       </div>
     </template>

--- a/frontend/src/components/workspace/SelectionPanel.vue
+++ b/frontend/src/components/workspace/SelectionPanel.vue
@@ -22,7 +22,7 @@ const emit = defineEmits(['export', 'save', 'clear'])
         class="flex items-center gap-6 rounded-full border border-slate-200/60 bg-white/70 px-6 py-3 shadow-md dark:border-white/10 dark:bg-white/[0.03]">
         <div class="flex items-center gap-3 border-r border-slate-200/60 pr-6 dark:border-white/10">
           <div
-            class="flex h-8 w-8 items-center justify-center rounded-full bg-blue-600 font-mono text-xs font-bold text-white shadow-sm dark:bg-indigo-500">
+            class="flex h-8 w-8 items-center justify-center rounded-full accent-bg font-mono text-xs font-bold text-white shadow-sm">
             {{ count }}
           </div>
           <span class="text-sm font-bold tracking-wider text-slate-700 dark:text-slate-200">已选中题目</span>

--- a/frontend/src/components/workspace/SidebarNav.vue
+++ b/frontend/src/components/workspace/SidebarNav.vue
@@ -128,7 +128,7 @@ const userQuotaSummary = computed(() => {
 <template>
   <!-- ================== 侧边栏容器 ================== -->
   <aside
-    class="flex min-h-0 flex-col z-20 transition-all duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)] bg-white dark:bg-[#0c0c0e] border-r border-gray-200/50 dark:border-white/[0.05] overflow-hidden"
+    class="flex min-h-0 flex-col z-20 transition-all duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)] bg-transparent overflow-hidden"
     :class="[
       isMobile
         ? 'fixed inset-y-0 left-0 w-64 transform ' + (mobileDrawerOpen ? 'translate-x-0' : '-translate-x-full')
@@ -145,7 +145,7 @@ const userQuotaSummary = computed(() => {
           <span v-if="!isNarrow">返回应用</span>
         </button>
 
-        <nav :ref="(el) => $emit('update:navRef', el)" class="flex flex-col gap-1.5 relative">
+        <nav :ref="(el) => $emit('update:navRef', el)" class="flex flex-col gap-1.5 relative pt-2">
           <div v-if="!isNarrow"
             class="px-3 pt-2 pb-1 text-xs font-medium uppercase tracking-[0.15em] text-gray-400 dark:text-[#62666d]">
             设置
@@ -197,7 +197,7 @@ const userQuotaSummary = computed(() => {
           </div>
 
           <!-- 视图切换菜单 -->
-          <nav :ref="(el) => $emit('update:navRef', el)" class="flex flex-col gap-1.5 relative transition-all"
+          <nav :ref="(el) => $emit('update:navRef', el)" class="flex flex-col gap-1.5 relative pt-2 transition-all"
             :class="isNarrow ? 'px-3' : 'px-4'">
 
             <template v-for="(group, gi) in navGroups" :key="gi">
@@ -355,7 +355,7 @@ const userQuotaSummary = computed(() => {
               :class="isNarrow ? 'justify-center px-0 w-10 h-10 mx-auto' : ''">
               <div
                 class="h-8 w-8 shrink-0 rounded-xl relative overflow-hidden flex items-center justify-center text-white text-sm font-medium"
-                style="background: linear-gradient(to bottom, rgba(129,115,223,0.9), rgba(99,87,199,0.9)); box-shadow: inset 0 1px 0 0 rgba(255,255,255,0.12);">
+                style="background: linear-gradient(to bottom, rgb(var(--accent-rgb) / 0.9), rgb(var(--accent-strong-rgb) / 0.9)); box-shadow: inset 0 1px 0 0 rgba(255,255,255,0.12);">
                 <img v-if="currentUser?.avatar_url" :src="currentUser.avatar_url" alt="用户头像"
                   class="h-full w-full object-cover" />
                 <template v-else>
@@ -369,7 +369,7 @@ const userQuotaSummary = computed(() => {
                   userDisplayName }}
                 </p>
                 <p v-if="userQuotaSummary"
-                  class="mt-0.5 text-xs text-[#5e6ad2] dark:text-[#7170ff] truncate leading-tight transition-colors">
+                  class="mt-0.5 text-xs accent-text truncate leading-tight transition-colors">
                   {{
                     userQuotaSummary }}</p>
                 <p v-else class="text-xs text-gray-500 dark:text-[#62666d] truncate leading-tight transition-colors">@{{

--- a/frontend/src/components/workspace/SplitLoading.vue
+++ b/frontend/src/components/workspace/SplitLoading.vue
@@ -85,7 +85,7 @@ defineProps({
   position: absolute;
   width: 120%;
   height: 120%;
-  background: radial-gradient(circle, rgba(129, 115, 223, 0.15) 0%, transparent 70%);
+  background: radial-gradient(circle, rgb(var(--accent-rgb) / 0.15) 0%, transparent 70%);
   filter: blur(20px);
   animation: breathe 4s ease-in-out infinite;
 }
@@ -94,8 +94,8 @@ defineProps({
 .orbit {
   position: absolute;
   border-radius: 50%;
-  border: 1.5px solid rgba(129, 115, 223, 0.1);
-  border-top-color: rgba(129, 115, 223, 0.5);
+  border: 1.5px solid rgb(var(--accent-rgb) / 0.1);
+  border-top-color: rgb(var(--accent-rgb) / 0.5);
 }
 
 .orbit-1 {
@@ -108,14 +108,14 @@ defineProps({
   width: 75%;
   height: 75%;
   animation: rotate 5s linear infinite reverse;
-  border-top-color: rgba(145, 132, 235, 0.5);
+  border-top-color: rgb(var(--accent-hover-rgb) / 0.5);
 }
 
 .orbit-3 {
   width: 50%;
   height: 50%;
   animation: rotate 3s linear infinite;
-  border-top-color: rgba(129, 115, 223, 0.5);
+  border-top-color: rgb(var(--accent-rgb) / 0.5);
 }
 
 /* 核心图标 */
@@ -131,7 +131,7 @@ defineProps({
   position: absolute;
   inset: -4px;
   border-radius: 1.25rem;
-  background: rgba(129, 115, 223, 0.2);
+  background: rgb(var(--accent-rgb) / 0.2);
   animation: pulse 2s ease-out infinite;
 }
 
@@ -141,8 +141,8 @@ defineProps({
   left: 0;
   right: 0;
   height: 2px;
-  background: linear-gradient(90deg, transparent, rgba(129, 115, 223, 0.8), transparent);
-  box-shadow: 0 0 15px rgba(129, 115, 223, 0.5);
+  background: linear-gradient(90deg, transparent, rgb(var(--accent-rgb) / 0.8), transparent);
+  box-shadow: 0 0 15px rgb(var(--accent-rgb) / 0.5);
   z-index: 5;
   animation: scan 3s ease-in-out infinite;
 }
@@ -171,7 +171,7 @@ defineProps({
   margin-top: 1.5rem;
   width: 100%;
   height: 4px;
-  background: rgba(129, 115, 223, 0.05);
+  background: rgb(var(--accent-rgb) / 0.05);
   border-radius: 10px;
   overflow: hidden;
 }
@@ -179,7 +179,7 @@ defineProps({
 .progress-bar {
   width: 40%;
   height: 100%;
-  background: linear-gradient(90deg, rgb(129,115,223), rgb(145,132,235));
+  background: linear-gradient(90deg, rgb(var(--accent-rgb)), rgb(var(--accent-hover-rgb)));
   border-radius: 10px;
   position: relative;
   animation: progress-move 2.5s ease-in-out infinite;

--- a/frontend/src/components/workspace/StatusBar.vue
+++ b/frontend/src/components/workspace/StatusBar.vue
@@ -176,7 +176,7 @@ const modelStatusError = computed(() => {
             :disabled="disabled">
             <div class="flex items-center gap-2.5 min-w-0 flex-1">
               <div
-                class="relative flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-gray-100 dark:bg-white/[0.05] text-[rgb(145,132,235)] transition-colors">
+                class="relative flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-gray-100 dark:bg-white/[0.05] accent-text transition-colors">
                 <Transition name="fade" mode="out-in">
                   <img v-if="currentOption && modelLogos[currentOption.category]" :key="currentOption.category"
                     :src="modelLogos[currentOption.category]" class="h-3.5 w-3.5 object-contain" alt="" />
@@ -240,7 +240,7 @@ const modelStatusError = computed(() => {
                         <img v-if="modelLogos[item.provider]" :src="modelLogos[item.provider]"
                           class="h-3.5 w-3.5 object-contain opacity-60 shrink-0" alt="" />
                         <span class="truncate text-sm transition-colors"
-                          :class="[selected ? 'font-medium text-indigo-600 dark:text-white' : 'font-medium text-gray-700 dark:text-[#d0d6e0]']">
+                          :class="[selected ? 'font-medium accent-text dark:text-white' : 'font-medium text-gray-700 dark:text-[#d0d6e0]']">
                           {{ item.label }}
                         </span>
                       </div>
@@ -248,7 +248,7 @@ const modelStatusError = computed(() => {
                         class="shrink-0 rounded bg-gray-100 px-1 py-0.5 text-[9px] font-bold text-gray-400 dark:bg-white/5 dark:text-[#62666d] transition-colors">默认</span>
                     </div>
                     <span v-if="selected"
-                      class="absolute inset-y-0 left-0 flex items-center pl-3 text-indigo-600 dark:text-white transition-colors">
+                      class="absolute inset-y-0 left-0 flex items-center pl-3 accent-text dark:text-white transition-colors">
                       <i class="fa-solid fa-check text-sm"></i>
                     </span>
                   </li>

--- a/frontend/src/components/workspace/StepIndicator.vue
+++ b/frontend/src/components/workspace/StepIndicator.vue
@@ -46,9 +46,9 @@ const descs = computed(() => props.mode === 'note' ? noteDescs : examDescs)
           class="step-circle relative z-10 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border"
           :class="
             n < step
-              ? 'border-transparent bg-gradient-to-br from-[rgb(129,115,223)] to-[rgb(145,132,235)] text-white/90'
+              ? 'border-transparent accent-gradient-bg text-white/90'
               : n === step
-                ? 'border-white/[0.12] bg-white/[0.08] text-[rgb(145,132,235)]'
+                ? 'border-white/[0.12] bg-white/[0.08] accent-text'
                 : 'border-white/[0.05] bg-white/[0.03] text-[#62666d]'
           "
         >
@@ -58,7 +58,7 @@ const descs = computed(() => props.mode === 'note' ? noteDescs : examDescs)
           </Transition>
 
           <!-- 当前步骤的光晕 -->
-          <div v-if="n === step" class="absolute -inset-1 animate-pulse rounded-lg bg-[rgb(129,115,223)]/20 blur-md"></div>
+          <div v-if="n === step" class="absolute -inset-1 animate-pulse rounded-lg accent-bg-soft blur-md"></div>
         </div>
 
         <!-- 文本描述 -->

--- a/frontend/src/components/workspace/UploadStage.vue
+++ b/frontend/src/components/workspace/UploadStage.vue
@@ -61,7 +61,7 @@ const emit = defineEmits([
     <!-- 擦除开关 -->
     <label class="flex cursor-pointer items-center gap-2" @click="emit('update:erase-enabled', !eraseEnabled)">
       <div class="relative h-4 w-7 rounded-full transition-colors"
-        :class="eraseEnabled ? 'bg-[rgb(129,115,223)]' : 'bg-gray-300 dark:bg-white/[0.08]'">
+        :class="eraseEnabled ? 'accent-bg' : 'bg-gray-300 dark:bg-white/[0.08]'">
         <div class="absolute top-0.5 h-3 w-3 rounded-full bg-white transition-transform"
           :class="eraseEnabled ? 'translate-x-3' : 'translate-x-0.5'"></div>
       </div>
@@ -100,26 +100,26 @@ const emit = defineEmits([
     <div class="grid w-full max-w-2xl grid-cols-4 gap-4 transition-colors">
       <div class="flex flex-col items-center gap-3 rounded-lg brand-btn p-4 text-center">
         <div class="flex h-12 w-12 items-center justify-center rounded-lg bg-gray-100 dark:bg-white/[0.04]">
-          <i class="fa-solid fa-cloud-arrow-up text-xl text-[rgb(129,115,223)]"></i>
+          <i class="fa-solid fa-cloud-arrow-up text-xl accent-text"></i>
         </div>
         <span class="text-sm text-gray-500 dark:text-[#8a8f98]">{{ uploadMode === 'note' ? '上传笔记' : '上传文件' }}</span>
       </div>
       <div class="flex flex-col items-center gap-3 rounded-lg brand-btn p-4 text-center">
         <div class="flex h-12 w-12 items-center justify-center rounded-lg bg-gray-100 dark:bg-white/[0.04]">
-          <i class="fa-solid fa-eye text-xl text-[rgb(129,115,223)]"></i>
+          <i class="fa-solid fa-eye text-xl accent-text"></i>
         </div>
         <span class="text-sm text-gray-500 dark:text-[#8a8f98]">AI 识别</span>
       </div>
       <div class="flex flex-col items-center gap-3 rounded-lg brand-btn p-4 text-center">
         <div class="flex h-12 w-12 items-center justify-center rounded-lg bg-gray-100 dark:bg-white/[0.04]">
-          <i class="fa-solid text-xl text-[rgb(129,115,223)]"
+          <i class="fa-solid text-xl accent-text"
             :class="uploadMode === 'note' ? 'fa-wand-magic-sparkles' : 'fa-scissors'"></i>
         </div>
         <span class="text-sm text-gray-500 dark:text-[#8a8f98]">{{ uploadMode === 'note' ? '智能整理' : '分割纠错' }}</span>
       </div>
       <div class="flex flex-col items-center gap-3 rounded-lg brand-btn p-4 text-center">
         <div class="flex h-12 w-12 items-center justify-center rounded-lg bg-gray-100 dark:bg-white/[0.04]">
-          <i class="fa-solid text-xl text-[rgb(129,115,223)]"
+          <i class="fa-solid text-xl accent-text"
             :class="uploadMode === 'note' ? 'fa-bookmark' : 'fa-file-export'"></i>
         </div>
         <span class="text-sm text-gray-500 dark:text-[#8a8f98]">{{ uploadMode === 'note' ? '保存笔记' : '导出归档' }}</span>

--- a/frontend/src/components/workspace/WorkspaceBackground.vue
+++ b/frontend/src/components/workspace/WorkspaceBackground.vue
@@ -23,7 +23,7 @@ const bgStars = (() => {
     <div
       v-for="(s, i) in bgStars"
       :key="i"
-      class="absolute rounded-full bg-indigo-400 dark:bg-white ws-star transition-colors duration-200"
+      class="absolute rounded-full bg-[rgb(var(--accent-hover-rgb))] dark:bg-white ws-star transition-colors duration-200"
       :style="{
         left: s.left + '%',
         top: s.top + '%',
@@ -52,7 +52,7 @@ const bgStars = (() => {
   width: 600px;
   height: 600px;
   border-radius: 9999px;
-  background: radial-gradient(circle, rgba(129,115,223,0.06) 0%, transparent 70%);
+  background: radial-gradient(circle, rgb(var(--accent-rgb) / 0.06) 0%, transparent 70%);
 }
 .ws-bg-noise {
   position: absolute;

--- a/frontend/src/composables/useTheme.js
+++ b/frontend/src/composables/useTheme.js
@@ -1,12 +1,101 @@
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
-const isDark = ref(document.documentElement.classList.contains('dark'))
+const canUseDom = typeof document !== 'undefined'
+const canUseStorage = typeof localStorage !== 'undefined'
+const isDark = ref(canUseDom ? document.documentElement.classList.contains('dark') : true)
+const THEME_COLOR_STORAGE_KEY = 'theme-color'
+
+const themeColors = [
+  {
+    id: 'violet',
+    name: 'Violet',
+    label: '紫罗兰',
+    rgb: '129 115 223',
+    hoverRgb: '145 132 235',
+    strongRgb: '99 87 199',
+  },
+  {
+    id: 'blue',
+    name: 'Blue',
+    label: '湖蓝',
+    rgb: '37 99 235',
+    hoverRgb: '59 130 246',
+    strongRgb: '29 78 216',
+  },
+  {
+    id: 'emerald',
+    name: 'Emerald',
+    label: '松石绿',
+    rgb: '5 150 105',
+    hoverRgb: '16 185 129',
+    strongRgb: '4 120 87',
+  },
+  {
+    id: 'rose',
+    name: 'Rose',
+    label: '玫瑰红',
+    rgb: '225 29 72',
+    hoverRgb: '244 63 94',
+    strongRgb: '190 18 60',
+  },
+  {
+    id: 'amber',
+    name: 'Amber',
+    label: '琥珀黄',
+    rgb: '217 119 6',
+    hoverRgb: '245 158 11',
+    strongRgb: '180 83 9',
+  },
+]
+
+const defaultThemeColor = themeColors[0]
+const accentColorId = ref(defaultThemeColor.id)
+
+function getThemeColor(id) {
+  return themeColors.find((color) => color.id === id) || defaultThemeColor
+}
+
+function applyAccentColor(color) {
+  if (!canUseDom) return
+  const root = document.documentElement
+  root.dataset.themeColor = color.id
+  root.style.setProperty('--accent-rgb', color.rgb)
+  root.style.setProperty('--accent-hover-rgb', color.hoverRgb)
+  root.style.setProperty('--accent-strong-rgb', color.strongRgb)
+}
+
+function getStoredValue(key, fallback) {
+  if (!canUseStorage) return fallback
+  try {
+    return localStorage.getItem(key) || fallback
+  } catch (_) {
+    return fallback
+  }
+}
+
+function setStoredValue(key, value) {
+  if (!canUseStorage) return
+  try {
+    localStorage.setItem(key, value)
+  } catch (_) {
+    // Ignore storage failures so theme switching still updates the live UI.
+  }
+}
 
 export function useTheme() {
+  const accentColor = computed(() => getThemeColor(accentColorId.value))
+
   function setTheme(dark) {
     isDark.value = dark
-    document.documentElement.classList.toggle('dark', dark)
-    localStorage.setItem('theme', dark ? 'dark' : 'light')
+    if (canUseDom) document.documentElement.classList.toggle('dark', dark)
+    setStoredValue('theme', dark ? 'dark' : 'light')
+  }
+
+  function setAccentColor(colorId) {
+    const color = getThemeColor(colorId)
+    accentColorId.value = color.id
+    applyAccentColor(color)
+    setStoredValue(THEME_COLOR_STORAGE_KEY, color.id)
   }
 
   /**
@@ -48,10 +137,12 @@ export function useTheme() {
   }
 
   function initTheme() {
-    const saved = localStorage.getItem('theme') || 'dark'
+    const saved = getStoredValue('theme', 'dark')
+    const savedColor = getStoredValue(THEME_COLOR_STORAGE_KEY, defaultThemeColor.id)
     isDark.value = saved === 'dark'
-    document.documentElement.classList.toggle('dark', isDark.value)
+    if (canUseDom) document.documentElement.classList.toggle('dark', isDark.value)
+    setAccentColor(savedColor)
   }
 
-  return { isDark, setTheme, toggleTheme, initTheme }
+  return { isDark, themeColors, accentColor, accentColorId, setTheme, toggleTheme, setAccentColor, initTheme }
 }

--- a/frontend/src/composables/useWorkspaceNav.js
+++ b/frontend/src/composables/useWorkspaceNav.js
@@ -24,6 +24,7 @@ const WORKSPACE_VIEWS = new Set(['workspace', 'workspace_review', 'split-history
 
 const SETTINGS_NAV_ITEMS = [
   { id: 'quota', label: '免费额度', icon: 'fa-gauge-high' },
+  { id: 'appearance', label: '外观设置', icon: 'fa-palette' },
   { id: 'profile', label: '用户资料设置', icon: 'fa-user-gear' },
   { id: 'api', label: 'API 设置', icon: 'fa-plug-circle-bolt' },
 ]

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3,6 +3,9 @@
   --sidebar-transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
   --mask-transition-duration: 300ms;
   --mask-transition-timing: ease-in-out;
+  --accent-rgb: 129 115 223;
+  --accent-hover-rgb: 145 132 235;
+  --accent-strong-rgb: 99 87 199;
 }
 
 @tailwind base;
@@ -13,7 +16,15 @@
 
   /* 优化按钮：引入微妙的渐变、阴影，以及点击和悬浮的丝滑微动效 */
   .btn-primary {
-    @apply inline-flex items-center justify-center gap-2 rounded-xl text-sm font-semibold shadow-md shadow-blue-500/20 transition-all duration-300 active:scale-[0.97] motion-reduce:active:scale-100 focus:outline-none bg-gradient-to-r from-blue-600 to-indigo-600 text-white hover:from-blue-500 hover:to-indigo-500 hover:shadow-lg hover:shadow-blue-500/30 focus:ring-4 focus:ring-blue-500/30 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:shadow-md dark:shadow-none dark:hover:shadow-blue-900/40;
+    @apply inline-flex items-center justify-center gap-2 rounded-xl text-sm font-semibold shadow-md transition-all duration-300 active:scale-[0.97] motion-reduce:active:scale-100 focus:outline-none text-white hover:shadow-lg focus:ring-4 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:shadow-md dark:shadow-none;
+    background-image: linear-gradient(to right, rgb(var(--accent-strong-rgb)), rgb(var(--accent-rgb)));
+    box-shadow: 0 10px 15px -3px rgb(var(--accent-rgb) / 0.2), 0 4px 6px -4px rgb(var(--accent-rgb) / 0.2);
+    --tw-ring-color: rgb(var(--accent-rgb) / 0.3);
+  }
+
+  .btn-primary:hover {
+    background-image: linear-gradient(to right, rgb(var(--accent-rgb)), rgb(var(--accent-hover-rgb)));
+    box-shadow: 0 10px 15px -3px rgb(var(--accent-rgb) / 0.3), 0 4px 6px -4px rgb(var(--accent-rgb) / 0.3);
   }
 
   .btn-success {
@@ -47,13 +58,13 @@
 }
 
 .filter-pill--active {
-  background: rgba(129, 115, 223, 0.08);
-  border-color: rgba(129, 115, 223, 0.2);
-  color: rgb(129, 115, 223);
+  background: rgb(var(--accent-rgb) / 0.08);
+  border-color: rgb(var(--accent-rgb) / 0.2);
+  color: rgb(var(--accent-rgb));
 }
 
 .filter-pill--active:hover {
-  background: rgba(129, 115, 223, 0.12);
+  background: rgb(var(--accent-rgb) / 0.12);
 }
 
 .dark .filter-pill {
@@ -69,13 +80,13 @@
 }
 
 .dark .filter-pill--active {
-  background: rgba(129, 115, 223, 0.12);
-  border-color: rgba(129, 115, 223, 0.3);
-  color: rgb(145, 132, 235);
+  background: rgb(var(--accent-rgb) / 0.12);
+  border-color: rgb(var(--accent-rgb) / 0.3);
+  color: rgb(var(--accent-hover-rgb));
 }
 
 .dark .filter-pill--active:hover {
-  background: rgba(129, 115, 223, 0.18);
+  background: rgb(var(--accent-rgb) / 0.18);
 }
 
 /* ── 毛玻璃 active 按钮（Linear 风格，全局共用） ── */
@@ -107,9 +118,55 @@
 }
 
 .brand-gradient-bg {
-  background: linear-gradient(to bottom, #5e6ad2, #4a55c2) !important;
+  background: linear-gradient(to bottom, rgb(var(--accent-rgb)), rgb(var(--accent-strong-rgb))) !important;
   box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.15), 0 2px 4px rgba(0, 0, 0, 0.2) !important;
   border: none !important;
+}
+
+.accent-gradient-bg {
+  background: linear-gradient(to bottom, rgb(var(--accent-rgb) / 0.95), rgb(var(--accent-strong-rgb) / 0.95));
+}
+
+.accent-bg {
+  background: rgb(var(--accent-rgb));
+}
+
+.accent-bg-soft {
+  background: rgb(var(--accent-rgb) / 0.12);
+}
+
+.accent-bg-muted {
+  background: rgb(var(--accent-rgb) / 0.08);
+}
+
+.accent-border {
+  border-color: rgb(var(--accent-rgb) / 0.4);
+}
+
+.accent-text {
+  color: rgb(var(--accent-rgb));
+}
+
+.dark .accent-text {
+  color: rgb(var(--accent-hover-rgb));
+}
+
+.accent-soft {
+  background: rgb(var(--accent-rgb) / 0.1);
+  color: rgb(var(--accent-rgb));
+}
+
+.dark .accent-soft {
+  background: rgb(var(--accent-rgb) / 0.16);
+  color: rgb(var(--accent-hover-rgb));
+}
+
+.home-title-accent {
+  background-image: linear-gradient(to right, rgb(var(--accent-hover-rgb)) 0%, rgb(var(--accent-hover-rgb)) 20%, rgb(var(--accent-strong-rgb)) 50%, rgb(var(--accent-hover-rgb)) 80%, rgb(var(--accent-hover-rgb)) 100%);
+}
+
+.dark .home-title-accent {
+  background-image: linear-gradient(to right, rgb(var(--accent-hover-rgb)) 0%, rgb(var(--accent-hover-rgb)) 20%, rgb(255, 255, 255) 50%, rgb(var(--accent-hover-rgb)) 80%, rgb(var(--accent-hover-rgb)) 100%);
 }
 
 /* Linear 风格的基础文本颜色 */
@@ -144,8 +201,16 @@ body,
 
 body {
   margin: 0;
-  @apply bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-50 selection:bg-blue-200 selection:text-blue-900 dark:selection:bg-blue-900/50 dark:selection:text-blue-100;
+  @apply bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-50 selection:text-blue-900 dark:selection:text-blue-100;
   -webkit-font-smoothing: antialiased;
+}
+
+::selection {
+  background: rgb(var(--accent-rgb) / 0.22);
+}
+
+.dark ::selection {
+  background: rgb(var(--accent-rgb) / 0.35);
 }
 
 /* ============================================================

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -237,7 +237,7 @@ onUnmounted(() => {
 
 <template>
   <div
-    class="min-h-screen bg-slate-50 text-slate-900 dark:bg-[#0A0A0F] dark:text-slate-300 selection:bg-blue-200 dark:selection:bg-indigo-500/30 page-enter">
+    class="min-h-screen bg-slate-50 text-slate-900 dark:bg-[#0A0A0F] dark:text-slate-300 page-enter">
 
     <!-- 🌟 真正的全局绝对底层固定背景 🌟 -->
     <!-- 将背景移出任何可能带有 transform / overflow-hidden 的包裹层，确保 fixed 完美生效 -->
@@ -426,7 +426,7 @@ html {
 }
 
 .footer-logo {
-  background: linear-gradient(to bottom, rgba(129, 115, 223, 0.9), rgba(99, 87, 199, 0.9));
+  background: linear-gradient(to bottom, rgb(var(--accent-rgb) / 0.9), rgb(var(--accent-strong-rgb) / 0.9));
   box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.12);
 }
 

--- a/frontend/src/views/app/ChatPageView.vue
+++ b/frontend/src/views/app/ChatPageView.vue
@@ -197,13 +197,13 @@ function autoResize() {
               :class="msg.role === 'user' ? 'justify-end' : 'justify-start'">
               <div class="max-w-[85%] rounded-2xl px-4 py-3 text-sm leading-relaxed"
                 :class="msg.role === 'user'
-                  ? 'bg-indigo-500 text-white rounded-br-lg shadow-sm dark:bg-[rgb(129,115,223)] dark:text-white dark:border-none'
+                  ? 'accent-bg text-white rounded-br-lg shadow-sm dark:text-white dark:border-none'
                   : 'bg-white border border-gray-200 text-gray-800 rounded-bl-lg shadow-sm dark:bg-white/[0.05] dark:text-[#d0d6e0] dark:border-white/[0.08]'">
                 <!-- 思考过程折叠面板 -->
                 <div v-if="msg.role === 'assistant' && msg.reasoning" class="mb-3">
                   <button @click="msg.reasoningOpen = !msg.reasoningOpen"
                     class="flex items-center gap-2 text-xs font-bold text-gray-500 hover:text-gray-700 dark:text-[#8a8f98] dark:hover:text-[#d0d6e0] transition-colors">
-                    <i class="fa-solid fa-brain text-indigo-500 dark:text-[rgb(129,115,223)]"></i>
+                    <i class="fa-solid fa-brain accent-text"></i>
                     <span>{{ streaming && i === messages.length - 1 && !msg.content ? '思考中...' : '已深度思考' }}</span>
                     <i class="fa-solid text-[10px] transition-transform"
                       :class="msg.reasoningOpen ? 'fa-chevron-up' : 'fa-chevron-down'"></i>
@@ -256,7 +256,7 @@ function autoResize() {
                 <button @click="deepThink = !deepThink"
                   class="h-8 px-2.5 rounded-lg text-xs font-bold flex items-center gap-1.5 transition-colors"
                   :class="deepThink
-                    ? 'bg-indigo-50 text-indigo-600 dark:bg-[rgb(129,115,223)]/15 dark:text-[rgb(145,132,235)]'
+                    ? 'accent-bg-soft accent-text'
                     : 'text-gray-500 hover:text-gray-700 hover:bg-gray-50 dark:text-[#62666d] dark:hover:text-[#8a8f98] dark:hover:bg-transparent'" title="深度思考">
                   <i class="fa-solid fa-brain text-sm"></i>
                   <span class="hidden sm:inline">深度思考</span>
@@ -279,7 +279,7 @@ function autoResize() {
                 <button @click="sessionId ? sendMessage() : createAiChat(currentView)"
                   :disabled="sessionId ? (!inputText.trim() || streaming) : false"
                   class="h-8 w-8 rounded-full flex items-center justify-center transition-all" :class="inputText.trim() && sessionId
-                    ? 'bg-indigo-500 text-white shadow-sm dark:bg-[rgb(129,115,223)]'
+                    ? 'accent-bg text-white shadow-sm'
                     : 'bg-gray-100 text-gray-400 dark:bg-white/[0.06] dark:text-[#62666d]'">
                   <i class="fa-solid fa-arrow-up text-xs"></i>
                 </button>

--- a/frontend/src/views/app/ChatView.vue
+++ b/frontend/src/views/app/ChatView.vue
@@ -264,8 +264,8 @@ onBeforeUnmount(() => {
 
         <!-- 空状态 -->
         <div v-if="!messages.length && !streaming" class="flex h-full flex-col items-center justify-center text-center">
-          <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-blue-50 dark:bg-blue-500/10">
-            <i class="fa-solid fa-chalkboard-user text-2xl text-blue-500 dark:text-blue-400"></i>
+          <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-2xl accent-bg-soft">
+            <i class="fa-solid fa-chalkboard-user text-2xl accent-text"></i>
           </div>
           <h3 class="text-lg font-bold text-slate-800 dark:text-slate-200">向 AI 老师提问吧</h3>
           <p class="mt-2 max-w-sm text-sm text-slate-500 dark:text-slate-400">
@@ -279,12 +279,12 @@ onBeforeUnmount(() => {
             :class="msg.role === 'user' ? 'justify-end' : 'justify-start'">
             <!-- assistant 头像 -->
             <div v-if="msg.role === 'assistant'"
-              class="mr-3 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-indigo-600 text-xs text-white shadow-md">
+              class="mr-3 flex h-8 w-8 shrink-0 items-center justify-center rounded-full accent-gradient-bg text-xs text-white shadow-md">
               <i class="fa-solid fa-graduation-cap"></i>
             </div>
 
             <div class="max-w-[80%] rounded-2xl px-4 py-3 text-sm leading-relaxed shadow-sm" :class="msg.role === 'user'
-              ? 'bg-blue-600 text-white dark:bg-indigo-500'
+              ? 'accent-bg text-white'
               : 'border border-slate-200/60 bg-white text-slate-800 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-200'
               ">
               <div v-if="msg.role === 'assistant'" class="chat-content whitespace-pre-wrap"
@@ -294,15 +294,15 @@ onBeforeUnmount(() => {
               <!-- 流式加载指示器 -->
               <span v-if="msg.role === 'assistant' && streaming && i === messages.length - 1 && !msg.content"
                 class="inline-flex items-center gap-1 text-slate-400">
-                <span class="h-1.5 w-1.5 animate-bounce rounded-full bg-blue-500 [animation-delay:-0.3s]"></span>
-                <span class="h-1.5 w-1.5 animate-bounce rounded-full bg-blue-500 [animation-delay:-0.15s]"></span>
-                <span class="h-1.5 w-1.5 animate-bounce rounded-full bg-blue-500"></span>
+                <span class="h-1.5 w-1.5 animate-bounce rounded-full accent-bg [animation-delay:-0.3s]"></span>
+                <span class="h-1.5 w-1.5 animate-bounce rounded-full accent-bg [animation-delay:-0.15s]"></span>
+                <span class="h-1.5 w-1.5 animate-bounce rounded-full accent-bg"></span>
               </span>
             </div>
 
             <!-- user 头像 -->
             <div v-if="msg.role === 'user'"
-              class="ml-3 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-indigo-600 dark:from-indigo-400 dark:to-indigo-600 text-xs font-extrabold text-white shadow-sm">
+              class="ml-3 flex h-8 w-8 shrink-0 items-center justify-center rounded-full accent-gradient-bg text-xs font-extrabold text-white shadow-sm">
               {{ username?.[0]?.toUpperCase() ?? '?' }}
             </div>
           </div>
@@ -315,9 +315,9 @@ onBeforeUnmount(() => {
         <div class="mx-auto flex max-w-3xl items-end gap-3">
           <textarea v-model="inputText" @keydown="onKeydown" :disabled="streaming" rows="1"
             placeholder="输入你的问题…（Enter 发送，Shift+Enter 换行）"
-            class="flex-1 resize-none rounded-xl border border-slate-200/80 bg-white px-4 py-3 text-sm text-slate-800 placeholder-slate-400 shadow-sm transition-colors focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 disabled:opacity-50 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-200 dark:placeholder-slate-500 dark:focus:border-indigo-500/50"></textarea>
+            class="flex-1 resize-none rounded-xl border border-slate-200/80 bg-white px-4 py-3 text-sm text-slate-800 placeholder-slate-400 shadow-sm transition-colors focus:border-[rgb(var(--accent-rgb)/0.4)] focus:outline-none focus:ring-2 focus:ring-[rgb(var(--accent-rgb)/0.2)] disabled:opacity-50 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-200 dark:placeholder-slate-500 dark:focus:border-[rgb(var(--accent-rgb)/0.4)]"></textarea>
           <button @click="sendMessage" :disabled="streaming || !inputText.trim()"
-            class="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-blue-600 text-white shadow-md transition-all hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-600">
+            class="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl accent-bg text-white shadow-md transition-all hover:bg-[rgb(var(--accent-hover-rgb))] disabled:cursor-not-allowed disabled:opacity-50">
             <i class="fa-solid" :class="streaming ? 'fa-circle-notch fa-spin' : 'fa-paper-plane'"></i>
           </button>
         </div>

--- a/frontend/src/views/app/DashboardView.vue
+++ b/frontend/src/views/app/DashboardView.vue
@@ -9,7 +9,7 @@ import BaseSelect from '@/components/base/BaseSelect.vue'
 import BaseCard from '@/components/base/BaseCard.vue'
 import StatCard from '@/components/dashboard/StatCard.vue'
 
-const { isDark } = useTheme()
+const { isDark, accentColorId } = useTheme()
 const { pushToast } = useToast()
 const { currentView } = useWorkspaceNav()
 const theme = computed(() => isDark.value ? 'dark' : 'light')
@@ -31,8 +31,19 @@ let barChart = null
 let stackedChart = null
 
 // ---- 颜色常量 ----
-const CHART_COLORS = ['#6366f1', '#3b82f6', '#10b981', '#f59e0b', '#ec4899', '#8b5cf6', '#14b8a6', '#f97316', '#06b6d4', '#e11d48']
+const CHART_COLORS = ['accent', '#3b82f6', '#10b981', '#f59e0b', '#ec4899', '#14b8a6', '#f97316', '#06b6d4', '#e11d48', '#84cc16']
 const STATUS_COLORS = { '待复习': '#f97316', '复习中': '#eab308', '已掌握': '#10b981' }
+
+const getAccentRgb = () => {
+  if (typeof window === 'undefined') return '129 115 223'
+  const raw = window.getComputedStyle(document.documentElement).getPropertyValue('--accent-rgb').trim()
+  return (raw || '129 115 223').split(/\s+/).join(', ')
+}
+
+const accentColor = () => `rgb(${getAccentRgb()})`
+const accentRgba = (alpha) => `rgba(${getAccentRgb()}, ${alpha})`
+const chartColor = (color) => color === 'accent' ? accentColor() : color
+const chartColorWithAlpha = (color, alpha) => color === 'accent' ? accentRgba(alpha) : `${color}${Math.round(alpha * 255).toString(16).padStart(2, '0')}`
 
 // ---- 数据加载 ----
 const loadStats = async () => {
@@ -75,10 +86,10 @@ const initTrendChart = (isDark, textColor, gridColor) => {
         {
           label: '每日新增',
           data: dc.map(d => d.count),
-          borderColor: '#3b82f6',
-          backgroundColor: 'rgba(59,130,246,0.1)',
+          borderColor: accentColor(),
+          backgroundColor: accentRgba(0.1),
           borderWidth: 2, tension: 0.4, fill: true,
-          pointBackgroundColor: '#3b82f6',
+          pointBackgroundColor: accentColor(),
           pointRadius: 0, pointHoverRadius: 4,
         },
         {
@@ -119,8 +130,8 @@ const initBarChart = (isDark, textColor, gridColor) => {
       datasets: [{
         label: '错题数',
         data: reversed.map(t => t.count),
-        backgroundColor: colors.map(c => c + '99'),
-        borderColor: colors,
+        backgroundColor: colors.map(c => chartColorWithAlpha(c, 0.6)),
+        borderColor: colors.map(chartColor),
         borderWidth: 1,
         borderRadius: 2,
         barPercentage: 0.85,
@@ -178,16 +189,16 @@ const heatmapCellColor = (val) => {
   const ratio = val / heatmapMax.value
   if (theme.value === 'dark') {
     const alpha = 0.15 + ratio * 0.7
-    return `rgba(99, 102, 241, ${alpha})`
+    return accentRgba(alpha)
   }
   const alpha = 0.08 + ratio * 0.6
-  return `rgba(99, 102, 241, ${alpha})`
+  return accentRgba(alpha)
 }
 
 // ---- 生命周期 ----
 onMounted(() => loadStats())
 
-watch(() => [isDark.value, stats.value], () => {
+watch(() => [isDark.value, stats.value, accentColorId.value], () => {
   if (stats.value) nextTick(initCharts)
 })
 
@@ -254,7 +265,7 @@ onBeforeUnmount(() => {
       <template v-else>
         <!-- 统计卡片 -->
         <div class="mb-8 grid grid-cols-2 gap-4 sm:grid-cols-4">
-          <StatCard label="总错题" icon="fa-solid fa-layer-group" :value="stats?.total_questions || 0" unit="道" color="indigo" />
+          <StatCard label="总错题" icon="fa-solid fa-layer-group" :value="stats?.total_questions || 0" unit="道" color="accent" />
           <StatCard label="待复习" icon="fa-solid fa-clock" :value="stats?.review_stats?.['待复习'] || 0" unit="道" color="blue" />
           <StatCard label="已掌握" icon="fa-solid fa-circle-check" :value="stats?.review_stats?.['已掌握'] || 0" unit="道" color="emerald" />
           <StatCard label="今日掌握" icon="fa-solid fa-bolt" :value="stats?.today_mastered || 0" unit="道" color="slate" />
@@ -270,7 +281,7 @@ onBeforeUnmount(() => {
           </BaseCard>
           <BaseCard>
             <h3 class="mb-4 flex items-center gap-2 text-sm font-black text-slate-700 dark:text-slate-300">
-              <i class="fa-solid fa-ranking-star text-indigo-500"></i> Top 10 易错知识点
+              <i class="fa-solid fa-ranking-star accent-text"></i> Top 10 易错知识点
             </h3>
             <div v-if="stats?.tag_stats?.length" class="relative h-[240px] w-full"><canvas ref="barCanvas"></canvas></div>
             <div v-else class="flex h-[240px] items-center justify-center text-sm text-slate-400">暂无标签数据</div>
@@ -305,7 +316,7 @@ onBeforeUnmount(() => {
                       <div
                         class="mx-auto flex h-8 w-full min-w-[40px] items-center justify-center rounded-lg font-bold"
                         :style="{ backgroundColor: heatmapCellColor(heatmapData.data[ri]?.[ci] || 0) }"
-                        :class="heatmapData.data[ri]?.[ci] ? 'text-indigo-700 dark:text-indigo-200' : 'text-slate-300 dark:text-slate-600'"
+                        :class="heatmapData.data[ri]?.[ci] ? 'accent-text' : 'text-slate-300 dark:text-slate-600'"
                       >{{ heatmapData.data[ri]?.[ci] || 0 }}</div>
                     </td>
                   </tr>

--- a/frontend/src/views/app/ErrorBankView.vue
+++ b/frontend/src/views/app/ErrorBankView.vue
@@ -341,14 +341,14 @@ onBeforeUnmount(() => {
             <i
               class="fa-solid fa-magnifying-glass pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-xs text-gray-400 dark:text-[#62666d] transition-colors"></i>
             <input v-model="filters.keyword" type="text" placeholder="搜索题目..."
-              class="h-8 w-52 rounded-md border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.02] pl-8 pr-3 text-xs font-medium text-gray-900 dark:text-[#f7f8f8] placeholder-gray-400 dark:placeholder-[#62666d] outline-none transition-colors hover:border-gray-300 dark:hover:border-white/[0.12] focus:border-indigo-500 dark:focus:border-white/[0.15]" />
+              class="h-8 w-52 rounded-md border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.02] pl-8 pr-3 text-xs font-medium text-gray-900 dark:text-[#f7f8f8] placeholder-gray-400 dark:placeholder-[#62666d] outline-none transition-colors hover:border-gray-300 dark:hover:border-white/[0.12] focus:border-[rgb(var(--accent-rgb)/0.4)] dark:focus:border-[rgb(var(--accent-rgb)/0.4)]" />
           </div>
 
           <!-- 操作按钮（推到右侧） -->
           <div class="ml-auto flex items-center gap-1 relative">
             <button @click.stop="toggleFilterPanel"
               class="flex h-7 w-7 items-center justify-center rounded-md border transition-colors"
-              :class="filterPanelOpen ? 'bg-indigo-50 dark:bg-white/[0.08] text-indigo-600 dark:text-[#f7f8f8] border-indigo-200 dark:border-white/[0.12]' : 'border-gray-200 dark:border-white/[0.06] bg-white dark:bg-white/[0.03] text-gray-500 dark:text-[#8a8f98] hover:bg-gray-50 dark:hover:bg-white/[0.06] hover:text-gray-700 dark:hover:text-[#d0d6e0]'"
+              :class="filterPanelOpen ? 'accent-bg-soft accent-text accent-border' : 'border-gray-200 dark:border-white/[0.06] bg-white dark:bg-white/[0.03] text-gray-500 dark:text-[#8a8f98] hover:bg-gray-50 dark:hover:bg-white/[0.06] hover:text-gray-700 dark:hover:text-[#d0d6e0]'"
               title="筛选设置">
               <i class="fa-solid fa-sliders text-xs"></i>
             </button>
@@ -359,7 +359,7 @@ onBeforeUnmount(() => {
 
             <button @click="toggleSelectMode"
               class="flex h-7 w-7 items-center justify-center rounded-md border transition-colors"
-              :class="selectMode ? 'bg-indigo-50 dark:bg-white/[0.08] text-indigo-600 dark:text-[#f7f8f8] border-indigo-200 dark:border-white/[0.12]' : 'border-gray-200 dark:border-white/[0.06] bg-white dark:bg-white/[0.03] text-gray-500 dark:text-[#8a8f98] hover:bg-gray-50 dark:hover:bg-white/[0.06] hover:text-gray-700 dark:hover:text-[#d0d6e0]'"
+              :class="selectMode ? 'accent-bg-soft accent-text accent-border' : 'border-gray-200 dark:border-white/[0.06] bg-white dark:bg-white/[0.03] text-gray-500 dark:text-[#8a8f98] hover:bg-gray-50 dark:hover:bg-white/[0.06] hover:text-gray-700 dark:hover:text-[#d0d6e0]'"
               title="导出题目">
               <i class="fa-solid fa-file-export text-xs"></i>
             </button>
@@ -434,7 +434,7 @@ onBeforeUnmount(() => {
                         <i class="fa-solid fa-note-sticky text-xs"></i>记笔记
                       </button>
                       <button @click.stop="openChat(question); hoverMenuId = null"
-                        class="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold text-slate-600 transition-all hover:bg-indigo-500/10 hover:text-indigo-600 dark:text-slate-300 dark:hover:bg-indigo-500/20 dark:hover:text-indigo-400">
+                        class="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold text-slate-600 transition-all hover:bg-[rgb(var(--accent-rgb)/0.12)] hover:text-[rgb(var(--accent-rgb))] dark:text-slate-300">
                         <i class="fa-solid fa-wand-magic-sparkles text-xs"></i>AI 辅导
                       </button>
                       <div class="mx-2 my-1.5 border-t border-slate-100 dark:border-white/5"></div>
@@ -473,7 +473,7 @@ onBeforeUnmount(() => {
             <template v-for="(p, i) in pageButtons" :key="i">
               <span v-if="p === '...'" class="flex w-8 justify-center font-bold text-slate-400">...</span>
               <button v-else @click="goPage(p)" class="h-9 min-w-[36px] rounded-xl text-sm font-bold transition-all"
-                :class="p === page ? 'bg-blue-600 text-white shadow-sm dark:bg-indigo-600' : 'text-slate-500 hover:bg-white dark:text-slate-400 dark:hover:bg-white/10'">
+                :class="p === page ? 'accent-bg text-white shadow-sm' : 'text-slate-500 hover:bg-white dark:text-slate-400 dark:hover:bg-white/10'">
                 {{ p }}
               </button>
             </template>

--- a/frontend/src/views/app/NoteView.vue
+++ b/frontend/src/views/app/NoteView.vue
@@ -244,14 +244,14 @@ function goToWorkspace() {
               <i
                 class="fa-solid fa-magnifying-glass pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-xs text-gray-400 dark:text-[#62666d] transition-colors"></i>
               <input v-model="filters.keyword" type="text" placeholder="搜索笔记..."
-                class="h-8 w-52 rounded-md border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.02] pl-8 pr-3 text-xs font-medium text-gray-900 dark:text-[#f7f8f8] placeholder-gray-400 dark:placeholder-[#62666d] outline-none transition-colors hover:border-gray-300 dark:hover:border-white/[0.12] focus:border-indigo-500 dark:focus:border-white/[0.15]" />
+                class="h-8 w-52 rounded-md border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.02] pl-8 pr-3 text-xs font-medium text-gray-900 dark:text-[#f7f8f8] placeholder-gray-400 dark:placeholder-[#62666d] outline-none transition-colors hover:border-gray-300 dark:hover:border-white/[0.12] focus:border-[rgb(var(--accent-rgb)/0.4)] dark:focus:border-[rgb(var(--accent-rgb)/0.4)]" />
             </div>
 
             <!-- 操作按钮 -->
             <div class="ml-auto flex items-center gap-1 relative">
               <button @click.stop="toggleFilterPanel"
                 class="flex h-7 w-7 items-center justify-center rounded-md border transition-colors"
-                :class="filterPanelOpen ? 'bg-indigo-50 dark:bg-white/[0.08] text-indigo-600 dark:text-[#f7f8f8] border-indigo-200 dark:border-white/[0.12]' : 'border-gray-200 dark:border-white/[0.06] bg-white dark:bg-white/[0.03] text-gray-500 dark:text-[#8a8f98] hover:bg-gray-50 dark:hover:bg-white/[0.06] hover:text-gray-700 dark:hover:text-[#d0d6e0]'"
+                :class="filterPanelOpen ? 'accent-bg-soft accent-text accent-border' : 'border-gray-200 dark:border-white/[0.06] bg-white dark:bg-white/[0.03] text-gray-500 dark:text-[#8a8f98] hover:bg-gray-50 dark:hover:bg-white/[0.06] hover:text-gray-700 dark:hover:text-[#d0d6e0]'"
                 title="筛选设置">
                 <i class="fa-solid fa-sliders text-xs"></i>
               </button>
@@ -268,7 +268,7 @@ function goToWorkspace() {
           <!-- 进度条 -->
           <div v-if="creating" class="mb-4">
             <div class="h-1 rounded-full bg-gray-200 dark:bg-white/[0.06]">
-              <div class="h-full rounded-full bg-indigo-500 dark:bg-[rgb(129,115,223)] transition-all duration-300"
+              <div class="h-full rounded-full accent-bg transition-all duration-300"
                 :style="{ width: createProgress + '%' }"></div>
             </div>
             <p class="mt-1 text-xs text-gray-500 dark:text-[#62666d]">OCR 识别 + AI 整理中... {{ createProgress }}%</p>
@@ -293,7 +293,7 @@ function goToWorkspace() {
                 </p>
                 <div class="flex flex-wrap items-center gap-2">
                   <span v-if="note.subject"
-                    class="rounded-md bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-600 dark:bg-[rgb(129,115,223)]/10 dark:text-[rgb(145,132,235)]">{{
+                    class="rounded-md accent-bg-soft px-2 py-0.5 text-xs font-medium accent-text">{{
                       note.subject }}</span>
                   <span v-for="tag in (note.knowledge_tags || []).slice(0, 3)" :key="tag"
                     class="rounded-md border border-gray-200 px-2 py-0.5 text-xs text-gray-500 dark:border-white/[0.06] dark:text-[#8a8f98]">{{
@@ -308,7 +308,7 @@ function goToWorkspace() {
             <div v-if="totalPages > 1" class="mt-8 flex justify-center gap-2">
               <button v-for="p in totalPages" :key="p" @click="page = p"
                 class="size-8 rounded-md text-xs font-medium transition-all"
-                :class="p === page ? 'bg-indigo-500 text-white shadow-sm dark:brand-btn dark:text-[#f7f8f8]' : 'border border-gray-200 bg-white text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:border-white/[0.06] dark:bg-transparent dark:text-[#8a8f98] dark:hover:bg-white/[0.04]'">
+                :class="p === page ? 'accent-bg text-white shadow-sm' : 'border border-gray-200 bg-white text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:border-white/[0.06] dark:bg-transparent dark:text-[#8a8f98] dark:hover:bg-white/[0.04]'">
                 {{ p }}
               </button>
             </div>

--- a/frontend/src/views/app/ReviewView.vue
+++ b/frontend/src/views/app/ReviewView.vue
@@ -195,9 +195,9 @@ onMounted(() => { loadAll() })
         <!-- 操作栏 -->
         <div class="mb-6 flex flex-wrap items-center justify-between gap-4">
           <h3 class="flex items-center gap-2 text-base font-black text-slate-900 dark:text-white">
-            <i class="fa-solid fa-list-check text-indigo-500"></i> 题目列表
+            <i class="fa-solid fa-list-check accent-text"></i> 题目列表
             <span v-if="reviewTotal"
-              class="ml-2 rounded-full bg-indigo-100 px-2 py-1 text-xs font-bold text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-400">{{
+              class="ml-2 rounded-full accent-bg-soft px-2 py-1 text-xs font-bold accent-text">{{
               reviewTotal }}</span>
           </h3>
           <div v-if="reviewItems.length" class="flex items-center gap-2">
@@ -212,7 +212,7 @@ onMounted(() => { loadAll() })
                 全选
               </button>
               <button @click="startAiAnalysis" :disabled="!selectedIds.size || aiAnalyzing"
-                class="rounded-xl bg-gradient-to-r from-indigo-500 to-blue-600 px-4 py-2 text-xs font-bold text-white shadow-sm shadow-indigo-500/20 transition-all disabled:opacity-50 disabled:cursor-not-allowed">
+                class="rounded-xl accent-gradient-bg px-4 py-2 text-xs font-bold text-white shadow-sm transition-all disabled:opacity-50 disabled:cursor-not-allowed">
                 <i class="fa-solid fa-wand-magic-sparkles mr-1" :class="{ 'animate-spin': aiAnalyzing }"></i>
                 AI 错题分析 <span v-if="selectedIds.size">({{ selectedIds.size }})</span>
               </button>
@@ -266,7 +266,7 @@ onMounted(() => { loadAll() })
                     class="rounded-lg px-3 py-1 text-xs font-bold text-slate-500 hover:text-slate-700 dark:text-slate-400">取消</button>
                   <button @click="saveInlineEdit" :disabled="answerEditSaving"
                     class="rounded-lg px-3 py-1 text-xs font-bold text-white disabled:opacity-50"
-                    :class="answerEditField === 'answer' ? 'bg-emerald-500 hover:bg-emerald-600' : 'bg-blue-500 hover:bg-blue-600'">
+                    :class="answerEditField === 'answer' ? 'bg-emerald-500 hover:bg-emerald-600' : 'accent-bg hover:bg-[rgb(var(--accent-hover-rgb))]'">
                     {{ answerEditSaving ? '保存中…' : '保存' }}
                   </button>
                 </div>
@@ -275,7 +275,7 @@ onMounted(() => { loadAll() })
             <template #actions>
               <div class="group/tip relative">
                 <button @click="quickMarkStatus(q, '复习中')"
-                  class="rounded-xl border border-indigo-200 bg-indigo-50 px-4 py-2 text-xs font-bold text-indigo-600 transition-all hover:bg-indigo-100 dark:border-indigo-500/20 dark:bg-indigo-500/10 dark:text-indigo-400">
+                  class="rounded-xl border accent-border accent-bg-soft px-4 py-2 text-xs font-bold accent-text transition-all hover:bg-[rgb(var(--accent-rgb)/0.16)]">
                   <i class="fa-solid fa-spinner mr-1"></i>复习中
                 </button>
                 <span

--- a/frontend/src/views/app/SettingsView.vue
+++ b/frontend/src/views/app/SettingsView.vue
@@ -5,6 +5,7 @@ import { genId } from '@/utils.js'
 import { useAuth } from '@/composables/useAuth.js'
 import { useToast } from '@/composables/useToast.js'
 import { useSystemStatus } from '@/composables/useSystemStatus.js'
+import { useTheme } from '@/composables/useTheme.js'
 import ContentPanel from '@/components/workspace/ContentPanel.vue'
 import ProviderDialog from '@/components/settings/ProviderDialog.vue'
 import ProviderSection from '@/components/settings/ProviderSection.vue'
@@ -21,6 +22,7 @@ const props = defineProps({
 const { currentUser, quota, setCurrentUser } = useAuth()
 const { pushToast } = useToast()
 const { doFetchStatus, selectedLlmOptionId, selectedLlmOption, modelOptionsData } = useSystemStatus()
+const { isDark, setTheme, themeColors, accentColorId, setAccentColor } = useTheme()
 
 // 计算当前设置页各分类应显示的“使用中” ID
 const currentActivePersonalLlmProviderId = computed(() => {
@@ -44,14 +46,17 @@ const quotaResetText = computed(() => {
 const isProfileSection = computed(() => props.section === 'profile')
 const isQuotaSection = computed(() => props.section === 'quota')
 const isApiSection = computed(() => props.section === 'api')
+const isAppearanceSection = computed(() => props.section === 'appearance')
 const settingsPageTitle = computed(() => {
   if (isApiSection.value) return 'API 设置'
   if (isQuotaSection.value) return '免费额度'
+  if (isAppearanceSection.value) return '外观设置'
   return '用户资料设置'
 })
 const settingsPageDescription = computed(() => {
   if (isApiSection.value) return '集中管理 AI 与 OCR provider 的接口配置。'
   if (isQuotaSection.value) return '查看系统托管 AI / OCR 服务的免费体验额度与每日重置时间。'
+  if (isAppearanceSection.value) return '切换明暗模式和主题强调色，界面会立即应用。'
   return '配置显示名称、昵称与头像，侧边栏会立即同步展示。'
 })
 const pageTitle = computed(() => isApiSection.value ? 'API 设置' : '用户资料设置')
@@ -75,6 +80,22 @@ const avatarInputRef = ref(null)
 const selectedAvatarFile = ref(null)
 const avatarPreviewUrl = ref('')
 const avatarUploadXhr = ref(null)
+
+const appearanceModeOptions = [
+  { id: 'dark', label: '深色', icon: 'fa-moon' },
+  { id: 'light', label: '浅色', icon: 'fa-sun' },
+]
+
+const currentAppearanceMode = computed(() => isDark.value ? 'dark' : 'light')
+
+const setAppearanceMode = (mode) => {
+  setTheme(mode === 'dark')
+}
+
+const selectAccentColor = (colorId) => {
+  setAccentColor(colorId)
+  pushToast('success', '主题颜色已更新')
+}
 
 // ---------- 修改邮箱弹窗逻辑 ----------
 const isEmailDialogOpen = ref(false)
@@ -773,6 +794,72 @@ watch(
           <div class="h-32 w-full rounded-2xl bg-gray-200 dark:bg-white/[0.08]"></div>
         </div>
 
+        <div v-else-if="isAppearanceSection" class="mx-auto max-w-2xl pb-12">
+          <BaseListGroup title="界面主题" description="外观偏好保存在当前浏览器中，刷新页面后仍会保持。">
+            <BaseListItem label="显示模式" description="选择浅色或深色界面">
+              <div class="grid grid-cols-2 gap-1 rounded-lg border border-gray-200 bg-gray-50 p-1 dark:border-white/[0.08] dark:bg-white/[0.03]">
+                <button
+                  v-for="mode in appearanceModeOptions"
+                  :key="mode.id"
+                  type="button"
+                  class="inline-flex h-8 items-center justify-center gap-1.5 rounded-md text-xs font-medium transition-colors"
+                  :class="currentAppearanceMode === mode.id
+                    ? 'bg-white text-gray-900 shadow-sm dark:bg-white/[0.1] dark:text-[#f7f8f8]'
+                    : 'text-gray-500 hover:text-gray-700 dark:text-[#8a8f98] dark:hover:text-[#d0d6e0]'"
+                  @click="setAppearanceMode(mode.id)"
+                >
+                  <i :class="['fa-solid', mode.icon, 'text-[11px]']"></i>
+                  <span>{{ mode.label }}</span>
+                </button>
+              </div>
+            </BaseListItem>
+          </BaseListGroup>
+
+          <BaseListGroup title="主题颜色" description="用于主按钮、选中状态和全局强调色。后续新增组件时可直接复用 CSS 变量。">
+            <li class="grid gap-3 p-4 sm:grid-cols-2">
+              <button
+                v-for="color in themeColors"
+                :key="color.id"
+                type="button"
+                class="group flex min-h-[68px] items-center justify-between rounded-lg border px-3 text-left transition-colors"
+                :class="accentColorId === color.id
+                  ? 'border-[rgb(var(--accent-rgb)/0.45)] bg-[rgb(var(--accent-rgb)/0.08)]'
+                  : 'border-gray-200 bg-white hover:bg-gray-50 dark:border-white/[0.08] dark:bg-white/[0.02] dark:hover:bg-white/[0.05]'"
+                @click="selectAccentColor(color.id)"
+              >
+                <span class="flex min-w-0 items-center gap-3">
+                  <span
+                    class="h-8 w-8 shrink-0 rounded-full shadow-sm ring-1 ring-black/10 dark:ring-white/10"
+                    :style="{ background: `linear-gradient(135deg, rgb(${color.hoverRgb.replaceAll(' ', ', ')}), rgb(${color.strongRgb.replaceAll(' ', ', ')}))` }"
+                  ></span>
+                  <span class="min-w-0">
+                    <span class="block truncate text-sm font-semibold text-gray-900 dark:text-[#f7f8f8]">{{ color.label }}</span>
+                    <span class="block truncate text-xs text-gray-500 dark:text-[#8a8f98]">{{ color.name }}</span>
+                  </span>
+                </span>
+                <i
+                  class="fa-solid fa-check text-sm transition-opacity"
+                  :class="accentColorId === color.id ? 'opacity-100 accent-text' : 'opacity-0'"
+                ></i>
+              </button>
+            </li>
+          </BaseListGroup>
+
+          <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-white/[0.08] dark:bg-[#1b1b1d]">
+            <div class="flex items-center justify-between border-b border-gray-100 px-4 py-3 dark:border-white/[0.04]">
+              <div>
+                <h3 class="text-sm font-semibold text-gray-900 dark:text-[#f7f8f8]">预览</h3>
+                <p class="mt-1 text-xs text-gray-500 dark:text-[#62666d]">当前强调色会驱动这些公共样式。</p>
+              </div>
+              <span class="rounded-full px-2.5 py-1 text-xs font-medium accent-soft">Accent</span>
+            </div>
+            <div class="grid gap-3 p-4 sm:grid-cols-2">
+              <BaseButton variant="primary" class="!h-10">主按钮</BaseButton>
+              <button type="button" class="filter-pill filter-pill--active justify-center">选中筛选</button>
+            </div>
+          </section>
+        </div>
+
         <div v-else-if="isProfileSection || isQuotaSection" class="space-y-6">
           <section v-if="isQuotaSection"
             class="rounded-2xl border border-white/[0.06] border-t-white/[0.15] border-b-white/[0.03] bg-white/[0.02] p-6 backdrop-blur-xl">
@@ -864,7 +951,7 @@ watch(
                   class="h-full w-full object-cover transition-opacity group-hover:opacity-80" />
                 <div v-else
                   class="relative flex h-full w-full items-center justify-center text-3xl font-bold text-white transition-opacity group-hover:opacity-80"
-                  style="background: linear-gradient(to bottom, rgba(129,115,223,0.9), rgba(99,87,199,0.9));">
+                  style="background: linear-gradient(to bottom, rgb(var(--accent-rgb) / 0.9), rgb(var(--accent-strong-rgb) / 0.9));">
                   <span class="absolute inset-0 pointer-events-none"
                     style="background-image: linear-gradient(to right, rgba(255,255,255,0.06) 1px, transparent 1px), linear-gradient(to bottom, rgba(255,255,255,0.06) 1px, transparent 1px); background-size: 8px 8px; mask-image: radial-gradient(ellipse at center, black 30%, transparent 80%); -webkit-mask-image: radial-gradient(ellipse at center, black 30%, transparent 80%);"></span>
                   <span class="relative z-10">{{ userPreviewInitial }}</span>

--- a/frontend/src/views/app/SplitHistoryView.vue
+++ b/frontend/src/views/app/SplitHistoryView.vue
@@ -167,7 +167,7 @@ defineExpose({ refresh: loadRecords })
 
         <!-- 加载状态 -->
         <div v-if="loading && !records.length" class="flex items-center justify-center py-10">
-          <div class="h-5 w-5 animate-spin rounded-full border-2 border-gray-200 dark:border-white/10 border-t-[rgb(129,115,223)] transition-colors"></div>
+          <div class="h-5 w-5 animate-spin rounded-full border-2 border-gray-200 dark:border-white/10 border-t-[rgb(var(--accent-rgb))] transition-colors"></div>
         </div>
 
         <!-- 空状态 -->
@@ -188,7 +188,7 @@ defineExpose({ refresh: loadRecords })
             <!-- 一行：科目 + 时间 + 题数 -->
             <div class="flex items-center justify-between mb-1">
               <span class="text-sm font-medium text-gray-900 dark:text-[#f7f8f8] truncate transition-colors">{{ r.subject || '未识别' }}</span>
-              <span class="text-xs tabular-nums text-[rgb(129,115,223)]">{{ r.question_count }} 题</span>
+              <span class="text-xs tabular-nums accent-text">{{ r.question_count }} 题</span>
             </div>
             <!-- 二行：文件数 + 时间 -->
             <div class="flex items-center gap-2 text-xs text-gray-500 dark:text-[#62666d] transition-colors">
@@ -209,7 +209,7 @@ defineExpose({ refresh: loadRecords })
               <div v-if="activeRecord?.id === r.id" class="overflow-hidden border-t border-slate-200/40 dark:border-white/5">
                 <!-- 加载中 -->
                 <div v-if="detailLoading" class="flex items-center justify-center py-10">
-                  <div class="h-7 w-7 animate-spin rounded-full border-[3px] border-slate-200 border-t-violet-500 dark:border-slate-700 dark:border-t-violet-400"></div>
+                  <div class="h-7 w-7 animate-spin rounded-full border-[3px] border-slate-200 border-t-[rgb(var(--accent-rgb))] dark:border-slate-700"></div>
                 </div>
 
                 <!-- 题目列表 -->
@@ -226,13 +226,13 @@ defineExpose({ refresh: loadRecords })
                         @click.stop="deselectAllQuestions"
                         class="rounded-lg border border-slate-200/60 bg-white/60 px-3 py-1.5 text-xs font-bold text-slate-500 transition-all hover:bg-white dark:border-white/10 dark:bg-white/5 dark:text-slate-400 dark:hover:bg-white/10"
                       >取消选择</button>
-                      <span v-if="selectedIds.size > 0" class="ml-1 text-xs font-semibold text-violet-600 dark:text-violet-400">
+                      <span v-if="selectedIds.size > 0" class="ml-1 text-xs font-semibold accent-text">
                         已选 {{ selectedIds.size }} / {{ activeQuestions.length }}
                       </span>
                     </div>
                     <button
                       @click.stop="loadToWorkspace"
-                      class="inline-flex items-center gap-2 rounded-xl bg-violet-600 px-4 py-2 text-xs font-bold text-white shadow-sm transition-all hover:bg-violet-700 hover:shadow-md dark:bg-violet-500 dark:hover:bg-violet-600"
+                      class="inline-flex items-center gap-2 rounded-xl accent-bg px-4 py-2 text-xs font-bold text-white shadow-sm transition-all hover:shadow-md"
                     >
                       <i class="fa-solid fa-arrow-right-to-bracket"></i>
                       {{ selectedIds.size > 0 ? `加载选中 (${selectedIds.size})` : '全部加载到工作台' }}
@@ -247,15 +247,15 @@ defineExpose({ refresh: loadRecords })
                       @click.stop="toggleSelect(q.uid)"
                       class="cursor-pointer rounded-xl border p-3.5 transition-all duration-200"
                       :class="selectedIds.has(q.uid)
-                        ? 'border-violet-400/60 bg-violet-50/60 ring-1 ring-violet-400/30 dark:border-violet-500/40 dark:bg-violet-500/[0.08] dark:ring-violet-500/20'
-                        : 'border-slate-200/50 bg-white/50 hover:border-violet-300/40 hover:bg-white/80 dark:border-white/[0.05] dark:bg-white/[0.02] dark:hover:border-violet-500/20'"
+                        ? 'accent-border accent-bg-muted ring-1 ring-[rgb(var(--accent-rgb)/0.3)]'
+                        : 'border-slate-200/50 bg-white/50 hover:border-[rgb(var(--accent-rgb)/0.35)] hover:bg-white/80 dark:border-white/[0.05] dark:bg-white/[0.02] dark:hover:border-[rgb(var(--accent-rgb)/0.25)]'"
                     >
                       <div class="mb-2 flex items-center gap-2">
                         <!-- 选中指示 -->
                         <div
                           class="flex h-5 w-5 shrink-0 items-center justify-center rounded-md border text-[10px] transition-colors"
                           :class="selectedIds.has(q.uid)
-                            ? 'border-violet-500 bg-violet-500 text-white dark:border-violet-400 dark:bg-violet-500'
+                            ? 'border-[rgb(var(--accent-rgb))] accent-bg text-white'
                             : 'border-slate-300 dark:border-white/15'"
                         >
                           <i v-if="selectedIds.has(q.uid)" class="fa-solid fa-check"></i>
@@ -267,7 +267,7 @@ defineExpose({ refresh: loadRecords })
                           <i class="fa-solid mr-0.5 text-[8px]" :class="questionTypeIcon(q.question_type)"></i>
                           {{ q.question_type }}
                         </span>
-                        <span v-if="q.has_formula" class="rounded-md bg-purple-100/80 px-1.5 py-0.5 text-[10px] font-bold text-purple-600 dark:bg-purple-500/15 dark:text-purple-300">
+                        <span v-if="q.has_formula" class="rounded-md accent-bg-soft px-1.5 py-0.5 text-[10px] font-bold accent-text">
                           <i class="fa-solid fa-square-root-variable text-[8px]"></i>
                         </span>
                         <span v-if="q.has_image" class="rounded-md bg-cyan-100/80 px-1.5 py-0.5 text-[10px] font-bold text-cyan-600 dark:bg-cyan-500/15 dark:text-cyan-300">

--- a/frontend/src/views/app/WorkspaceView.vue
+++ b/frontend/src/views/app/WorkspaceView.vue
@@ -257,7 +257,7 @@ onBeforeUnmount(() => {
               <i class="fa-solid fa-arrows-rotate text-[10px]"></i> 重新擦除
             </button>
             <button @click="doOcr"
-              class="inline-flex items-center gap-1.5 rounded-md bg-[rgb(129,115,223)] px-3 py-1.5 text-xs font-medium text-white hover:bg-[rgb(145,132,235)] transition-colors">
+              class="inline-flex items-center gap-1.5 rounded-md accent-bg px-3 py-1.5 text-xs font-medium text-white hover:bg-[rgb(var(--accent-hover-rgb))] transition-colors">
               <i class="fa-solid fa-check text-[10px]"></i> 确认，开始 OCR
             </button>
           </template>
@@ -267,7 +267,7 @@ onBeforeUnmount(() => {
               <i class="fa-solid fa-arrows-rotate text-[10px]"></i> 重新识别
             </button>
             <button @click="doSplit"
-              class="inline-flex items-center gap-1.5 rounded-md bg-[rgb(129,115,223)] px-3 py-1.5 text-xs font-medium text-white hover:bg-[rgb(145,132,235)] transition-colors">
+              class="inline-flex items-center gap-1.5 rounded-md accent-bg px-3 py-1.5 text-xs font-medium text-white hover:bg-[rgb(var(--accent-hover-rgb))] transition-colors">
               <i class="fa-solid fa-check text-[10px]"></i> 确认并分割
             </button>
           </template>

--- a/frontend/src/views/auth/AuthLayout.vue
+++ b/frontend/src/views/auth/AuthLayout.vue
@@ -78,28 +78,28 @@ onMounted(() => {
   <div class="min-h-screen flex bg-slate-50 dark:bg-[#0A0A0F] transition-colors duration-200">
 
     <!-- 左侧品牌区（大屏显示） -->
-    <div ref="brandRef" class="hidden lg:flex flex-col justify-between w-[52%] relative overflow-hidden p-12 bg-gradient-to-br from-indigo-50 to-white dark:from-[#12121a] dark:to-[#0A0A0F] transition-colors duration-200">
+    <div ref="brandRef" class="hidden lg:flex flex-col justify-between w-[52%] relative overflow-hidden p-12 bg-gradient-to-br from-[rgb(var(--accent-rgb)/0.08)] to-white dark:from-[#12121a] dark:to-[#0A0A0F] transition-colors duration-200">
       <!-- 底层：紫色曲线（暗态） -->
       <svg class="absolute inset-0 w-full h-full pointer-events-none" viewBox="0 0 600 800" preserveAspectRatio="none" fill="none">
-        <path d="M-50,250 C120,400 280,100 420,280 C560,460 600,180 700,350" stroke="rgba(129,115,223,0.12)" class="dark:stroke-indigo-400/10 stroke-indigo-600/10" stroke-width="2.5" />
-        <path d="M-80,500 C80,650 240,340 400,520 C560,700 620,400 720,580" stroke="rgba(129,115,223,0.08)" class="dark:stroke-indigo-400/10 stroke-indigo-600/10" stroke-width="2" />
+        <path d="M-50,250 C120,400 280,100 420,280 C560,460 600,180 700,350" stroke="rgb(var(--accent-rgb) / 0.12)" stroke-width="2.5" />
+        <path d="M-80,500 C80,650 240,340 400,520 C560,700 620,400 720,580" stroke="rgb(var(--accent-rgb) / 0.08)" stroke-width="2" />
       </svg>
       <!-- 亮层：鼠标跟随发光的紫色曲线（通过 mask 只显示鼠标附近） -->
       <div class="auth-glow-layer absolute inset-0 pointer-events-none">
         <svg class="w-full h-full" viewBox="0 0 600 800" preserveAspectRatio="none" fill="none">
-          <path d="M-50,250 C120,400 280,100 420,280 C560,460 600,180 700,350" stroke="rgba(151,137,222,0.9)" stroke-width="3" style="filter: drop-shadow(0 0 14px rgba(129,115,223,0.8)) drop-shadow(0 0 40px rgba(129,115,223,0.4));" />
-          <path d="M-80,500 C80,650 240,340 400,520 C560,700 620,400 720,580" stroke="rgba(151,137,222,0.7)" stroke-width="2.5" style="filter: drop-shadow(0 0 12px rgba(129,115,223,0.7)) drop-shadow(0 0 30px rgba(129,115,223,0.3));" />
+          <path d="M-50,250 C120,400 280,100 420,280 C560,460 600,180 700,350" stroke="rgb(var(--accent-hover-rgb) / 0.9)" stroke-width="3" class="auth-line-glow-strong" />
+          <path d="M-80,500 C80,650 240,340 400,520 C560,700 620,400 720,580" stroke="rgb(var(--accent-hover-rgb) / 0.7)" stroke-width="2.5" class="auth-line-glow-soft" />
         </svg>
       </div>
       <!-- 底部紫色光晕 -->
-      <div class="absolute bottom-0 left-1/2 -translate-x-1/2 w-[80%] h-[200px] pointer-events-none rounded-full bg-indigo-500/10 dark:bg-indigo-500/[0.08] blur-[80px] transition-colors"></div>
+      <div class="absolute bottom-0 left-1/2 -translate-x-1/2 w-[80%] h-[200px] pointer-events-none rounded-full bg-[rgb(var(--accent-rgb)/0.1)] dark:bg-[rgb(var(--accent-rgb)/0.08)] blur-[80px] transition-colors"></div>
 
       <!-- 不规则星星 -->
       <div class="absolute inset-0 pointer-events-none">
         <div
           v-for="(s, i) in stars"
           :key="i"
-          class="absolute rounded-full bg-indigo-400 dark:bg-white star-twinkle transition-colors"
+          class="absolute rounded-full bg-[rgb(var(--accent-hover-rgb))] dark:bg-white star-twinkle transition-colors"
           :style="{
             left: s.left + '%',
             top: s.top + '%',
@@ -127,11 +127,11 @@ onMounted(() => {
         <h2 class="text-4xl font-semibold text-gray-900 dark:text-white leading-tight mb-4 tracking-tight transition-colors">
           重塑错题整理<br />
           <span class="text-transparent bg-clip-text animate-gradient-sweep dark:hidden" style="
-            background-image: linear-gradient(to right, rgb(151, 137, 222) 0%, rgb(151, 137, 222) 20%, rgb(79, 70, 229) 50%, rgb(151, 137, 222) 80%, rgb(151, 137, 222) 100%);
+            background-image: linear-gradient(to right, rgb(var(--accent-hover-rgb)) 0%, rgb(var(--accent-hover-rgb)) 20%, rgb(var(--accent-strong-rgb)) 50%, rgb(var(--accent-hover-rgb)) 80%, rgb(var(--accent-hover-rgb)) 100%);
             background-size: 200% auto;
           ">一键生成知识图谱</span>
           <span class="text-transparent bg-clip-text animate-gradient-sweep hidden dark:inline" style="
-            background-image: linear-gradient(to right, rgb(151, 137, 222) 0%, rgb(151, 137, 222) 20%, rgb(255, 255, 255) 50%, rgb(151, 137, 222) 80%, rgb(151, 137, 222) 100%);
+            background-image: linear-gradient(to right, rgb(var(--accent-hover-rgb)) 0%, rgb(var(--accent-hover-rgb)) 20%, rgb(255, 255, 255) 50%, rgb(var(--accent-hover-rgb)) 80%, rgb(var(--accent-hover-rgb)) 100%);
             background-size: 200% auto;
           ">一键生成知识图谱</span>
         </h2>
@@ -148,7 +148,7 @@ onMounted(() => {
               <div class="absolute inset-0 bg-gray-200 dark:bg-white/[0.08] rounded-xl transition-colors"></div>
               <!-- 鼠标跟随边框高光 -->
               <div class="pointer-events-none absolute inset-0"
-                style="background: radial-gradient(80px circle at var(--ix, -500px) var(--iy, -500px), rgba(151,137,222,0.7), transparent 50%);"></div>
+                style="background: radial-gradient(80px circle at var(--ix, -500px) var(--iy, -500px), rgb(var(--accent-hover-rgb) / 0.7), transparent 50%);"></div>
               <!-- 图标内部 -->
               <div class="relative h-full w-full bg-white dark:bg-[#15151e] rounded-[11px] flex items-center justify-center transition-colors">
                 <!-- 白色底层图标 -->
@@ -157,7 +157,7 @@ onMounted(() => {
                 <div class="absolute inset-0 flex items-center justify-center"
                   style="mask-image: radial-gradient(80px circle at var(--ix, -500px) var(--iy, -500px), black 0%, transparent 100%);
                          -webkit-mask-image: radial-gradient(80px circle at var(--ix, -500px) var(--iy, -500px), black 0%, transparent 100%);">
-                  <i :class="`fas ${f.icon} text-xs text-[#9789de] drop-shadow-[0_0_8px_rgba(151,137,222,0.8)]`"></i>
+                  <i :class="`fas ${f.icon} text-xs accent-text auth-feature-icon-glow`"></i>
                 </div>
               </div>
             </div>
@@ -274,6 +274,22 @@ input:-webkit-autofill:focus {
 }
 
 /* 紫-白-紫渐变扫光 */
+.auth-line-glow-strong {
+  filter:
+    drop-shadow(0 0 14px rgb(var(--accent-rgb) / 0.8))
+    drop-shadow(0 0 40px rgb(var(--accent-rgb) / 0.4));
+}
+
+.auth-line-glow-soft {
+  filter:
+    drop-shadow(0 0 12px rgb(var(--accent-rgb) / 0.7))
+    drop-shadow(0 0 30px rgb(var(--accent-rgb) / 0.3));
+}
+
+.auth-feature-icon-glow {
+  filter: drop-shadow(0 0 8px rgb(var(--accent-hover-rgb) / 0.8));
+}
+
 @keyframes gradient-sweep {
   0% { background-position: -100% center; }
   100% { background-position: 100% center; }

--- a/frontend/src/views/auth/LoginView.vue
+++ b/frontend/src/views/auth/LoginView.vue
@@ -60,7 +60,7 @@ async function handleLogin() {
 
     <div class="flex justify-end">
       <button type="button" @click="fpOpen = true"
-        class="text-xs text-gray-500 dark:text-white/40 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
+        class="text-xs text-gray-500 dark:text-white/40 hover:accent-text transition-colors">
         忘记密码？
       </button>
     </div>

--- a/frontend/src/views/home/HomeDemo.vue
+++ b/frontend/src/views/home/HomeDemo.vue
@@ -15,12 +15,10 @@ import BaseButton from '@/components/base/BaseButton.vue'
     <div class="reveal max-w-5xl mx-auto px-4 sm:px-6 relative z-10">
       <div class="text-center mb-12">
         <h2 class="reveal text-3xl font-semibold tracking-tight mb-4">
-          <span class="text-transparent bg-clip-text animate-gradient-sweep dark:hidden" style="
-            background-image: linear-gradient(to right, rgb(151, 137, 222) 0%, rgb(151, 137, 222) 20%, rgb(79, 70, 229) 50%, rgb(151, 137, 222) 80%, rgb(151, 137, 222) 100%);
+          <span class="text-transparent bg-clip-text animate-gradient-sweep home-title-accent" style="
             background-size: 200% auto;
           ">眼见为实的转变</span>
-          <span class="text-transparent bg-clip-text animate-gradient-sweep hidden dark:inline" style="
-            background-image: linear-gradient(to right, rgb(151, 137, 222) 0%, rgb(151, 137, 222) 20%, rgb(255, 255, 255) 50%, rgb(151, 137, 222) 80%, rgb(151, 137, 222) 100%);
+          <span class="hidden" style="
             background-size: 200% auto;
           ">眼见为实的转变</span>
         </h2>
@@ -41,26 +39,26 @@ import BaseButton from '@/components/base/BaseButton.vue'
 
         <!-- 中间箭头 -->
         <div class="hidden lg:flex items-center justify-center w-12">
-          <ArrowRight class="w-5 h-5 text-indigo-500/70 dark:text-indigo-400/50 animate-pulse transition-colors duration-200" />
+          <ArrowRight class="w-5 h-5 accent-text animate-pulse transition-colors duration-200" />
         </div>
         <div class="lg:hidden flex justify-center py-2">
-          <ArrowRight class="w-5 h-5 text-indigo-500/70 dark:text-indigo-400/50 rotate-90 animate-pulse transition-colors duration-200" />
+          <ArrowRight class="w-5 h-5 accent-text rotate-90 animate-pulse transition-colors duration-200" />
         </div>
 
         <!-- 右侧：AI 结果 -->
-        <div class="reveal flex-1 w-full max-w-md bg-indigo-50/50 border border-indigo-100/50 dark:bg-transparent dark:border-none dark:brand-btn p-6 rounded-lg relative overflow-hidden text-left transition-colors duration-200" style="transition-delay: 200ms;">
-          <div class="absolute top-0 right-0 w-32 h-32 bg-indigo-500/20 dark:bg-indigo-500/10 blur-[50px] rounded-full pointer-events-none transition-colors duration-200"></div>
+        <div class="reveal flex-1 w-full max-w-md bg-[rgb(var(--accent-rgb)/0.08)] border accent-border dark:bg-transparent dark:border-none dark:brand-btn p-6 rounded-lg relative overflow-hidden text-left transition-colors duration-200" style="transition-delay: 200ms;">
+          <div class="absolute top-0 right-0 w-32 h-32 bg-[rgb(var(--accent-rgb)/0.2)] dark:bg-[rgb(var(--accent-rgb)/0.1)] blur-[50px] rounded-full pointer-events-none transition-colors duration-200"></div>
           
-          <div class="text-xs font-medium tracking-wide text-indigo-600 dark:text-indigo-400 uppercase flex items-center gap-1.5 mb-4 relative z-10 transition-colors duration-200">
+          <div class="text-xs font-medium tracking-wide accent-text uppercase flex items-center gap-1.5 mb-4 relative z-10 transition-colors duration-200">
             <Sparkles class="w-3 h-3" /> Output / 结构化数据
           </div>
 
-          <div class="bg-white border border-indigo-100/80 shadow-sm dark:bg-[#0A0A0F]/80 dark:border-white/[0.04] dark:shadow-inner p-4 rounded-xl text-gray-700 dark:text-white/70 font-mono text-sm leading-relaxed relative z-10 transition-colors duration-200">
+          <div class="bg-white border accent-border shadow-sm dark:bg-[#0A0A0F]/80 dark:border-white/[0.04] dark:shadow-inner p-4 rounded-xl text-gray-700 dark:text-white/70 font-mono text-sm leading-relaxed relative z-10 transition-colors duration-200">
             <div class="flex gap-2 mb-4">
-              <span class="bg-indigo-50/80 text-indigo-600/80 border border-indigo-100 dark:bg-white/[0.04] dark:text-white/50 px-2 py-0.5 rounded-full text-xs dark:border-white/[0.06] transition-colors duration-200">选择题</span>
-              <span class="bg-indigo-50/80 text-indigo-600/80 border border-indigo-100 dark:bg-white/[0.04] dark:text-white/50 px-2 py-0.5 rounded-full text-xs dark:border-white/[0.06] transition-colors duration-200">三角函数</span>
+              <span class="accent-bg-soft accent-text border accent-border px-2 py-0.5 rounded-full text-xs transition-colors duration-200">选择题</span>
+              <span class="accent-bg-soft accent-text border accent-border px-2 py-0.5 rounded-full text-xs transition-colors duration-200">三角函数</span>
             </div>
-            <p class="text-sm"><span class="text-indigo-600/80 dark:text-indigo-400/70 mr-1.5 transition-colors duration-200">## 3.</span> 已知函数 <span class="text-indigo-700/90 bg-indigo-100/50 dark:text-indigo-300/80 dark:bg-indigo-500/10 px-1 rounded transition-colors duration-200">$f(x) = 2\sin(\omega x + \varphi)$</span> <span class="text-indigo-700/90 bg-indigo-100/50 dark:text-indigo-300/80 dark:bg-indigo-500/10 px-1 rounded transition-colors duration-200">$(\omega &gt; 0, |\varphi| &lt; \frac{\pi}{2})$</span> 的图像...</p>
+            <p class="text-sm"><span class="accent-text mr-1.5 transition-colors duration-200">## 3.</span> 已知函数 <span class="accent-text accent-bg-soft px-1 rounded transition-colors duration-200">$f(x) = 2\sin(\omega x + \varphi)$</span> <span class="accent-text accent-bg-soft px-1 rounded transition-colors duration-200">$(\omega &gt; 0, |\varphi| &lt; \frac{\pi}{2})$</span> 的图像...</p>
             <div class="mt-4 pl-3 border-l border-gray-200 dark:border-white/[0.06] space-y-2 transition-colors duration-200">
               <p class="flex gap-2"><span class="text-gray-400 dark:text-white/25 transition-colors duration-200">A.</span> <span class="text-gray-700 dark:text-white/60 transition-colors duration-200">$\omega = 2, \varphi = \frac{\pi}{6}$</span></p>
               <p class="flex gap-2"><span class="text-gray-400 dark:text-white/25 transition-colors duration-200">B.</span> <span class="text-gray-700 dark:text-white/60 transition-colors duration-200">$\omega = 2, \varphi = -\frac{\pi}{6}$</span></p>

--- a/frontend/src/views/home/HomeFeatures.vue
+++ b/frontend/src/views/home/HomeFeatures.vue
@@ -65,10 +65,10 @@ const FEATURES = [
 
     <!-- 背景装饰：模糊环境光 (Ambient Glow) -->
     <div
-      class="absolute top-[20%] left-[-10%] w-[500px] h-[500px] rounded-full bg-indigo-600/10 dark:bg-indigo-600/5 blur-[150px] pointer-events-none z-0">
+      class="absolute top-[20%] left-[-10%] w-[500px] h-[500px] rounded-full bg-[rgb(var(--accent-rgb)/0.1)] dark:bg-[rgb(var(--accent-rgb)/0.05)] blur-[150px] pointer-events-none z-0">
     </div>
     <div
-      class="absolute bottom-[10%] right-[-5%] w-[400px] h-[400px] rounded-full bg-violet-600/10 dark:bg-violet-600/5 blur-[120px] pointer-events-none z-0">
+      class="absolute bottom-[10%] right-[-5%] w-[400px] h-[400px] rounded-full bg-[rgb(var(--accent-hover-rgb)/0.1)] dark:bg-[rgb(var(--accent-hover-rgb)/0.05)] blur-[120px] pointer-events-none z-0">
     </div>
 
     <!-- 顶部分割线 -->
@@ -81,7 +81,7 @@ const FEATURES = [
       <!-- 标题区 -->
       <div class="mb-16 text-center">
         <h2
-          class="reveal text-3xl font-semibold tracking-tight mb-4 text-transparent bg-clip-text animate-gradient-sweep bg-[linear-gradient(to_right,rgb(151,137,222)_0%,rgb(151,137,222)_20%,rgb(79,70,229)_50%,rgb(151,137,222)_80%,rgb(151,137,222)_100%)] dark:bg-[linear-gradient(to_right,rgb(151,137,222)_0%,rgb(151,137,222)_20%,rgb(255,255,255)_50%,rgb(151,137,222)_80%,rgb(151,137,222)_100%)]"
+          class="reveal text-3xl font-semibold tracking-tight mb-4 text-transparent bg-clip-text animate-gradient-sweep home-title-accent"
           style="
             background-size: 200% auto;
           ">

--- a/frontend/src/views/home/HomeHero.vue
+++ b/frontend/src/views/home/HomeHero.vue
@@ -69,7 +69,7 @@ onUnmounted(() => {
       aspect-ratio: 1.3 / 1;
     ">
       <!-- 椭圆本体 -->
-      <div class="absolute inset-0 rounded-[50%] bg-gradient-to-b from-[#8173DF]/40 to-[#6357C7]/80 shadow-[inset_0_-20px_24px_0_rgba(99,87,199,0.6),0_24px_48px_0_rgba(99,87,199,0.8),0_0_32px_0_rgba(129,115,223,0.5),inset_0_-1px_0_0_rgba(255,255,255,1),inset_0_1px_0_0_rgba(255,255,255,1)] dark:from-[rgba(92,81,148,0.5)] dark:to-[rgba(47,40,91,0.95)] dark:shadow-[inset_0_-20px_24px_0_rgba(255,255,255,0.15),0_16px_32px_0_rgba(97,62,210,0.32),inset_0_-1px_0_0_rgba(129,115,223,0.6)] backdrop-blur-md"></div>
+      <div class="hero-orb absolute inset-0 rounded-[50%] backdrop-blur-md"></div>
 
       <!-- 土星光环: LaTeX 公式 -->
       <!-- 放大容器以远离"土星"本体，同时增加 Z 轴旋转(rotateX)和倾斜(rotateZ)产生悬浮交错的纵深感 -->
@@ -88,11 +88,11 @@ onUnmounted(() => {
             <path id="saturn-ring-path-1" d="M 500, 980 A 480,480 0 1,0 500,20 A 480,480 0 1,0 500,980" fill="none" />
             
             <!-- 轨道装饰线 -->
-            <path d="M 500, 500 m -488, 0 a 488,488 0 1,1 976,0 a 488,488 0 1,1 -976,0" fill="none" class="stroke-indigo-900/30 dark:stroke-indigo-400/20" stroke-width="1.5" />
-            <path d="M 500, 500 m -472, 0 a 472,472 0 1,1 944,0 a 472,472 0 1,1 -944,0" fill="none" class="stroke-indigo-900/30 dark:stroke-indigo-400/20" stroke-width="1.5" />
+            <path d="M 500, 500 m -488, 0 a 488,488 0 1,1 976,0 a 488,488 0 1,1 -976,0" fill="none" class="hero-ring-stroke" stroke-width="1.5" />
+            <path d="M 500, 500 m -472, 0 a 472,472 0 1,1 944,0 a 472,472 0 1,1 -944,0" fill="none" class="hero-ring-stroke" stroke-width="1.5" />
 
             <!-- 公式文本 -->
-            <text fill="currentColor" class="text-indigo-900/70 dark:text-indigo-200/80 font-bold" font-family="'Times New Roman', Times, serif" font-size="18" font-style="italic" letter-spacing="5">
+            <text fill="currentColor" class="hero-ring-text font-bold" font-family="'Times New Roman', Times, serif" font-size="18" font-style="italic" letter-spacing="5">
               <textPath href="#saturn-ring-path-1" startOffset="0%">
                 ∇⋅E = ρ/ε₀ &nbsp;&nbsp;&nbsp;&nbsp; ∇×B = μ₀J + μ₀ε₀(∂E/∂t) &nbsp;&nbsp;&nbsp;&nbsp; R_μν - ½Rg_μν + Λg_μν = (8πG/c⁴)T_μν &nbsp;&nbsp;&nbsp;&nbsp; iℏ(∂Ψ/∂t) = ĤΨ &nbsp;&nbsp;&nbsp;&nbsp; (iγ^μ∂_μ - m)ψ = 0 &nbsp;&nbsp;&nbsp;&nbsp; e^(iπ) + 1 = 0 &nbsp;&nbsp;&nbsp;&nbsp; S = ∫ L dt &nbsp;&nbsp;&nbsp;&nbsp; ∇⋅E = ρ/ε₀ &nbsp;&nbsp;&nbsp;&nbsp; ∇×B = μ₀J + μ₀ε₀(∂E/∂t) &nbsp;&nbsp;&nbsp;&nbsp; R_μν - ½Rg_μν + Λg_μν = (8πG/c⁴)T_μν &nbsp;&nbsp;&nbsp;&nbsp; iℏ(∂Ψ/∂t) = ĤΨ &nbsp;&nbsp;&nbsp;&nbsp; (iγ^μ∂_μ - m)ψ = 0 &nbsp;&nbsp;&nbsp;&nbsp; e^(iπ) + 1 = 0 &nbsp;&nbsp;&nbsp;&nbsp; S = ∫ L dt &nbsp;&nbsp;&nbsp;&nbsp; ∇⋅E = ρ/ε₀ &nbsp;&nbsp;&nbsp;&nbsp; ∇×B = μ₀J + μ₀ε₀(∂E/∂t) &nbsp;&nbsp;&nbsp;&nbsp; R_μν - ½Rg_μν + Λg_μν = (8πG/c⁴)T_μν &nbsp;&nbsp;&nbsp;&nbsp; iℏ(∂Ψ/∂t) = ĤΨ &nbsp;&nbsp;&nbsp;&nbsp; (iγ^μ∂_μ - m)ψ = 0 &nbsp;&nbsp;&nbsp;&nbsp; e^(iπ) + 1 = 0 &nbsp;&nbsp;&nbsp;&nbsp; S = ∫ L dt
               </textPath>
@@ -105,11 +105,11 @@ onUnmounted(() => {
             <path id="saturn-ring-path-2" d="M 500, 1040 A 540,540 0 1,0 500,-40 A 540,540 0 1,0 500,1040" fill="none" />
             
             <!-- 轨道装饰线 -->
-            <path d="M 500, 500 m -546, 0 a 546,546 0 1,1 1092,0 a 546,546 0 1,1 -1092,0" fill="none" class="stroke-indigo-900/25 dark:stroke-indigo-400/15" stroke-width="1.5" />
-            <path d="M 500, 500 m -534, 0 a 534,534 0 1,1 1068,0 a 534,534 0 1,1 -1068,0" fill="none" class="stroke-indigo-900/25 dark:stroke-indigo-400/15" stroke-width="1.5" />
+            <path d="M 500, 500 m -546, 0 a 546,546 0 1,1 1092,0 a 546,546 0 1,1 -1092,0" fill="none" class="hero-ring-stroke-soft" stroke-width="1.5" />
+            <path d="M 500, 500 m -534, 0 a 534,534 0 1,1 1068,0 a 534,534 0 1,1 -1068,0" fill="none" class="hero-ring-stroke-soft" stroke-width="1.5" />
 
             <!-- 公式文本 (换成另一组数学公式：傅里叶变换、高斯-博内定理、薛定谔、贝叶斯等) -->
-            <text fill="currentColor" class="text-indigo-900/60 dark:text-indigo-200/70 font-bold" font-family="'Times New Roman', Times, serif" font-size="14" font-style="italic" letter-spacing="6">
+            <text fill="currentColor" class="hero-ring-text-soft font-bold" font-family="'Times New Roman', Times, serif" font-size="14" font-style="italic" letter-spacing="6">
               <textPath href="#saturn-ring-path-2" startOffset="0%">
                 F(ω) = ∫ f(t)e^(-iωt)dt &nbsp;&nbsp;&nbsp;&nbsp; ∫K dA + ∫k_g ds = 2πχ(M) &nbsp;&nbsp;&nbsp;&nbsp; P(A|B) = P(B|A)P(A)/P(B) &nbsp;&nbsp;&nbsp;&nbsp; dS ≥ 0 &nbsp;&nbsp;&nbsp;&nbsp; E = mc² &nbsp;&nbsp;&nbsp;&nbsp; V - E + F = 2 &nbsp;&nbsp;&nbsp;&nbsp; F(ω) = ∫ f(t)e^(-iωt)dt &nbsp;&nbsp;&nbsp;&nbsp; ∫K dA + ∫k_g ds = 2πχ(M) &nbsp;&nbsp;&nbsp;&nbsp; P(A|B) = P(B|A)P(A)/P(B) &nbsp;&nbsp;&nbsp;&nbsp; dS ≥ 0 &nbsp;&nbsp;&nbsp;&nbsp; E = mc² &nbsp;&nbsp;&nbsp;&nbsp; V - E + F = 2 &nbsp;&nbsp;&nbsp;&nbsp; F(ω) = ∫ f(t)e^(-iωt)dt &nbsp;&nbsp;&nbsp;&nbsp; ∫K dA + ∫k_g ds = 2πχ(M) &nbsp;&nbsp;&nbsp;&nbsp; P(A|B) = P(B|A)P(A)/P(B) &nbsp;&nbsp;&nbsp;&nbsp; dS ≥ 0 &nbsp;&nbsp;&nbsp;&nbsp; E = mc² &nbsp;&nbsp;&nbsp;&nbsp; V - E + F = 2 &nbsp;&nbsp;&nbsp;&nbsp; F(ω) = ∫ f(t)e^(-iωt)dt &nbsp;&nbsp;&nbsp;&nbsp; ∫K dA + ∫k_g ds = 2πχ(M) &nbsp;&nbsp;&nbsp;&nbsp; P(A|B) = P(B|A)P(A)/P(B) &nbsp;&nbsp;&nbsp;&nbsp; dS ≥ 0 &nbsp;&nbsp;&nbsp;&nbsp; E = mc² &nbsp;&nbsp;&nbsp;&nbsp; V - E + F = 2
               </textPath>
@@ -120,17 +120,17 @@ onUnmounted(() => {
     </div>
 
     <!-- 装饰: 光斑 -->
-    <div class="absolute pointer-events-none z-0 w-80 h-80 rounded-full blur-[120px] bg-indigo-600/[0.15] dark:bg-indigo-600/[0.07]"
+    <div class="absolute pointer-events-none z-0 w-80 h-80 rounded-full blur-[120px] bg-[rgb(var(--accent-rgb)/0.15)] dark:bg-[rgb(var(--accent-rgb)/0.07)]"
       style="top: 25%; left: 8%;"
     ></div>
-    <div class="absolute pointer-events-none z-0 w-64 h-64 rounded-full blur-[100px] bg-violet-500/[0.12] dark:bg-violet-500/[0.05]"
+    <div class="absolute pointer-events-none z-0 w-64 h-64 rounded-full blur-[100px] bg-[rgb(var(--accent-hover-rgb)/0.12)] dark:bg-[rgb(var(--accent-hover-rgb)/0.05)]"
       style="top: 55%; right: 10%;"
     ></div>
 
     <!-- 装饰: 底部简约的环境光晕 -->
     <div class="absolute bottom-0 left-1/2 -translate-x-1/2 w-[80vw] h-[30vh] pointer-events-none z-0">
-      <div class="absolute inset-0 bg-indigo-500/20 dark:bg-indigo-500/10 blur-[100px] rounded-[100%] transform translate-y-1/2"></div>
-      <div class="absolute inset-0 bg-violet-500/10 dark:bg-violet-500/5 blur-[120px] rounded-[100%] transform translate-y-1/2 scale-150"></div>
+      <div class="absolute inset-0 bg-[rgb(var(--accent-rgb)/0.2)] dark:bg-[rgb(var(--accent-rgb)/0.1)] blur-[100px] rounded-[100%] transform translate-y-1/2"></div>
+      <div class="absolute inset-0 bg-[rgb(var(--accent-hover-rgb)/0.1)] dark:bg-[rgb(var(--accent-hover-rgb)/0.05)] blur-[120px] rounded-[100%] transform translate-y-1/2 scale-150"></div>
     </div>
 
     <!-- 首屏区块 — 居中布局 -->
@@ -141,7 +141,7 @@ onUnmounted(() => {
 
         <h1 class="text-4xl sm:text-5xl font-semibold tracking-tight leading-tight mb-6 text-gray-900 dark:text-white">
           重塑错题整理<br />
-          <span class="text-transparent bg-clip-text animate-gradient-sweep bg-[linear-gradient(to_right,rgb(151,137,222)_0%,rgb(151,137,222)_20%,rgb(79,70,229)_50%,rgb(151,137,222)_80%,rgb(151,137,222)_100%)] dark:bg-[linear-gradient(to_right,rgb(151,137,222)_0%,rgb(151,137,222)_20%,rgb(255,255,255)_50%,rgb(151,137,222)_80%,rgb(151,137,222)_100%)]" style="
+          <span class="home-title-accent text-transparent bg-clip-text animate-gradient-sweep" style="
             background-size: 200% auto;
           ">一键生成知识图谱</span>
         </h1>
@@ -168,7 +168,7 @@ onUnmounted(() => {
       <div
         v-for="(s, i) in stars"
         :key="i"
-        class="absolute rounded-full bg-indigo-400 dark:bg-white"
+        class="absolute rounded-full bg-[rgb(var(--accent-hover-rgb))] dark:bg-white"
         :style="{
           left: s.left + '%',
           top: s.top + '%',
@@ -214,6 +214,56 @@ onUnmounted(() => {
 .rings-paused .ring-spin-cw,
 .rings-paused .ring-spin-ccw {
   animation-play-state: paused;
+}
+
+.hero-orb {
+  background: linear-gradient(to bottom, rgb(var(--accent-rgb) / 0.4), rgb(var(--accent-strong-rgb) / 0.8));
+  box-shadow:
+    inset 0 -20px 24px 0 rgb(var(--accent-strong-rgb) / 0.6),
+    0 24px 48px 0 rgb(var(--accent-strong-rgb) / 0.8),
+    0 0 32px 0 rgb(var(--accent-rgb) / 0.5),
+    inset 0 -1px 0 0 rgba(255, 255, 255, 1),
+    inset 0 1px 0 0 rgba(255, 255, 255, 1);
+}
+
+.dark .hero-orb {
+  background: linear-gradient(to bottom, rgb(var(--accent-rgb) / 0.25), rgb(var(--accent-strong-rgb) / 0.5));
+  box-shadow:
+    inset 0 -20px 24px 0 rgba(255, 255, 255, 0.15),
+    0 16px 32px 0 rgb(var(--accent-rgb) / 0.32),
+    inset 0 -1px 0 0 rgb(var(--accent-rgb) / 0.6);
+}
+
+.hero-ring-stroke {
+  stroke: rgb(var(--accent-strong-rgb) / 0.3);
+}
+
+.dark .hero-ring-stroke {
+  stroke: rgb(var(--accent-hover-rgb) / 0.2);
+}
+
+.hero-ring-stroke-soft {
+  stroke: rgb(var(--accent-strong-rgb) / 0.25);
+}
+
+.dark .hero-ring-stroke-soft {
+  stroke: rgb(var(--accent-hover-rgb) / 0.15);
+}
+
+.hero-ring-text {
+  color: rgb(var(--accent-strong-rgb) / 0.7);
+}
+
+.dark .hero-ring-text {
+  color: rgb(var(--accent-hover-rgb) / 0.8);
+}
+
+.hero-ring-text-soft {
+  color: rgb(var(--accent-strong-rgb) / 0.6);
+}
+
+.dark .hero-ring-text-soft {
+  color: rgb(var(--accent-hover-rgb) / 0.7);
 }
 
 @keyframes gradient-sweep {

--- a/frontend/src/views/home/HomeWorkflow.vue
+++ b/frontend/src/views/home/HomeWorkflow.vue
@@ -57,12 +57,10 @@ onUnmounted(() => {
     <div class="reveal max-w-5xl mx-auto px-4 sm:px-6 relative z-10">
       <div class="text-center mb-16">
         <h2 class="reveal text-3xl font-semibold tracking-tight mb-4">
-          <span class="text-transparent bg-clip-text animate-gradient-sweep dark:hidden" style="
-            background-image: linear-gradient(to right, rgb(151, 137, 222) 0%, rgb(151, 137, 222) 20%, rgb(79, 70, 229) 50%, rgb(151, 137, 222) 80%, rgb(151, 137, 222) 100%);
+          <span class="text-transparent bg-clip-text animate-gradient-sweep home-title-accent" style="
             background-size: 200% auto;
           ">极简四步，自动运转</span>
-          <span class="text-transparent bg-clip-text animate-gradient-sweep hidden dark:inline" style="
-            background-image: linear-gradient(to right, rgb(151, 137, 222) 0%, rgb(151, 137, 222) 20%, rgb(255, 255, 255) 50%, rgb(151, 137, 222) 80%, rgb(151, 137, 222) 100%);
+          <span class="hidden" style="
             background-size: 200% auto;
           ">极简四步，自动运转</span>
         </h2>
@@ -73,7 +71,7 @@ onUnmounted(() => {
         <!-- 连接线 -->
         <div class="absolute top-10 left-12 right-12 h-px bg-gray-200 dark:bg-white/[0.06] hidden lg:block transition-colors duration-200 z-0">
           <div
-            class="h-full bg-gradient-to-r from-indigo-500 to-violet-500 transition-all duration-700 ease-out"
+            class="h-full bg-gradient-to-r from-[rgb(var(--accent-rgb))] to-[rgb(var(--accent-hover-rgb))] transition-all duration-700 ease-out"
             :style="{ width: getProgressWidth() }"
           ></div>
         </div>


### PR DESCRIPTION
- 新增主题色配置能力，提供统一的 accent 色变量、选项列表和本地持久化
- 在系统设置中集成外观配置，支持切换浅色/深色模式和主题颜色
- 将首页、登录页、工作台、聊天、仪表盘等界面的主色硬编码迁移到主题变量
- 优化侧边栏视觉结构，移除容器填充色和边框，保留局部交互状态样式
- 添加主题色相关工具类，统一按钮、图标、边框、阴影和图表主色表现

验证：
- npm run build