### PR TITLE
feat(workspace): 完善项目化错题库与侧边栏体验

### DIFF
--- a/backend/db/__init__.py
+++ b/backend/db/__init__.py
@@ -43,6 +43,27 @@ def _migrate_schema():
         if 'answer' not in columns:
             cursor.execute("ALTER TABLE questions ADD COLUMN answer TEXT")
             conn.commit()
+        if 'project_id' not in columns:
+            cursor.execute("ALTER TABLE questions ADD COLUMN project_id INTEGER")
+            conn.commit()
+
+        cursor.execute("PRAGMA table_info(upload_batches)")
+        batch_columns = {row[1] for row in cursor.fetchall()}
+        if 'project_id' not in batch_columns:
+            cursor.execute("ALTER TABLE upload_batches ADD COLUMN project_id INTEGER")
+            conn.commit()
+
+        cursor.execute("PRAGMA table_info(notes)")
+        note_columns = {row[1] for row in cursor.fetchall()}
+        if 'project_id' not in note_columns:
+            cursor.execute("ALTER TABLE notes ADD COLUMN project_id INTEGER")
+            conn.commit()
+
+        cursor.execute("PRAGMA table_info(projects)")
+        project_columns = {row[1] for row in cursor.fetchall()}
+        if 'project_type' not in project_columns:
+            cursor.execute("ALTER TABLE projects ADD COLUMN project_type TEXT DEFAULT 'question'")
+            conn.commit()
 
         cursor.execute("PRAGMA table_info(users)")
         user_columns = {row[1] for row in cursor.fetchall()}
@@ -99,6 +120,7 @@ def _migrate_schema():
         # 给 public_id 创建唯一索引（SQLite 不支持后加 UNIQUE 约束，用唯一索引替代）
         cursor.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_chat_sessions_public_id_unique ON chat_sessions(public_id)")
         conn.commit()
+
     finally:
         conn.close()
 

--- a/backend/db/crud/__init__.py
+++ b/backend/db/crud/__init__.py
@@ -53,6 +53,7 @@ from db.crud.tags import (
 
 from db.crud.questions import (
     compute_content_hash,
+    compute_project_content_hash,
     question_exists,
     save_questions_to_db,
     get_questions_by_subject,
@@ -111,6 +112,18 @@ from db.crud.providers import (
     get_active_system_provider,
 )
 
+from db.crud.projects import (
+    normalize_project_type,
+    serialize_project,
+    get_projects,
+    get_project,
+    create_project,
+    resolve_project_id,
+    require_project_id,
+    update_project,
+    delete_project,
+)
+
 from db.crud.notes import (
     save_note,
     get_notes,
@@ -145,6 +158,7 @@ __all__ = [
     "get_all_tags",
     # questions
     "compute_content_hash",
+    "compute_project_content_hash",
     "question_exists",
     "save_questions_to_db",
     "get_questions_by_subject",
@@ -193,6 +207,16 @@ __all__ = [
     "save_system_providers",
     "get_active_provider",
     "get_active_system_provider",
+    # projects
+    "normalize_project_type",
+    "serialize_project",
+    "get_projects",
+    "get_project",
+    "create_project",
+    "resolve_project_id",
+    "require_project_id",
+    "update_project",
+    "delete_project",
     # notes
     "save_note",
     "get_notes",

--- a/backend/db/crud/notes.py
+++ b/backend/db/crud/notes.py
@@ -22,6 +22,7 @@ def save_note(
     ocr_text: str,
     knowledge_tags: List[str] = None,
     user_id: int = None,
+    project_id: int = None,
 ) -> Note:
     """保存一条笔记到数据库
 
@@ -39,6 +40,7 @@ def save_note(
     """
     note = Note(
         user_id=user_id,
+        project_id=project_id,
         title=title,
         subject=subject,
         content_markdown=content_markdown,
@@ -73,6 +75,7 @@ def get_notes(
     keyword: str = None,
     page: int = 1,
     page_size: int = 20,
+    project_id: int = None,
 ) -> tuple:
     """分页查询笔记列表
 
@@ -85,6 +88,8 @@ def get_notes(
 
     if user_id is not None:
         query = query.filter(Note.user_id == user_id)
+    if project_id is not None:
+        query = query.filter(Note.project_id == project_id)
     if subject:
         query = query.filter(Note.subject == subject)
     if keyword:
@@ -109,7 +114,7 @@ def get_notes(
     return notes, total
 
 
-def get_note_by_id(db: Session, note_id: int, user_id=None) -> Optional[Note]:
+def get_note_by_id(db: Session, note_id: int, user_id=None, project_id=None) -> Optional[Note]:
     """根据 ID 获取单条笔记"""
     query = (
         db.query(Note)
@@ -120,6 +125,8 @@ def get_note_by_id(db: Session, note_id: int, user_id=None) -> Optional[Note]:
     )
     if user_id is not None:
         query = query.filter(Note.user_id == user_id)
+    if project_id is not None:
+        query = query.filter(Note.project_id == project_id)
     return query.first()
 
 
@@ -131,6 +138,7 @@ def update_note(
     subject: str = None,
     knowledge_tags: List[str] = None,
     user_id=None,
+    project_id=None,
 ) -> Optional[Note]:
     """更新笔记内容
 
@@ -147,6 +155,8 @@ def update_note(
     query = db.query(Note).filter(Note.id == note_id)
     if user_id is not None:
         query = query.filter(Note.user_id == user_id)
+    if project_id is not None:
+        query = query.filter(Note.project_id == project_id)
     note = query.first()
     if not note:
         return None
@@ -175,28 +185,33 @@ def update_note(
     return note
 
 
-def delete_note(db: Session, note_id: int, user_id=None) -> bool:
+def delete_note(db: Session, note_id: int, user_id=None, project_id=None) -> bool:
     """删除笔记（级联删除标签关联）"""
     query = db.query(Note).filter(Note.id == note_id)
     if user_id is not None:
         query = query.filter(Note.user_id == user_id)
+    if project_id is not None:
+        query = query.filter(Note.project_id == project_id)
     note = query.first()
     if not note:
         return False
     db.delete(note)
     db.commit()
+    return True
 
 
-def get_note_subjects(db: Session, user_id=None) -> List[str]:
+def get_note_subjects(db: Session, user_id=None, project_id=None) -> List[str]:
     """获取笔记库中已有的科目列表"""
     query = db.query(Note.subject).filter(Note.subject.isnot(None))
     if user_id is not None:
         query = query.filter(Note.user_id == user_id)
+    if project_id is not None:
+        query = query.filter(Note.project_id == project_id)
     rows = query.distinct().order_by(Note.subject).all()
     return [r[0] for r in rows]
 
 
-def get_note_tag_names(db: Session, subject: str = None, user_id=None) -> List[str]:
+def get_note_tag_names(db: Session, subject: str = None, user_id=None, project_id=None) -> List[str]:
     """获取笔记库中已有的知识点标签名称列表"""
     query = (
         db.query(KnowledgeTag.tag_name)
@@ -205,6 +220,7 @@ def get_note_tag_names(db: Session, subject: str = None, user_id=None) -> List[s
         .filter(
             Note.subject == subject if subject else True,
             Note.user_id == user_id if user_id is not None else True,
+            Note.project_id == project_id if project_id is not None else True,
         )
     )
     rows = query.distinct().order_by(KnowledgeTag.tag_name).all()

--- a/backend/db/crud/projects.py
+++ b/backend/db/crud/projects.py
@@ -1,0 +1,129 @@
+﻿"""Project CRUD helpers."""
+
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from db.models import Note, Project, Question, UploadBatch
+
+
+VALID_PROJECT_TYPES = {"question", "note"}
+
+
+def normalize_project_type(project_type=None) -> str:
+    value = (project_type or "question").strip().lower()
+    return value if value in VALID_PROJECT_TYPES else "question"
+
+
+def serialize_project(project: Project) -> dict:
+    return {
+        "id": project.id,
+        "public_id": project.public_id,
+        "name": project.name,
+        "project_type": normalize_project_type(getattr(project, "project_type", None)),
+        "description": project.description or "",
+        "color": project.color or "#2563eb",
+        "icon": project.icon or "book-open",
+        "is_default": bool(project.is_default),
+        "created_at": project.created_at.isoformat() if project.created_at else None,
+        "updated_at": project.updated_at.isoformat() if project.updated_at else None,
+    }
+
+
+def get_projects(db: Session, user_id=None, project_type=None) -> List[Project]:
+    query = db.query(Project)
+    if user_id is not None:
+        query = query.filter(Project.user_id == user_id)
+    else:
+        query = query.filter(Project.user_id == None)
+    if project_type:
+        query = query.filter(Project.project_type == normalize_project_type(project_type))
+    query = query.filter(Project.is_default == False)
+    return query.order_by(Project.project_type.asc(), Project.updated_at.desc(), Project.id.desc()).all()
+
+
+def get_project(db: Session, project_id: int, user_id=None) -> Optional[Project]:
+    if not project_id:
+        return None
+    query = db.query(Project).filter(Project.id == project_id)
+    if user_id is not None:
+        query = query.filter(Project.user_id == user_id)
+    else:
+        query = query.filter(Project.user_id == None)
+    return query.first()
+
+
+def create_project(
+    db: Session,
+    name: str,
+    user_id=None,
+    description: str = "",
+    color: str = "#2563eb",
+    icon: str = "book-open",
+    is_default: bool = False,
+    project_type: str = "question",
+) -> Project:
+    project_type = normalize_project_type(project_type)
+    project = Project(
+        user_id=user_id,
+        name=(name or "").strip()[:100],
+        project_type=project_type,
+        description=(description or "").strip()[:1000],
+        color=(color or "#2563eb").strip()[:20],
+        icon=(icon or "book-open").strip()[:50],
+        is_default=is_default,
+    )
+    db.add(project)
+    db.commit()
+    db.refresh(project)
+    return project
+
+
+def resolve_project_id(db: Session, project_id=None, user_id=None, project_type: str = "question") -> int:
+    project_type = normalize_project_type(project_type)
+    if not project_id:
+        raise ValueError("PROJECT_REQUIRED")
+    project = get_project(db, int(project_id), user_id=user_id)
+    if not project:
+        raise ValueError("PROJECT_NOT_FOUND")
+    if normalize_project_type(project.project_type) != project_type:
+        raise ValueError("PROJECT_TYPE_MISMATCH")
+    return project.id
+
+
+def require_project_id(db: Session, project_id, user_id=None, project_type=None) -> int:
+    project = get_project(db, int(project_id), user_id=user_id) if project_id else None
+    if not project:
+        raise ValueError("PROJECT_NOT_FOUND")
+    if project_type and normalize_project_type(project.project_type) != normalize_project_type(project_type):
+        raise ValueError("PROJECT_TYPE_MISMATCH")
+    return project.id
+
+
+def update_project(db: Session, project_id: int, user_id=None, name: str = None) -> Optional[Project]:
+    project = get_project(db, project_id, user_id=user_id)
+    if not project:
+        return None
+    if project.is_default:
+        raise ValueError("DEFAULT_PROJECT_IMMUTABLE")
+    if name is not None:
+        project.name = name.strip()[:100]
+    db.commit()
+    db.refresh(project)
+    return project
+
+
+def delete_project(db: Session, project_id: int, user_id=None) -> bool:
+    project = get_project(db, project_id, user_id=user_id)
+    if not project:
+        return False
+    if project.is_default:
+        raise ValueError("DEFAULT_PROJECT_IMMUTABLE")
+    has_questions = db.query(Question.id).filter(Question.project_id == project.id).first()
+    has_notes = db.query(Note.id).filter(Note.project_id == project.id).first()
+    has_batches = db.query(UploadBatch.id).filter(UploadBatch.project_id == project.id).first()
+    if has_questions or has_notes or has_batches:
+        raise ValueError("PROJECT_NOT_EMPTY")
+    db.delete(project)
+    db.commit()
+    return True

--- a/backend/db/crud/questions.py
+++ b/backend/db/crud/questions.py
@@ -39,11 +39,25 @@ def compute_content_hash(content_blocks: List[Dict]) -> str:
     return hashlib.sha256(text.encode()).hexdigest()
 
 
-def question_exists(db, content_hash, user_id=None):
+def compute_project_content_hash(content_blocks: List[Dict], project_id=None) -> str:
+    """Calculate the stored dedupe hash; scoped by project when available."""
+    base_hash = compute_content_hash(content_blocks)
+    if project_id is None:
+        return base_hash
+    return hashlib.sha256(f"{project_id}:{base_hash}".encode()).hexdigest()
+
+
+def question_exists(db, content_hash, user_id=None, project_id=None):
     """检查题目是否已存在（通过内容哈希 + 用户隔离）"""
-    q = db.query(Question).filter(Question.content_hash == content_hash)
+    hashes = [content_hash]
+    if project_id is not None:
+        scoped_hash = hashlib.sha256(f"{project_id}:{content_hash}".encode()).hexdigest()
+        hashes.append(scoped_hash)
+    q = db.query(Question).filter(Question.content_hash.in_(hashes))
     if user_id is not None:
         q = q.filter(Question.user_id == user_id)
+    if project_id is not None:
+        q = q.filter(Question.project_id == project_id)
     return q.first()
 
 
@@ -52,6 +66,7 @@ def save_questions_to_db(
     questions: List[Dict],
     batch_info: Dict[str, Any],
     user_id=None,
+    project_id=None,
 ) -> Dict[str, int]:
     """
     批量入库题目
@@ -66,10 +81,14 @@ def save_questions_to_db(
     """
     # 科目由编排智能体识别，不再使用关键词匹配
     subject = batch_info.get("subject") or "未知"
+    project_id = project_id or batch_info.get("project_id")
+    if not project_id:
+        raise ValueError("PROJECT_REQUIRED")
 
     # 创建批次记录
     batch = UploadBatch(
         user_id=user_id,
+        project_id=project_id,
         original_filename=batch_info.get("original_filename", "未知"),
         subject=subject,
         file_path=batch_info.get("file_path", ""),
@@ -89,15 +108,16 @@ def save_questions_to_db(
         content_hash = compute_content_hash(content_blocks)
 
         # 检查是否已存在
-        if question_exists(db, content_hash, user_id=user_id):
+        if question_exists(db, content_hash, user_id=user_id, project_id=project_id):
             duplicates += 1
             continue
 
         # 创建题目记录
         question = Question(
             user_id=user_id,
+            project_id=project_id,
             batch_id=batch.id,
-            content_hash=content_hash,
+            content_hash=compute_project_content_hash(content_blocks, project_id),
             question_type=q.get("question_type"),
             content_json=json.dumps(content_blocks, ensure_ascii=False),
             options_json=json.dumps(q.get("options"), ensure_ascii=False) if q.get("options") else None,
@@ -283,6 +303,7 @@ def query_questions(
     page: int = 1,
     page_size: int = 20,
     user_id=None,
+    project_id=None,
 ) -> Tuple[List[Question], int]:
     """
     统一查询题目（合并 get_history_questions 和 search_questions 的能力）
@@ -293,6 +314,8 @@ def query_questions(
 
     if user_id is not None:
         query = query.filter(Question.user_id == user_id)
+    if project_id is not None:
+        query = query.filter(Question.project_id == project_id)
 
     # 未筛选的总收录数（仅按用户隔离）
     grand_total = query.distinct().count()
@@ -455,7 +478,7 @@ def update_review_status(db: Session, question_id: int, review_status: str, user
         raise
 
 
-def get_existing_subjects(db, user_id=None):
+def get_existing_subjects(db, user_id=None, project_id=None):
     """获取数据库中已有的所有科目名称（去重）"""
     query = db.query(UploadBatch.subject).distinct().filter(
         UploadBatch.subject.isnot(None),
@@ -463,10 +486,12 @@ def get_existing_subjects(db, user_id=None):
     )
     if user_id is not None:
         query = query.filter(UploadBatch.user_id == user_id)
+    if project_id is not None:
+        query = query.filter(UploadBatch.project_id == project_id)
     return [r[0] for r in query.all()]
 
 
-def get_existing_question_types(db: Session, user_id=None) -> List[str]:
+def get_existing_question_types(db: Session, user_id=None, project_id=None) -> List[str]:
     """获取数据库中已有的所有题型（去重）"""
     query = db.query(Question.question_type).distinct().filter(
         Question.question_type.isnot(None),
@@ -474,4 +499,6 @@ def get_existing_question_types(db: Session, user_id=None) -> List[str]:
     )
     if user_id is not None:
         query = query.filter(Question.user_id == user_id)
+    if project_id is not None:
+        query = query.filter(Question.project_id == project_id)
     return [r[0] for r in query.all()]

--- a/backend/db/crud/stats.py
+++ b/backend/db/crud/stats.py
@@ -19,18 +19,22 @@ def _get_filters():
     return _filter_by_subject, _filter_by_user
 
 
-def get_statistics(db: Session, subject: Optional[str] = None, user_id=None) -> Dict[str, Any]:
+def get_statistics(db: Session, subject: Optional[str] = None, user_id=None, project_id=None) -> Dict[str, Any]:
     """获取统计信息"""
     _filter_by_subject, _filter_by_user = _get_filters()
 
     q_query = _filter_by_subject(db.query(func.count(Question.id)), subject)
     if user_id is not None:
         q_query = q_query.filter(Question.user_id == user_id)
+    if project_id is not None:
+        q_query = q_query.filter(Question.project_id == project_id)
     total_questions = q_query.scalar()
 
     batch_query = db.query(func.count(UploadBatch.id))
     if user_id is not None:
         batch_query = batch_query.filter(UploadBatch.user_id == user_id)
+    if project_id is not None:
+        batch_query = batch_query.filter(UploadBatch.project_id == project_id)
     total_batches = batch_query.scalar()
 
     total_tags = db.query(func.count(KnowledgeTag.id)).scalar()
@@ -39,6 +43,8 @@ def get_statistics(db: Session, subject: Optional[str] = None, user_id=None) -> 
     subject_q = db.query(UploadBatch.subject, func.count(Question.id)).join(Question)
     if user_id is not None:
         subject_q = subject_q.filter(Question.user_id == user_id)
+    if project_id is not None:
+        subject_q = subject_q.filter(Question.project_id == project_id)
     subject_stats = subject_q.group_by(UploadBatch.subject).all()
 
     return {
@@ -49,7 +55,7 @@ def get_statistics(db: Session, subject: Optional[str] = None, user_id=None) -> 
     }
 
 
-def get_knowledge_stats(db: Session, subject: Optional[str] = None, limit: Optional[int] = None, user_id=None) -> List[Dict]:
+def get_knowledge_stats(db: Session, subject: Optional[str] = None, limit: Optional[int] = None, user_id=None, project_id=None) -> List[Dict]:
     """
     获取知识点统计信息
 
@@ -72,6 +78,10 @@ def get_knowledge_stats(db: Session, subject: Optional[str] = None, limit: Optio
         query = query.join(Question, Question.id == QuestionTagMapping.question_id).filter(
             Question.user_id == user_id
         )
+    elif project_id is not None:
+        query = query.join(Question, Question.id == QuestionTagMapping.question_id)
+    if project_id is not None:
+        query = query.filter(Question.project_id == project_id)
 
     if subject:
         query = query.filter(KnowledgeTag.subject == subject)
@@ -90,7 +100,7 @@ def get_knowledge_stats(db: Session, subject: Optional[str] = None, limit: Optio
     return [{"tag_name": tag_name, "count": count} for tag_name, count in stats]
 
 
-def get_review_status_stats(db: Session, subject: Optional[str] = None, user_id=None) -> Dict[str, int]:
+def get_review_status_stats(db: Session, subject: Optional[str] = None, user_id=None, project_id=None) -> Dict[str, int]:
     """按复习状态分组统计数量"""
     _filter_by_subject, _filter_by_user = _get_filters()
 
@@ -100,6 +110,8 @@ def get_review_status_stats(db: Session, subject: Optional[str] = None, user_id=
     ), subject)
     if user_id is not None:
         query = query.filter(Question.user_id == user_id)
+    if project_id is not None:
+        query = query.filter(Question.project_id == project_id)
 
     rows = query.group_by(Question.review_status).all()
 
@@ -113,7 +125,7 @@ def get_review_status_stats(db: Session, subject: Optional[str] = None, user_id=
     return result
 
 
-def get_today_mastered_count(db: Session, subject: Optional[str] = None, user_id=None) -> int:
+def get_today_mastered_count(db: Session, subject: Optional[str] = None, user_id=None, project_id=None) -> int:
     """获取今日新掌握的题目数（updated_at 在今天且状态为已掌握）"""
     _filter_by_subject, _filter_by_user = _get_filters()
 
@@ -124,10 +136,12 @@ def get_today_mastered_count(db: Session, subject: Optional[str] = None, user_id
     ), subject)
     if user_id is not None:
         query = query.filter(Question.user_id == user_id)
+    if project_id is not None:
+        query = query.filter(Question.project_id == project_id)
     return query.scalar() or 0
 
 
-def get_daily_counts(db: Session, days: int = 7, subject: Optional[str] = None, user_id=None) -> List[Dict[str, Any]]:
+def get_daily_counts(db: Session, days: int = 7, subject: Optional[str] = None, user_id=None, project_id=None) -> List[Dict[str, Any]]:
     """获取最近 N 天每日新增题目数 + 每日新增已掌握数"""
     from datetime import timedelta
     _filter_by_subject, _filter_by_user = _get_filters()
@@ -144,6 +158,8 @@ def get_daily_counts(db: Session, days: int = 7, subject: Optional[str] = None, 
     ).filter(Question.created_at >= cutoff), subject)
     if user_id is not None:
         query = query.filter(Question.user_id == user_id)
+    if project_id is not None:
+        query = query.filter(Question.project_id == project_id)
     rows = query.group_by(date_expr).order_by(date_expr).all()
     date_map = {str(row.date): row.count for row in rows}
 
@@ -158,6 +174,8 @@ def get_daily_counts(db: Session, days: int = 7, subject: Optional[str] = None, 
     ), subject)
     if user_id is not None:
         mq = mq.filter(Question.user_id == user_id)
+    if project_id is not None:
+        mq = mq.filter(Question.project_id == project_id)
     mastered_rows = mq.group_by(mastered_date_expr).order_by(mastered_date_expr).all()
     mastered_map = {str(row.date): row.count for row in mastered_rows}
 
@@ -176,7 +194,7 @@ def get_daily_counts(db: Session, days: int = 7, subject: Optional[str] = None, 
     return result
 
 
-def get_tag_status_stats(db: Session, subject: Optional[str] = None, limit: int = 10, user_id=None) -> List[Dict]:
+def get_tag_status_stats(db: Session, subject: Optional[str] = None, limit: int = 10, user_id=None, project_id=None) -> List[Dict]:
     """
     知识点 × 掌握状态统计（堆叠柱状图用）
 
@@ -195,6 +213,8 @@ def get_tag_status_stats(db: Session, subject: Optional[str] = None, limit: int 
 
     if user_id is not None:
         query = query.filter(Question.user_id == user_id)
+    if project_id is not None:
+        query = query.filter(Question.project_id == project_id)
     if subject:
         query = query.filter(KnowledgeTag.subject == subject)
 
@@ -221,7 +241,7 @@ def get_tag_status_stats(db: Session, subject: Optional[str] = None, limit: int 
     return [tag_data[t] for t in sorted_tags]
 
 
-def get_tag_type_stats(db: Session, subject: Optional[str] = None, tag_limit: int = 8, user_id=None) -> Dict[str, Any]:
+def get_tag_type_stats(db: Session, subject: Optional[str] = None, tag_limit: int = 8, user_id=None, project_id=None) -> Dict[str, Any]:
     """
     知识点 × 题型交叉统计（热力图用）
 
@@ -243,6 +263,8 @@ def get_tag_type_stats(db: Session, subject: Optional[str] = None, tag_limit: in
 
     if user_id is not None:
         query = query.filter(Question.user_id == user_id)
+    if project_id is not None:
+        query = query.filter(Question.project_id == project_id)
     if subject:
         query = query.filter(KnowledgeTag.subject == subject)
 

--- a/backend/db/migrate.py
+++ b/backend/db/migrate.py
@@ -43,6 +43,10 @@ def migrate():
         _add_column_if_missing(conn, "users", "daily_free_quota", "INTEGER", 5)
         _add_column_if_missing(conn, "users", "daily_free_used", "INTEGER", 0)
         _add_column_if_missing(conn, "users", "daily_free_quota_date", "VARCHAR(10)")
+        _add_column_if_missing(conn, "upload_batches", "project_id", "INTEGER")
+        _add_column_if_missing(conn, "questions", "project_id", "INTEGER")
+        _add_column_if_missing(conn, "notes", "project_id", "INTEGER")
+        _add_column_if_missing(conn, "projects", "project_type", "VARCHAR(20)", "'question'")
         _add_column_if_missing(conn, "chat_sessions", "public_id", "TEXT")
         conn.commit()
 

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -35,6 +35,29 @@ class User(Base):
     split_records = relationship("SplitRecord", back_populates="user")
     provider_configs = relationship("ProviderConfig", back_populates="user", cascade="all, delete-orphan")
     notes = relationship("Note", back_populates="user")
+    projects = relationship("Project", back_populates="user", cascade="all, delete-orphan")
+
+
+class Project(Base):
+    """Learning space that groups questions and notes."""
+    __tablename__ = "projects"
+
+    id = Column(Integer, primary_key=True)
+    public_id = Column(String(36), unique=True, index=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
+    name = Column(String(100), nullable=False)
+    project_type = Column(String(20), default="question", nullable=False, index=True)
+    description = Column(Text, default="")
+    color = Column(String(20), default="#2563eb")
+    icon = Column(String(50), default="book-open")
+    is_default = Column(Boolean, default=False, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    user = relationship("User", back_populates="projects")
+    upload_batches = relationship("UploadBatch", back_populates="project")
+    questions = relationship("Question", back_populates="project")
+    notes = relationship("Note", back_populates="project")
 
 
 class ProviderConfig(Base):
@@ -88,6 +111,7 @@ class UploadBatch(Base):
 
     id = Column(Integer, primary_key=True)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
+    project_id = Column(Integer, ForeignKey("projects.id"), nullable=True, index=True)
     original_filename = Column(String(255), nullable=False)
     subject = Column(String(50))
     file_path = Column(Text)
@@ -95,6 +119,7 @@ class UploadBatch(Base):
     created_at = Column(DateTime, default=datetime.utcnow)
 
     user = relationship("User", back_populates="upload_batches")
+    project = relationship("Project", back_populates="upload_batches")
     questions = relationship("Question", back_populates="batch")
 
 
@@ -104,6 +129,7 @@ class Question(Base):
 
     id = Column(Integer, primary_key=True)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
+    project_id = Column(Integer, ForeignKey("projects.id"), nullable=True, index=True)
     batch_id = Column(Integer, ForeignKey("upload_batches.id"))
     content_hash = Column(String(64), nullable=False)
     question_type = Column(String(20))
@@ -121,10 +147,11 @@ class Question(Base):
     answer = Column(Text, nullable=True)
 
     __table_args__ = (
-        UniqueConstraint('content_hash', 'user_id', name='uq_question_hash_user'),
+        UniqueConstraint('content_hash', 'user_id', 'project_id', name='uq_question_hash_user_project'),
     )
 
     user = relationship("User", back_populates="questions")
+    project = relationship("Project", back_populates="questions")
     batch = relationship("UploadBatch", back_populates="questions")
     tags = relationship("QuestionTagMapping", back_populates="question")
     chat_sessions = relationship("ChatSession", back_populates="question")
@@ -207,6 +234,7 @@ class Note(Base):
 
     id = Column(Integer, primary_key=True)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
+    project_id = Column(Integer, ForeignKey("projects.id"), nullable=True, index=True)
     title = Column(String(255), nullable=False)          # 笔记标题
     subject = Column(String(50))                          # 科目
     content_markdown = Column(Text, default="")           # LLM 整理后的 Markdown 内容
@@ -216,6 +244,7 @@ class Note(Base):
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     user = relationship("User", back_populates="notes")
+    project = relationship("Project", back_populates="notes")
     tags = relationship("NoteTagMapping", back_populates="note", cascade="all, delete-orphan")
 
 

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -9,6 +9,7 @@ from .chat import bp as chat_bp
 from .stats import bp as stats_bp
 from .settings import bp as settings_bp
 from .notes import bp as notes_bp
+from .projects import bp as projects_bp
 
 
 def register_routes(app):
@@ -20,3 +21,4 @@ def register_routes(app):
     app.register_blueprint(stats_bp, url_prefix='/api')
     app.register_blueprint(settings_bp, url_prefix='/api')
     app.register_blueprint(notes_bp, url_prefix='/api/notes')
+    app.register_blueprint(projects_bp, url_prefix='/api')

--- a/backend/routes/notes.py
+++ b/backend/routes/notes.py
@@ -37,6 +37,26 @@ def _effective_user_id():
     return session.get("user_id")
 
 
+def _project_id_arg():
+    value = request.args.get("project_id") or None
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _project_id_form():
+    value = request.form.get("project_id") or None
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _allowed_image(filename):
     """检查是否为允许的图片格式"""
     return PurePath(filename).suffix.lower().lstrip(".") in {
@@ -130,6 +150,14 @@ def create_note():
             )
 
     user_id = session.get("user_id")
+    project_id = _project_id_form()
+    try:
+        with SessionLocal() as db:
+            project_id = crud.require_project_id(db, project_id, user_id=user_id, project_type="note")
+    except ValueError as exc:
+        if str(exc) == "PROJECT_TYPE_MISMATCH":
+            return jsonify({"success": False, "error": "请选择一个笔记本"}), 400
+        return jsonify({"success": False, "error": "请先创建并选择一个笔记本"}), 400
     model_provider = request.form.get("model_provider", "openai")
     model_name = request.form.get("model_name") or None
     provider_source = request.form.get("provider_source") or None
@@ -261,6 +289,16 @@ def create_note():
 
         # 4. 保存到数据库
         with SessionLocal() as db:
+            try:
+                project_id = (
+                    crud.require_project_id(db, project_id, user_id=user_id, project_type="note")
+                    if project_id
+                    else crud.resolve_project_id(db, project_id, user_id=user_id, project_type="note")
+                )
+            except ValueError as exc:
+                if str(exc) == "PROJECT_REQUIRED":
+                    return jsonify({"success": False, "error": "请先创建并选择一个笔记本"}), 400
+                return jsonify({"success": False, "error": "项目不存在"}), 404
             note = crud.save_note(
                 db,
                 title=result.title,
@@ -270,6 +308,7 @@ def create_note():
                 ocr_text=ocr_text,
                 knowledge_tags=result.knowledge_tags,
                 user_id=user_id,
+                project_id=project_id,
             )
             note_id = note.id
 
@@ -309,6 +348,7 @@ def list_notes():
         knowledge_tag = request.args.get("knowledge_tag") or None
         keyword = request.args.get("keyword") or None
         user_id = session.get("user_id")
+        project_id = _project_id_arg()
 
         with SessionLocal() as db:
             notes, total = crud.get_notes(
@@ -319,6 +359,7 @@ def list_notes():
                 keyword=keyword,
                 page=page,
                 page_size=limit,
+                project_id=project_id,
             )
             return jsonify(
                 {
@@ -400,7 +441,7 @@ def list_note_subjects():
     """获取笔记库中的科目列表"""
     try:
         with SessionLocal() as db:
-            subjects = crud.get_note_subjects(db, user_id=_effective_user_id())
+            subjects = crud.get_note_subjects(db, user_id=_effective_user_id(), project_id=_project_id_arg())
             return jsonify({"success": True, "subjects": subjects})
     except Exception as e:
         logger.exception("获取笔记科目列表失败")
@@ -414,7 +455,7 @@ def list_note_tags():
         subject = request.args.get("subject") or None
         with SessionLocal() as db:
             tags = crud.get_note_tag_names(
-                db, subject=subject, user_id=_effective_user_id()
+                db, subject=subject, user_id=_effective_user_id(), project_id=_project_id_arg()
             )
             return jsonify({"success": True, "tags": tags})
     except Exception as e:

--- a/backend/routes/projects.py
+++ b/backend/routes/projects.py
@@ -1,0 +1,116 @@
+﻿"""Project routes."""
+
+import logging
+
+from flask import Blueprint, jsonify, request, session
+
+from db import SessionLocal
+from db import crud
+from db.models import Note, Question
+
+logger = logging.getLogger(__name__)
+
+bp = Blueprint("projects", __name__)
+
+
+def _project_owner_id():
+    return session.get("user_id")
+
+
+def _serialize_project_with_counts(db, project):
+    payload = crud.serialize_project(project)
+    payload["question_count"] = db.query(Question).filter(Question.project_id == project.id).count()
+    payload["note_count"] = db.query(Note).filter(Note.project_id == project.id).count()
+    return payload
+
+
+@bp.route("/projects", methods=["GET"])
+def list_projects():
+    try:
+        with SessionLocal() as db:
+            user_id = _project_owner_id()
+            project_type = request.args.get("project_type") or request.args.get("type") or None
+            projects = crud.get_projects(db, user_id=user_id, project_type=project_type)
+            return jsonify({
+                "success": True,
+                "projects": [_serialize_project_with_counts(db, p) for p in projects],
+            })
+    except Exception:
+        logger.exception("list projects failed")
+        return jsonify({"success": False, "error": "获取项目列表失败"}), 500
+
+
+@bp.route("/projects", methods=["POST"])
+def create_project():
+    try:
+        data = request.get_json(silent=True) or {}
+        name = (data.get("name") or "").strip()
+        project_type = crud.normalize_project_type(data.get("project_type") or data.get("type"))
+        if not name:
+            return jsonify({"success": False, "error": "项目名称不能为空"}), 400
+        if len(name) > 100:
+            return jsonify({"success": False, "error": "项目名称不能超过 100 个字符"}), 400
+
+        with SessionLocal() as db:
+            project = crud.create_project(
+                db,
+                name=name,
+                user_id=_project_owner_id(),
+                description=data.get("description") or "",
+                color=data.get("color") or "#2563eb",
+                icon=data.get("icon") or ("book-open" if project_type == "note" else "database"),
+                project_type=project_type,
+            )
+            payload = _serialize_project_with_counts(db, project)
+            return jsonify({
+                "success": True,
+                "project": payload,
+            }), 201
+    except Exception:
+        logger.exception("create project failed")
+        return jsonify({"success": False, "error": "创建项目失败"}), 500
+
+
+@bp.route("/projects/<int:project_id>", methods=["PUT"])
+def update_project(project_id):
+    try:
+        data = request.get_json(silent=True) or {}
+        name = (data.get("name") or "").strip()
+        if not name:
+            return jsonify({"success": False, "error": "项目名称不能为空"}), 400
+        if len(name) > 100:
+            return jsonify({"success": False, "error": "项目名称不能超过 100 个字符"}), 400
+
+        with SessionLocal() as db:
+            try:
+                project = crud.update_project(db, project_id, user_id=_project_owner_id(), name=name)
+            except ValueError as exc:
+                if str(exc) == "DEFAULT_PROJECT_IMMUTABLE":
+                    return jsonify({"success": False, "error": "默认项目不能重命名"}), 400
+                raise
+            if not project:
+                return jsonify({"success": False, "error": "项目不存在"}), 404
+            return jsonify({"success": True, "project": _serialize_project_with_counts(db, project)})
+    except Exception:
+        logger.exception("update project failed")
+        return jsonify({"success": False, "error": "更新项目失败"}), 500
+
+
+@bp.route("/projects/<int:project_id>", methods=["DELETE"])
+def delete_project(project_id):
+    try:
+        with SessionLocal() as db:
+            try:
+                deleted = crud.delete_project(db, project_id, user_id=_project_owner_id())
+            except ValueError as exc:
+                if str(exc) == "DEFAULT_PROJECT_IMMUTABLE":
+                    return jsonify({"success": False, "error": "默认项目不能删除"}), 400
+                if str(exc) == "PROJECT_NOT_EMPTY":
+                    return jsonify({"success": False, "error": "项目里还有内容，暂时不能删除"}), 400
+                raise
+            if not deleted:
+                return jsonify({"success": False, "error": "项目不存在"}), 404
+            return jsonify({"success": True})
+    except Exception:
+        logger.exception("delete project failed")
+        return jsonify({"success": False, "error": "删除项目失败"}), 500

--- a/backend/routes/questions.py
+++ b/backend/routes/questions.py
@@ -23,6 +23,26 @@ def _effective_user_id():
     return session.get('user_id')
 
 
+def _project_id_arg():
+    value = request.args.get('project_id') or None
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _project_id_body(data):
+    value = (data or {}).get('project_id')
+    if value in (None, ''):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _serialize_question(q: Question) -> dict:
     """将 Question ORM 对象序列化为前端 JSON 格式"""
     subject = None
@@ -268,6 +288,7 @@ def get_error_bank():
         question_type = request.args.get('question_type', type=str) or None
         keyword = request.args.get('keyword', type=str) or None
         review_status = request.args.get('review_status', type=str) or None
+        project_id = _project_id_arg()
         start_date_str = request.args.get('start_date')
         end_date_str = request.args.get('end_date')
 
@@ -291,6 +312,7 @@ def get_error_bank():
                 review_status=review_status,
                 page=page,
                 page_size=page_size,
+                project_id=project_id,
             )
 
             total_pages = (total + page_size - 1) // page_size
@@ -318,7 +340,7 @@ def get_subjects():
     """获取所有科目列表"""
     try:
         with SessionLocal() as db:
-            subjects = crud.get_existing_subjects(db, user_id=_effective_user_id())
+            subjects = crud.get_existing_subjects(db, user_id=_effective_user_id(), project_id=_project_id_arg())
             return jsonify({'success': True, 'subjects': subjects})
     except Exception as e:
         logger.exception("获取科目列表失败")
@@ -330,7 +352,7 @@ def get_question_types():
     """获取所有题型列表"""
     try:
         with SessionLocal() as db:
-            types = crud.get_existing_question_types(db, user_id=_effective_user_id())
+            types = crud.get_existing_question_types(db, user_id=_effective_user_id(), project_id=_project_id_arg())
             return jsonify({'success': True, 'question_types': types})
     except Exception as e:
         logger.exception("获取题型列表失败")
@@ -354,7 +376,7 @@ def update_question(question_id):
                     text = str(data['content'])[:20000]
                     blocks = [{'block_type': 'text', 'content': text}]
                     question.content_json = json.dumps(blocks, ensure_ascii=False)
-                    question.content_hash = crud.compute_content_hash(blocks)
+                    question.content_hash = crud.compute_project_content_hash(blocks, question.project_id)
                 if 'answer' in data:
                     question.answer = str(data['answer'])[:10000] if data['answer'] else None
                 question.updated_at = datetime.utcnow()
@@ -437,6 +459,7 @@ def save_to_db():
     try:
         data = request.get_json(silent=True) or {}
         selected_uids = data.get('selected_ids', [])
+        project_id = _project_id_body(data)
 
         if not isinstance(selected_uids, list) or not selected_uids:
             return jsonify({'success': False, 'error': '请选择至少一道题目'}), 400
@@ -481,7 +504,23 @@ def save_to_db():
             }
 
         with SessionLocal() as db:
-            result = crud.save_questions_to_db(db, selected_questions, batch_info, user_id=session.get('user_id'))
+            try:
+                project_id = (
+                    crud.require_project_id(db, project_id, user_id=session.get('user_id'), project_type="question")
+                    if project_id
+                    else crud.resolve_project_id(db, project_id, user_id=session.get('user_id'), project_type="question")
+                )
+            except ValueError as exc:
+                if str(exc) == "PROJECT_REQUIRED":
+                    return jsonify({'success': False, 'error': '请先创建并选择一个错题库'}), 400
+                return jsonify({'success': False, 'error': '项目不存在'}), 404
+            result = crud.save_questions_to_db(
+                db,
+                selected_questions,
+                batch_info,
+                user_id=session.get('user_id'),
+                project_id=project_id,
+            )
 
         return jsonify({
             'success': True,

--- a/backend/routes/stats.py
+++ b/backend/routes/stats.py
@@ -17,8 +17,9 @@ def get_stats():
     """
     try:
         subject = request.args.get('subject', type=str) or None
+        project_id = request.args.get('project_id', type=int)
         with SessionLocal() as db:
-            stats = crud.get_knowledge_stats(db, subject=subject, user_id=session.get('user_id'))
+            stats = crud.get_knowledge_stats(db, subject=subject, user_id=session.get('user_id'), project_id=project_id)
             return jsonify({
                 'success': True,
                 'stats': stats,
@@ -35,31 +36,32 @@ def get_dashboard_stats():
     """获取 Dashboard 所需的完整统计数据，支持 ?subject= 学科筛选"""
     try:
         subject = request.args.get('subject') or None
+        project_id = request.args.get('project_id', type=int)
         uid = session.get('user_id')
         with SessionLocal() as db:
             # 可用学科列表（按当前用户隔离）
-            subjects = crud.get_existing_subjects(db, user_id=uid)
+            subjects = crud.get_existing_subjects(db, user_id=uid, project_id=project_id)
 
             # 复习状态统计
-            review_stats = crud.get_review_status_stats(db, subject=subject, user_id=uid)
+            review_stats = crud.get_review_status_stats(db, subject=subject, user_id=uid, project_id=project_id)
 
             # 总体统计
-            statistics = crud.get_statistics(db, subject=subject, user_id=uid)
+            statistics = crud.get_statistics(db, subject=subject, user_id=uid, project_id=project_id)
 
             # 知识点标签统计 top 10（横向条形图）
-            tag_stats = crud.get_knowledge_stats(db, subject=subject, limit=10, user_id=uid)
+            tag_stats = crud.get_knowledge_stats(db, subject=subject, limit=10, user_id=uid, project_id=project_id)
 
             # 知识点 × 掌握状态（堆叠柱状图）
-            tag_status_stats = crud.get_tag_status_stats(db, subject=subject, limit=10, user_id=uid)
+            tag_status_stats = crud.get_tag_status_stats(db, subject=subject, limit=10, user_id=uid, project_id=project_id)
 
             # 知识点 × 题型（热力图）
-            tag_type_stats = crud.get_tag_type_stats(db, subject=subject, tag_limit=8, user_id=uid)
+            tag_type_stats = crud.get_tag_type_stats(db, subject=subject, tag_limit=8, user_id=uid, project_id=project_id)
 
             # 今日掌握数
-            today_mastered = crud.get_today_mastered_count(db, subject=subject, user_id=uid)
+            today_mastered = crud.get_today_mastered_count(db, subject=subject, user_id=uid, project_id=project_id)
 
             # 最近30天每日新增 + 已掌握趋势
-            daily_counts = crud.get_daily_counts(db, days=30, subject=subject, user_id=uid)
+            daily_counts = crud.get_daily_counts(db, days=30, subject=subject, user_id=uid, project_id=project_id)
 
             return jsonify({
                 'success': True,

--- a/backend/routes/upload.py
+++ b/backend/routes/upload.py
@@ -2,6 +2,7 @@ import os
 import json
 import uuid
 import logging
+from datetime import timezone
 from pathlib import PurePath
 from typing import Optional
 
@@ -50,6 +51,16 @@ def _read_split_subject() -> Optional[str]:
     return None
 
 
+def _isoformat_utc(dt) -> Optional[str]:
+    if not dt:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt.isoformat().replace("+00:00", "Z")
+
+
 def _serialize_split_record(r) -> dict:
     """将 SplitRecord ORM 对象序列化为前端 JSON 格式"""
     return {
@@ -58,7 +69,7 @@ def _serialize_split_record(r) -> dict:
         "model_provider": r.model_provider,
         "file_names": json.loads(r.file_names_json) if r.file_names_json else [],
         "question_count": r.question_count,
-        "created_at": r.created_at.isoformat() if r.created_at else None,
+        "created_at": _isoformat_utc(r.created_at),
     }
 
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -140,6 +140,39 @@ export async function fetchStatus() {
   return data.status
 }
 
+export async function fetchProjects() {
+  const resp = await fetch('/api/projects')
+  const data = await _assertJsonSuccess(resp, '获取项目列表失败')
+  return data.projects || []
+}
+
+export async function createProject(payload) {
+  const resp = await fetch('/api/projects', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  const data = await _assertJsonSuccess(resp, '创建项目失败')
+  return data.project
+}
+
+export async function updateProject(projectId, payload) {
+  const resp = await fetch(`/api/projects/${encodeURIComponent(projectId)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  const data = await _assertJsonSuccess(resp, '更新项目失败')
+  return data.project
+}
+
+export async function deleteProject(projectId) {
+  const resp = await fetch(`/api/projects/${encodeURIComponent(projectId)}`, {
+    method: 'DELETE',
+  })
+  return _assertJsonSuccess(resp, '删除项目失败')
+}
+
 export async function cancelFile(fileKey) {
   const resp = await fetch('/api/cancel_file', {
     method: 'POST',
@@ -207,11 +240,13 @@ export async function exportQuestions(selectedIds) {
   return _assertJsonSuccess(resp, '导出失败')
 }
 
-export async function saveToDb(selectedIds, answers = []) {
+export async function saveToDb(selectedIds, answers = [], projectId) {
+  const body = { selected_ids: selectedIds, answers }
+  if (projectId) body.project_id = projectId
   const resp = await fetch('/api/save-to-db', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ selected_ids: selectedIds, answers }),
+    body: JSON.stringify(body),
   })
   return _assertJsonSuccess(resp, '导入错题库失败')
 }
@@ -242,21 +277,26 @@ export async function fetchErrorBank(params = {}) {
   return _assertJsonSuccess(resp, '查询错题库失败')
 }
 
-export async function fetchSubjects() {
-  const resp = await fetch('/api/subjects')
+export async function fetchSubjects(projectId) {
+  const qs = new URLSearchParams()
+  if (projectId) qs.set('project_id', projectId)
+  const resp = await fetch(`/api/subjects?${qs}`)
   const data = await _assertJsonSuccess(resp, '获取科目列表失败')
   return data.subjects
 }
 
-export async function fetchQuestionTypes() {
-  const resp = await fetch('/api/question-types')
+export async function fetchQuestionTypes(projectId) {
+  const qs = new URLSearchParams()
+  if (projectId) qs.set('project_id', projectId)
+  const resp = await fetch(`/api/question-types?${qs}`)
   const data = await _assertJsonSuccess(resp, '获取题型列表失败')
   return data.question_types
 }
 
-export async function fetchTagNames(subject) {
+export async function fetchTagNames(subject, projectId) {
   const qs = new URLSearchParams()
   if (subject) qs.set('subject', subject)
+  if (projectId) qs.set('project_id', projectId)
   const resp = await fetch(`/api/stats?${qs}`)
   const data = await _assertJsonSuccess(resp, '获取标签列表失败')
   return (data.stats || []).map(s => s.tag_name)
@@ -294,9 +334,10 @@ export async function updateReviewStatus(questionId, reviewStatus) {
   return _assertJsonSuccess(resp, '更新复习状态失败')
 }
 
-export async function fetchDashboardStats(subject) {
+export async function fetchDashboardStats(subject, projectId) {
   const qs = new URLSearchParams()
   if (subject) qs.set('subject', subject)
+  if (projectId) qs.set('project_id', projectId)
   const resp = await fetch(`/api/dashboard-stats?${qs}`)
   return _assertJsonSuccess(resp, '获取统计数据失败')
 }
@@ -408,6 +449,7 @@ export async function fetchNotes(params = {}) {
   if (params.subject) query.set('subject', params.subject)
   if (params.knowledge_tag) query.set('knowledge_tag', params.knowledge_tag)
   if (params.keyword) query.set('keyword', params.keyword)
+  if (params.project_id) query.set('project_id', params.project_id)
 
   const resp = await fetch(`/api/notes/?${query}`)
   return _assertJsonSuccess(resp, '获取笔记列表失败')
@@ -447,8 +489,10 @@ export async function deleteNote(noteId) {
 /**
  * 获取笔记库科目列表
  */
-export async function fetchNoteSubjects() {
-  const resp = await fetch('/api/notes/subjects')
+export async function fetchNoteSubjects(projectId) {
+  const qs = new URLSearchParams()
+  if (projectId) qs.set('project_id', projectId)
+  const resp = await fetch(`/api/notes/subjects?${qs}`)
   const data = await _assertJsonSuccess(resp, '获取科目列表失败')
   return data.subjects
 }
@@ -456,9 +500,10 @@ export async function fetchNoteSubjects() {
 /**
  * 获取笔记库知识点标签列表
  */
-export async function fetchNoteTagNames(subject) {
+export async function fetchNoteTagNames(subject, projectId) {
   const qs = new URLSearchParams()
   if (subject) qs.set('subject', subject)
+  if (projectId) qs.set('project_id', projectId)
   const resp = await fetch(`/api/notes/tags?${qs}`)
   const data = await _assertJsonSuccess(resp, '获取标签列表失败')
   return data.tags

--- a/frontend/src/components/workspace/ContentPanel.vue
+++ b/frontend/src/components/workspace/ContentPanel.vue
@@ -5,18 +5,69 @@
  * 支持：顶部栏（标题 + 步骤 tab + 工具栏）+ 主内容区 + 可选右侧属性栏
  */
 import { PanelLeft } from 'lucide-vue-next'
+import { computed, onBeforeUnmount, onMounted, ref, useSlots } from 'vue'
 import { useWorkspaceNav } from '@/composables/useWorkspaceNav.js'
 import BaseTooltip from '@/components/base/BaseTooltip.vue'
 
-defineProps({
+const props = defineProps({
   title: { type: String, required: true },
   steps: { type: Array, default: () => [] },  // [{ label, active, done }]
   currentStep: { type: Number, default: -1 }, // -1 = 不显示步骤
+  sidebarOpen: { type: Boolean, default: undefined },
+  sidebarOpen: { type: Boolean, default: undefined },
 })
 
 const emit = defineEmits(['step-click'])
+const slots = useSlots()
 
 const { sidebarMode, isMobile, toggleSidebar } = useWorkspaceNav()
+
+const SIDEBAR_WIDTH_KEY = 'content_panel_sidebar_width_v1'
+const SIDEBAR_MIN_WIDTH = 280
+const SIDEBAR_MAX_WIDTH = 520
+const sidebarWidth = ref(320)
+const resizingSidebar = ref(false)
+
+const sidebarWidthPx = computed(() => `${sidebarWidth.value}px`)
+const hasSidebar = computed(() => Boolean(slots.sidebar))
+const isSidebarOpen = computed(() => hasSidebar.value && (props.sidebarOpen ?? true))
+
+const clampSidebarWidth = (width) => Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, width))
+
+const onSidebarResizeMove = (event) => {
+  if (!resizingSidebar.value) return
+  sidebarWidth.value = clampSidebarWidth(window.innerWidth - event.clientX)
+}
+
+const stopSidebarResize = () => {
+  if (!resizingSidebar.value) return
+  resizingSidebar.value = false
+  document.body.style.cursor = ''
+  document.body.style.userSelect = ''
+  try { localStorage.setItem(SIDEBAR_WIDTH_KEY, String(sidebarWidth.value)) } catch (_) { }
+  window.removeEventListener('pointermove', onSidebarResizeMove)
+  window.removeEventListener('pointerup', stopSidebarResize)
+  window.removeEventListener('pointercancel', stopSidebarResize)
+}
+
+const startSidebarResize = (event) => {
+  if (isMobile.value) return
+  event.preventDefault()
+  resizingSidebar.value = true
+  document.body.style.cursor = 'col-resize'
+  document.body.style.userSelect = 'none'
+  window.addEventListener('pointermove', onSidebarResizeMove)
+  window.addEventListener('pointerup', stopSidebarResize)
+  window.addEventListener('pointercancel', stopSidebarResize)
+}
+
+onMounted(() => {
+  let saved = null
+  try { saved = Number(localStorage.getItem(SIDEBAR_WIDTH_KEY)) } catch (_) { }
+  if (saved) sidebarWidth.value = clampSidebarWidth(saved)
+})
+
+onBeforeUnmount(stopSidebarResize)
 </script>
 
 <template>
@@ -83,9 +134,25 @@ const { sidebarMode, isMobile, toggleSidebar } = useWorkspaceNav()
       </div>
 
       <!-- 右侧属性栏（可选） -->
-      <aside v-if="$slots.sidebar"
-        class="hidden lg:flex w-80 shrink-0 flex-col border-l border-gray-200 dark:border-white/[0.05] overflow-y-auto transition-colors">
-        <slot name="sidebar"></slot>
+      <aside v-if="hasSidebar"
+        class="relative hidden shrink-0 overflow-hidden transition-[width,border-color] duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)] lg:flex"
+        :class="[
+          resizingSidebar ? '!transition-none' : '',
+          isSidebarOpen ? 'border-l border-gray-200 dark:border-white/[0.05]' : 'border-l border-transparent'
+        ]"
+        :style="{ width: isSidebarOpen ? sidebarWidthPx : '0px' }">
+          <button
+            v-show="isSidebarOpen"
+            class="absolute inset-y-0 left-0 z-20 w-2 -translate-x-1 cursor-col-resize outline-none transition-colors hover:bg-[rgb(var(--accent-rgb)/0.14)] focus-visible:bg-[rgb(var(--accent-rgb)/0.18)]"
+            title="拖动调整宽度"
+            @pointerdown="startSidebarResize"
+          ></button>
+          <div
+            class="flex h-full shrink-0 flex-col overflow-y-auto transition-[opacity,transform] duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)]"
+            :class="isSidebarOpen ? 'translate-x-0 opacity-100' : 'pointer-events-none translate-x-4 opacity-0'"
+            :style="{ width: sidebarWidthPx }">
+            <slot name="sidebar"></slot>
+          </div>
       </aside>
     </div>
   </div>

--- a/frontend/src/components/workspace/ModelProviderSelect.vue
+++ b/frontend/src/components/workspace/ModelProviderSelect.vue
@@ -1,0 +1,302 @@
+<script setup>
+import { computed, ref, watch } from 'vue'
+import {
+  Listbox,
+  ListboxButton,
+  ListboxOption,
+  ListboxOptions,
+} from '@headlessui/vue'
+import { useToast } from '@/composables/useToast.js'
+import deepseekLogo from '@/assets/deepseek.svg'
+import ernieLogo from '@/assets/ernie.svg'
+
+const props = defineProps({
+  modelValue: { type: String, default: '' },
+  modelOptionsData: { type: Object, default: null },
+  disabled: { type: Boolean, default: false },
+  noModels: { type: Boolean, default: false },
+  statusLoading: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['update:modelValue'])
+const { pushToast } = useToast()
+
+const modelLogos = { openai: deepseekLogo, anthropic: ernieLogo }
+const checking = ref(false)
+const activeSource = ref('')
+
+const options = computed(() => props.modelOptionsData?.options || [])
+
+const sourceGroups = computed(() => {
+  const groups = props.modelOptionsData?.groups || []
+  return groups
+    .map((group) => ({
+      key: group.key,
+      label: group.key === 'personal' ? '我的 Provider' : group.label,
+      count: options.value.filter((option) => option.source === group.key).length,
+    }))
+    .filter((group) => group.count > 0)
+})
+
+const groupedOptions = computed(() => {
+  const groups = sourceGroups.value
+  const items = []
+
+  for (const group of groups) {
+    if (activeSource.value && group.key !== activeSource.value) continue
+    const groupOptions = options.value.filter((option) => option.source === group.key)
+    if (!groupOptions.length) continue
+
+    items.push({ type: 'group', key: group.key, label: group.label })
+    for (const option of groupOptions) {
+      items.push({
+        type: 'model',
+        optionId: option.option_id,
+        source: option.source,
+        provider: option.category,
+        providerName: option.provider_name,
+        modelName: option.model_name,
+        label: option.label || option.model_name,
+        available: option.available,
+        isDefault: option.is_default,
+        reason: option.reason,
+      })
+    }
+  }
+
+  return items
+})
+
+const currentOption = computed(() => {
+  return options.value.find((option) => option.option_id === props.modelValue) || null
+})
+
+const currentSourceLabel = computed(() => {
+  const source = currentOption.value?.source || activeSource.value
+  const group = sourceGroups.value.find((item) => item.key === source)
+  return group?.label || ''
+})
+
+const selectedLabel = computed(() => {
+  if (props.noModels) return '暂无模型'
+  return currentOption.value?.label || currentOption.value?.model_name || '选择模型'
+})
+
+const statusState = computed(() => {
+  if (props.statusLoading || checking.value) return 'checking'
+  if (!currentOption.value) return 'idle'
+  if (!currentOption.value.available) return 'error'
+  return 'ready'
+})
+
+const selectModel = (value) => {
+  emit('update:modelValue', value)
+}
+
+const selectSource = (source) => {
+  activeSource.value = source
+}
+
+watch(() => props.modelValue, () => {
+  if (!props.modelValue) return
+  if (currentOption.value?.source) {
+    activeSource.value = currentOption.value.source
+  }
+  checking.value = true
+  pushToast?.('info', '正在检查模型状态...', 1000)
+
+  window.setTimeout(() => {
+    checking.value = false
+    const option = currentOption.value
+    if (!option) return
+    if (!option.available) {
+      pushToast?.('error', option.reason || '模型不可用', 3000)
+    } else {
+      pushToast?.('success', `${option.provider_name} 状态验证成功`, 2000)
+    }
+  }, 700)
+})
+
+watch(sourceGroups, (groups) => {
+  if (!groups.length) {
+    activeSource.value = ''
+    return
+  }
+  if (!groups.some((group) => group.key === activeSource.value)) {
+    activeSource.value = currentOption.value?.source || groups[0].key
+  }
+}, { immediate: true })
+</script>
+
+<template>
+  <Listbox :model-value="modelValue" :disabled="disabled || noModels" @update:model-value="selectModel">
+    <div class="relative w-56 min-w-0">
+      <ListboxButton
+        class="group flex h-10 w-full cursor-pointer items-center justify-between gap-3 rounded-lg border border-gray-200 bg-white/80 px-3 text-left text-xs font-medium text-gray-900 shadow-sm shadow-black/[0.02] transition-all hover:border-gray-300 hover:bg-white disabled:cursor-not-allowed disabled:opacity-60 dark:border-white/[0.09] dark:bg-white/[0.035] dark:text-[#d0d6e0] dark:shadow-black/20 dark:hover:border-white/[0.14] dark:hover:bg-white/[0.06]"
+      >
+        <div class="flex min-w-0 flex-1 items-center gap-2.5">
+          <div
+            class="relative flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-gray-500 transition-colors dark:bg-white/[0.06] dark:text-[#8a8f98]"
+          >
+            <Transition name="model-fade" mode="out-in">
+              <img
+                v-if="currentOption && modelLogos[currentOption.category]"
+                :key="currentOption.category"
+                :src="modelLogos[currentOption.category]"
+                class="h-3.5 w-3.5 object-contain"
+                alt=""
+              />
+              <i v-else key="fallback" class="fa-solid fa-robot text-[10px]"></i>
+            </Transition>
+            <span
+              class="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full border border-white dark:border-[#101114]"
+              :class="{
+                'animate-pulse bg-amber-400': statusState === 'checking',
+                'bg-emerald-500': statusState === 'ready',
+                'bg-rose-500': statusState === 'error',
+                'bg-gray-400': statusState === 'idle',
+              }"
+            ></span>
+          </div>
+
+          <span class="min-w-0 flex-1 truncate text-[13px] font-semibold tracking-tight">
+            {{ selectedLabel }}
+          </span>
+        </div>
+
+        <div class="flex shrink-0 items-center gap-2">
+          <span
+            v-if="currentSourceLabel"
+            class="hidden rounded-md bg-gray-100 px-1.5 py-0.5 text-[10px] font-semibold text-gray-500 dark:bg-white/[0.055] dark:text-[#777b84] sm:inline-flex"
+          >
+            {{ currentSourceLabel }}
+          </span>
+          <Transition name="model-pop" mode="out-in">
+            <i
+              v-if="statusState === 'checking'"
+              key="checking"
+              class="fa-solid fa-spinner animate-spin text-[10px] text-amber-500"
+            ></i>
+            <i
+              v-else-if="statusState === 'error'"
+              key="error"
+              class="fa-solid fa-xmark text-[10px] text-rose-500"
+            ></i>
+            <i
+              v-else-if="statusState === 'ready'"
+              key="ready"
+              class="fa-solid fa-check text-[10px] text-emerald-500"
+            ></i>
+          </Transition>
+          <i
+            class="fa-solid fa-chevron-down text-[10px] text-gray-400 transition-transform duration-200 group-aria-expanded:rotate-180 dark:text-[#62666d]"
+          ></i>
+        </div>
+      </ListboxButton>
+
+      <Transition
+        enter-active-class="transition duration-160 ease-out"
+        enter-from-class="-translate-y-1 scale-[0.98] opacity-0"
+        enter-to-class="translate-y-0 scale-100 opacity-100"
+        leave-active-class="transition duration-100 ease-in"
+        leave-from-class="translate-y-0 scale-100 opacity-100"
+        leave-to-class="-translate-y-1 scale-[0.98] opacity-0"
+      >
+        <ListboxOptions
+          class="absolute right-0 z-50 mt-2 max-h-72 w-full overflow-hidden rounded-lg border border-gray-200 bg-white p-1 text-sm shadow-xl shadow-black/10 outline-none dark:border-white/[0.08] dark:bg-[#151617] dark:shadow-black/30"
+        >
+          <div
+            v-if="sourceGroups.length > 1"
+            class="mb-1 grid grid-cols-2 gap-1 rounded-md bg-gray-100 p-1 dark:bg-white/[0.04]"
+          >
+            <button
+              v-for="source in sourceGroups"
+              :key="source.key"
+              type="button"
+              class="rounded px-2 py-1.5 text-xs font-semibold transition-colors"
+              :class="activeSource === source.key
+                ? 'bg-white text-gray-950 shadow-sm dark:bg-white/[0.08] dark:text-[#f7f8f8]'
+                : 'text-gray-500 hover:text-gray-800 dark:text-[#777b84] dark:hover:text-[#d0d6e0]'"
+              @click.stop="selectSource(source.key)"
+            >
+              {{ source.label }}
+            </button>
+          </div>
+
+          <template v-for="(item, index) in groupedOptions" :key="item.type === 'group' ? item.key : item.optionId">
+            <li
+              v-if="item.type === 'group'"
+              class="select-none px-3 py-1.5 text-[11px] font-medium text-gray-500 dark:text-[#777b84]"
+              :class="index > 0 ? 'mt-1 border-t border-gray-100 pt-2 dark:border-white/[0.06]' : ''"
+            >
+              {{ item.label }}
+            </li>
+
+            <ListboxOption
+              v-else
+              v-slot="{ active, selected, disabled: optionDisabled }"
+              :value="item.optionId"
+              :disabled="!item.available"
+              as="template"
+            >
+              <li
+                class="relative flex cursor-pointer select-none items-center gap-2 rounded-md px-3 py-2.5 transition-colors"
+                :class="[
+                  active ? 'bg-gray-100 dark:bg-white/[0.045]' : '',
+                  selected ? 'text-gray-950 dark:text-[#f7f8f8]' : 'text-gray-700 dark:text-[#cbd5e1]',
+                  optionDisabled ? 'cursor-not-allowed opacity-45' : '',
+                ]"
+                :title="item.reason || item.label"
+              >
+                <i
+                  class="fa-solid fa-check w-3 shrink-0 text-[11px] transition-opacity"
+                  :class="selected ? 'opacity-100 accent-text' : 'opacity-0'"
+                ></i>
+                <img
+                  v-if="modelLogos[item.provider]"
+                  :src="modelLogos[item.provider]"
+                  class="h-3.5 w-3.5 shrink-0 object-contain opacity-75"
+                  alt=""
+                />
+                <i v-else class="fa-solid fa-robot h-3.5 w-3.5 shrink-0 text-[11px] text-gray-400"></i>
+                <span class="min-w-0 flex-1 truncate text-[13px] font-semibold">
+                  {{ item.label }}
+                </span>
+                <span
+                  v-if="item.isDefault"
+                  class="shrink-0 rounded-md bg-gray-100 px-1.5 py-0.5 text-[10px] font-semibold text-gray-400 dark:bg-white/[0.06] dark:text-[#62666d]"
+                >
+                  默认
+                </span>
+              </li>
+            </ListboxOption>
+          </template>
+        </ListboxOptions>
+      </Transition>
+    </div>
+  </Listbox>
+</template>
+
+<style scoped>
+.model-fade-enter-active,
+.model-fade-leave-active {
+  transition: opacity 160ms ease, transform 160ms ease;
+}
+
+.model-fade-enter-from,
+.model-fade-leave-to {
+  opacity: 0;
+  transform: scale(0.9);
+}
+
+.model-pop-enter-active,
+.model-pop-leave-active {
+  transition: opacity 160ms ease, transform 160ms ease;
+}
+
+.model-pop-enter-from,
+.model-pop-leave-to {
+  opacity: 0;
+  transform: scale(0.65);
+}
+</style>

--- a/frontend/src/components/workspace/SelectionPanel.vue
+++ b/frontend/src/components/workspace/SelectionPanel.vue
@@ -6,6 +6,7 @@
 defineProps({
   count: { type: Number, default: 0 },
   visible: { type: Boolean, default: false },
+  showExport: { type: Boolean, default: true },
   exportLabel: { type: String, default: '生成复习卷' },
   showSave: { type: Boolean, default: false },
 })
@@ -29,20 +30,22 @@ const emit = defineEmits(['export', 'save', 'clear'])
         </div>
 
         <div class="flex items-center gap-3">
-          <button @click="emit('export')"
-            class="group inline-flex h-10 items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-6 text-[13px] font-black tracking-widest text-slate-900 shadow-sm transition-all hover:border-slate-900 hover:bg-slate-50 dark:border-white/10 dark:bg-slate-900 dark:text-white dark:hover:border-white dark:hover:bg-slate-800">
+          <button v-if="showExport" @click="emit('export')"
+            class="group inline-flex h-10 items-center justify-center gap-2 rounded-xl px-6 text-[13px] font-black tracking-widest text-white shadow-sm transition-all hover:shadow-[0_0_22px_rgb(var(--accent-rgb)/0.22)]"
+            style="background: linear-gradient(to bottom, rgb(var(--accent-rgb) / 0.95), rgb(var(--accent-strong-rgb) / 0.95)); box-shadow: inset 0 1px 0 rgba(255,255,255,0.14);">
             <i class="fa-solid fa-file-export transition-transform group-hover:-translate-x-0.5"></i>
             {{ exportLabel }}
           </button>
 
           <button v-if="showSave" @click="emit('save')"
-            class="group inline-flex h-10 items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-6 text-[13px] font-black tracking-widest text-slate-900 shadow-sm transition-all hover:border-slate-900 hover:bg-slate-50 dark:border-white/10 dark:bg-slate-900 dark:text-white dark:hover:border-white dark:hover:bg-slate-800">
+            class="group inline-flex h-10 items-center justify-center gap-2 rounded-xl px-6 text-[13px] font-black tracking-widest text-white shadow-sm transition-all hover:shadow-[0_0_22px_rgb(var(--accent-rgb)/0.22)]"
+            style="background: linear-gradient(to bottom, rgb(var(--accent-rgb) / 0.95), rgb(var(--accent-strong-rgb) / 0.95)); box-shadow: inset 0 1px 0 rgba(255,255,255,0.14);">
             <i class="fa-solid fa-database transition-transform group-hover:-translate-y-0.5"></i>
             导入错题库
           </button>
 
           <button @click="emit('clear')"
-            class="group inline-flex h-10 items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-6 text-[13px] font-black tracking-widest text-slate-900 shadow-sm transition-all hover:border-slate-900 hover:bg-slate-50 dark:border-white/10 dark:bg-slate-900 dark:text-white dark:hover:border-white dark:hover:bg-slate-800">
+            class="group inline-flex h-10 items-center justify-center gap-2 rounded-xl border border-slate-200/70 bg-white/70 px-6 text-[13px] font-black tracking-widest text-slate-600 shadow-sm transition-all hover:border-slate-300 hover:bg-white hover:text-slate-900 dark:border-white/10 dark:bg-white/[0.04] dark:text-[#d0d6e0] dark:hover:border-white/[0.16] dark:hover:bg-white/[0.07] dark:hover:text-white">
             清除
           </button>
         </div>

--- a/frontend/src/components/workspace/SidebarNav.vue
+++ b/frontend/src/components/workspace/SidebarNav.vue
@@ -213,7 +213,7 @@ const userQuotaSummary = computed(() => {
 <template>
   <!-- ================== 侧边栏容器 ================== -->
   <aside
-    class="flex min-h-0 flex-col z-20 transition-all duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)] bg-transparent overflow-hidden"
+    class="sidebar-3d-stage flex min-h-0 flex-col z-20 transition-all duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)] bg-transparent overflow-hidden"
     :class="[
       isMobile
         ? 'fixed inset-y-0 left-0 w-64 transform ' + (mobileDrawerOpen ? 'translate-x-0' : '-translate-x-full')
@@ -221,8 +221,11 @@ const userQuotaSummary = computed(() => {
     ]">
 
     <!-- 设置视图 -->
-    <template v-if="isSettingsView">
-      <div class="flex min-h-0 flex-1 flex-col px-4 py-4 overflow-hidden">
+    <div class="sidebar-3d-shell relative min-h-0 flex-1">
+      <div class="sidebar-3d-card absolute inset-0" :class="isSettingsView ? 'is-flipped' : ''">
+      <div class="sidebar-3d-face sidebar-3d-face-back absolute inset-0 flex min-h-0 flex-1 flex-col px-4 py-4 overflow-hidden"
+        :class="isSettingsView ? 'sidebar-3d-face-active' : 'sidebar-3d-face-inactive'"
+        :aria-hidden="!isSettingsView">
         <button @click="returnToApp"
           class="mb-4 inline-flex w-full items-center gap-2 overflow-hidden px-3 pt-2 text-sm font-medium text-gray-500 transition-all duration-300 ease-[var(--sidebar-transition-timing)] hover:text-gray-700 dark:text-[#8a8f98] dark:hover:text-white">
           <i class="fa-solid fa-arrow-left text-xs"></i>
@@ -258,11 +261,12 @@ const userQuotaSummary = computed(() => {
           </div>
         </nav>
       </div>
-    </template>
+
 
     <!-- 主视图 -->
-    <template v-else>
-      <div class="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div class="sidebar-3d-face sidebar-3d-face-front absolute inset-0 flex min-h-0 flex-1 flex-col overflow-hidden pb-16"
+        :class="isSettingsView ? 'sidebar-3d-face-inactive' : 'sidebar-3d-face-active'"
+        :aria-hidden="isSettingsView">
         <div>
           <!-- Logo 标题区 -->
           <div class="flex h-14 items-center justify-between gap-2 px-3 transition-all duration-300 ease-[var(--sidebar-transition-timing)]">
@@ -650,8 +654,8 @@ const userQuotaSummary = computed(() => {
         </div>
       </div>
 
-      <!-- 底部用户区 -->
-      <div class="relative p-1.5">
+        <!-- 底部用户区 -->
+        <div class="absolute inset-x-0 bottom-0 p-1.5">
         <BaseDropdown :modelValue="userMenuOpen" @update:modelValue="(val) => emit('update:userMenuOpen', val)"
           :position="isNarrow ? 'right' : 'top'" :align="isNarrow ? 'end' : 'center'"
           :width="isNarrow ? 'w-48' : 'w-full'" :offset="isNarrow ? 'ml-4' : 'mb-1'"
@@ -665,7 +669,7 @@ const userQuotaSummary = computed(() => {
           <template #trigger="{ toggle }">
             <!-- 用户信息 -->
             <button @click.stop="toggle"
-              class="flex w-full items-center gap-2 rounded-md px-2 py-1 hover:bg-gray-100 dark:bg-white/[0.025] dark:hover:bg-white/[0.045] transition-all">
+              class="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 hover:bg-gray-100 dark:bg-white/[0.025] dark:hover:bg-white/[0.045] transition-all">
               <div
                 class="h-7 w-7 shrink-0 rounded-lg relative overflow-hidden flex items-center justify-center text-white text-xs font-medium"
                 style="background: linear-gradient(to bottom, rgb(var(--accent-rgb) / 0.9), rgb(var(--accent-strong-rgb) / 0.9)); box-shadow: inset 0 1px 0 0 rgba(255,255,255,0.12);">
@@ -717,12 +721,75 @@ const userQuotaSummary = computed(() => {
             </button>
           </template>
         </BaseDropdown>
+        </div>
       </div>
-    </template>
+    </div>
   </aside>
 </template>
 
 <style scoped>
+.sidebar-3d-stage {
+  perspective: 1100px;
+  transform-style: preserve-3d;
+}
+
+.sidebar-3d-shell {
+  perspective: 1100px;
+  transform-style: preserve-3d;
+}
+
+.sidebar-3d-card {
+  transform-style: preserve-3d;
+  transform-origin: center center;
+  transition: filter 280ms cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: filter;
+}
+
+.sidebar-3d-card.is-flipped {
+  filter: brightness(0.985);
+}
+
+.sidebar-3d-face {
+  backface-visibility: hidden;
+  transform-origin: center center;
+  transform-style: preserve-3d;
+  transition:
+    opacity 120ms ease,
+    transform 280ms cubic-bezier(0.22, 1, 0.36, 1),
+    filter 280ms cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: opacity, transform, filter;
+}
+
+.sidebar-3d-face-front {
+  transform: rotateY(0deg) translateX(0) scale(1);
+}
+
+.sidebar-3d-face-back {
+  transform: rotateY(0deg) translateX(0) scale(1);
+}
+
+.sidebar-3d-face-front.sidebar-3d-face-active,
+.sidebar-3d-face-back.sidebar-3d-face-active {
+  opacity: 1;
+  filter: brightness(1);
+  pointer-events: auto;
+  transform: rotateY(0deg) translateX(0) scale(1);
+}
+
+.sidebar-3d-face-front.sidebar-3d-face-inactive {
+  opacity: 0;
+  filter: brightness(0.9);
+  pointer-events: none;
+  transform: rotateY(90deg) scale(0.98);
+}
+
+.sidebar-3d-face-back.sidebar-3d-face-inactive {
+  opacity: 0;
+  filter: brightness(0.9);
+  pointer-events: none;
+  transform: rotateY(-90deg) scale(0.98);
+}
+
 .custom-scrollbar::-webkit-scrollbar {
   width: 4px;
 }

--- a/frontend/src/components/workspace/SidebarNav.vue
+++ b/frontend/src/components/workspace/SidebarNav.vue
@@ -3,7 +3,7 @@
  * SidebarNav.vue
  * 工作台左侧边栏导航（PC 端双模式 + 移动端抽屉）+ 底部 Tab 导航（移动端）
  */
-import { computed } from 'vue'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import BaseLogo from '@/components/base/BaseLogo.vue'
 import BaseDropdown from '@/components/base/BaseDropdown.vue'
 import BaseTooltip from '@/components/base/BaseTooltip.vue'
@@ -20,6 +20,9 @@ const props = defineProps({
   navGroups: { type: Array, required: true },
   workspaceViews: { type: Object, required: true },
   collapsedGroups: { type: Object, required: true },
+  projects: { type: Array, default: () => [] },
+  activeProjectId: { type: [String, Number], default: null },
+  loadingProjects: { type: Boolean, default: false },
   // 指示器
   navRef: { type: Object, default: null },
   navBtnRefs: { type: Object, required: true },
@@ -49,6 +52,7 @@ const emit = defineEmits([
   'update:userMenuOpen', 'update:chatMenuOpenId', 'update:renameText', 'update:renamingChatId',
   'update:navRef', 'update:chatListRef',
   'navigate-home', 'logout', 'toggle-theme',
+  'select-project', 'create-project', 'rename-project', 'delete-project',
   'create-ai-chat', 'select-ai-chat',
   'start-rename-chat', 'confirm-rename-chat', 'delete-ai-chat', 'toggle-chat-menu',
   'toggle-sidebar',
@@ -56,6 +60,21 @@ const emit = defineEmits([
 
 const isSettingsView = computed(() => props.currentView === 'settings')
 const isNarrow = computed(() => !props.isMobile && props.sidebarMode === 'collapsed-icon')
+const topNavGroups = computed(() => props.navGroups.filter(group => !group.label))
+const lowerNavGroups = computed(() => props.navGroups.filter(group => group.label))
+const errorBankProjects = computed(() => props.projects.filter(p => !p.is_default && (p.project_type || 'question') === 'question'))
+const noteProjects = computed(() => props.projects.filter(p => !p.is_default && p.project_type === 'note'))
+const projectGroupsCollapsed = ref({
+  errorBank: false,
+  notes: false,
+})
+const projectMenuOpenId = ref(null)
+const projectActiveClass = 'bg-[rgb(var(--accent-rgb)/0.12)] text-[rgb(var(--accent-strong-rgb))] ring-1 ring-[rgb(var(--accent-rgb)/0.18)] dark:bg-[rgb(var(--accent-rgb)/0.10)] dark:text-[rgb(var(--accent-hover-rgb))] dark:ring-[rgb(var(--accent-rgb)/0.14)]'
+const projectInactiveClass = 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-[#8a8f98] dark:hover:bg-white/[0.035] dark:hover:text-[#d0d6e0]'
+const chatScrollReady = ref(!props.chatCollapsed)
+let chatScrollTimer = null
+
+const projectDisplayName = (project) => project?.name || ''
 
 const setView = (view) => {
   emit('update:currentView', view)
@@ -86,6 +105,8 @@ const returnToApp = () => {
 }
 
 const selectChat = (s) => {
+  projectMenuOpenId.value = null
+  emit('update:chatMenuOpenId', null)
   emit('select-ai-chat', s)
   if (props.isMobile && props.mobileDrawerOpen) {
     emit('toggle-sidebar')
@@ -99,12 +120,76 @@ const createChat = () => {
   }
 }
 
+const selectProjectView = (project, view) => {
+  projectMenuOpenId.value = null
+  emit('update:chatMenuOpenId', null)
+  emit('select-project', project.id)
+  setView(view)
+}
+
+const renameProject = (project) => {
+  projectMenuOpenId.value = null
+  emit('update:chatMenuOpenId', null)
+  emit('rename-project', project)
+}
+
+const deleteProject = (project) => {
+  projectMenuOpenId.value = null
+  emit('update:chatMenuOpenId', null)
+  emit('delete-project', project)
+}
+
+const setProjectMenuOpen = (id, open) => {
+  projectMenuOpenId.value = open ? id : null
+  if (open) emit('update:chatMenuOpenId', null)
+}
+
+const setChatMenuOpen = (id, open) => {
+  emit('update:chatMenuOpenId', open ? id : null)
+  if (open) projectMenuOpenId.value = null
+}
+
 const toggleGroup = (gi) => {
   if (isNarrow.value) return // 窄栏模式下不允许折叠分组
   const next = { ...props.collapsedGroups }
   next[gi] = !next[gi]
   emit('update:collapsedGroups', next)
 }
+
+const toggleProjectGroup = (key) => {
+  if (isNarrow.value) return
+  projectMenuOpenId.value = null
+  projectGroupsCollapsed.value = {
+    ...projectGroupsCollapsed.value,
+    [key]: !projectGroupsCollapsed.value[key],
+  }
+}
+
+const toggleChatCollapsed = () => {
+  projectMenuOpenId.value = null
+  emit('update:chatMenuOpenId', null)
+  emit('update:chatCollapsed', !props.chatCollapsed)
+}
+
+const syncChatScroll = (collapsed) => {
+  if (chatScrollTimer) {
+    window.clearTimeout(chatScrollTimer)
+    chatScrollTimer = null
+  }
+  chatScrollReady.value = false
+  if (!collapsed) {
+    chatScrollTimer = window.setTimeout(() => {
+      chatScrollReady.value = true
+      chatScrollTimer = null
+    }, 320)
+  }
+}
+
+watch(() => props.chatCollapsed, syncChatScroll)
+
+onBeforeUnmount(() => {
+  if (chatScrollTimer) window.clearTimeout(chatScrollTimer)
+})
 
 const userDisplayName = computed(() => {
   const user = props.currentUser || {}
@@ -207,7 +292,217 @@ const userQuotaSummary = computed(() => {
             class="relative flex flex-col gap-1.5 pt-2 transition-all duration-300 ease-[var(--sidebar-transition-timing)]"
             :class="isNarrow ? 'px-3' : 'px-4'">
 
-            <template v-for="(group, gi) in navGroups" :key="gi">
+            <template v-for="(group, gi) in topNavGroups" :key="`top-${gi}`">
+              <!-- 分组标题（可折叠） -->
+              <button v-if="group.label" @click="group.collapsible && toggleGroup(gi)"
+                class="flex items-center gap-1 overflow-hidden text-xs font-medium uppercase tracking-[0.15em] text-gray-400 transition-all duration-300 ease-[var(--sidebar-transition-timing)] hover:text-gray-700 dark:text-[#62666d] dark:hover:text-[#8a8f98]"
+                :class="[
+                  isNarrow ? 'pointer-events-none mt-0 max-h-0 px-3 pb-0 opacity-0' : 'mt-6 max-h-8 px-3 pb-2 opacity-100',
+                  group.collapsible ? 'cursor-pointer' : 'cursor-default'
+                ]">
+                <span>{{ group.label }}</span>
+                <i v-if="group.collapsible"
+                  class="fa-solid fa-play text-[8px] text-gray-400 dark:text-[#62666d] transition-transform duration-200"
+                  :class="collapsedGroups[gi] ? '' : 'rotate-90'"></i>
+              </button>
+
+              <!-- 分组内容（grid 折叠动画） -->
+              <div class="grid transition-[grid-template-rows] duration-200 ease-out"
+                :class="isNarrow || !collapsedGroups[gi] ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'">
+                <div class="overflow-hidden">
+                  <div class="flex flex-col gap-1">
+                    <template v-for="item in group.items" :key="item.id">
+                      <!-- 禁用项 -->
+                      <BaseTooltip :text="item.label" placement="right" :disabled="!isNarrow">
+                        <button v-if="item.disabled" disabled
+                          class="flex items-center justify-between rounded-lg px-3 py-3 text-sm cursor-not-allowed text-gray-400 dark:text-[#62666d]">
+                          <div class="flex items-center gap-3 transition-all duration-300 ease-[var(--sidebar-transition-timing)]">
+                            <i class="fa-solid w-4 shrink-0 text-center text-sm" :class="item.icon"></i>
+                            <span
+                              class="overflow-hidden whitespace-nowrap transition-all duration-300 ease-[var(--sidebar-transition-timing)]"
+                              :class="isNarrow ? 'max-w-0 -translate-x-1 opacity-0' : 'max-w-[96px] translate-x-0 opacity-100'">{{ item.label }}</span>
+                          </div>
+                          <span
+                            class="overflow-hidden whitespace-nowrap rounded-md bg-gray-100 text-[10px] font-medium text-gray-500 transition-all duration-300 ease-[var(--sidebar-transition-timing)] dark:bg-white/[0.04] dark:text-[#62666d]"
+                            :class="isNarrow ? 'max-w-0 px-0 py-0 opacity-0' : 'max-w-[68px] px-2 py-0.5 opacity-100'">敬请期待</span>
+                        </button>
+                        <!-- 普通项 -->
+                        <button v-else :ref="el => navBtnRefs[item.id] = el"
+                          @click="setView(item.id === 'workspace' ? lastWorkspaceView : item.id)"
+                          class="group relative z-10 flex items-center rounded-lg text-sm font-medium outline-none transition-[width,height,padding,margin,gap] duration-300 ease-[var(--sidebar-transition-timing)]"
+                          :class="[
+                            item.match(currentView)
+                              ? 'brand-gradient-bg text-white shadow-sm border-none'
+                              : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-[#8a8f98] dark:hover:bg-white/[0.04] dark:hover:text-[#d0d6e0] transition-colors duration-150',
+                            'w-full gap-3 px-3 py-2'
+                          ]">
+                          <i class="fa-solid w-4 shrink-0 text-center text-sm" :class="item.icon"></i>
+                          <span
+                            class="overflow-hidden truncate whitespace-nowrap transition-all duration-300 ease-[var(--sidebar-transition-timing)]"
+                            :class="isNarrow ? 'max-w-0 -translate-x-1 opacity-0' : 'max-w-[128px] translate-x-0 opacity-100'">
+                            {{ item.label }}
+                          </span>
+                        </button>
+                      </BaseTooltip>
+                    </template>
+                  </div>
+                </div>
+              </div>
+            </template>
+
+            <section>
+              <div
+                class="flex items-center justify-between transition-all duration-300 ease-[var(--sidebar-transition-timing)]"
+                :class="isNarrow ? 'max-h-0 overflow-hidden p-0 opacity-0' : 'mt-5 max-h-7 pb-1.5 pl-2.5 pr-0 opacity-100'">
+                <button @click="toggleProjectGroup('errorBank')"
+                  class="flex h-6 items-center gap-1.5 overflow-hidden text-xs font-medium text-gray-400 transition-colors duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)] hover:text-gray-700 dark:text-[#62666d] dark:hover:text-[#9aa0aa]">
+                  <span>我的错题库</span>
+                  <i class="fa-solid fa-play text-[8px] text-gray-400 dark:text-[#62666d] transition-transform duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)]"
+                    :class="projectGroupsCollapsed.errorBank ? '' : 'rotate-90'"></i>
+                </button>
+                <button class="flex h-6 w-6 items-center justify-center rounded-md text-gray-500 transition-colors duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)] hover:bg-gray-100 hover:text-gray-700 dark:text-[#8a8f98] dark:hover:bg-white/[0.04] dark:hover:text-[#d0d6e0]"
+                  title="新建错题库" @click.stop="emit('create-project', 'question')">
+                  <i class="fa-solid fa-plus text-[10px]"></i>
+                </button>
+              </div>
+              <div class="grid transition-[grid-template-rows] duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)]"
+                :class="isNarrow || !projectGroupsCollapsed.errorBank ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'">
+                <div class="min-h-0"
+                  :class="projectMenuOpenId?.startsWith('q-') && !projectGroupsCollapsed.errorBank ? 'overflow-visible' : 'overflow-hidden'">
+                  <div class="flex flex-col gap-1 pb-px">
+                  <BaseTooltip v-if="isNarrow" text="我的错题库" placement="right">
+                    <button @click="setView('error-bank')"
+                      class="flex w-full items-center justify-center rounded-lg px-3 py-2 text-sm font-medium"
+                      :class="currentView === 'error-bank' ? 'brand-gradient-bg text-white shadow-sm' : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-[#8a8f98] dark:hover:bg-white/[0.04] dark:hover:text-[#d0d6e0]'">
+                      <i class="fa-solid fa-database w-4 text-center text-sm"></i>
+                    </button>
+                  </BaseTooltip>
+                  <template v-else>
+                    <div v-for="project in errorBankProjects" :key="`q-${project.id}`"
+                      class="group relative ml-5 flex min-h-7 w-[calc(100%-1.25rem)] items-center rounded-md text-xs font-medium transition-colors duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)]"
+                      :class="currentView === 'error-bank' && String(activeProjectId) === String(project.id)
+                        ? projectActiveClass
+                        : projectInactiveClass">
+                      <button @click="selectProjectView(project, 'error-bank')"
+                        class="flex min-w-0 flex-1 items-center gap-2.5 rounded-md px-2.5 py-1 text-left">
+                        <i class="fa-solid fa-database w-3.5 shrink-0 text-center text-[11px] opacity-90"></i>
+                        <span class="min-w-0 truncate">{{ projectDisplayName(project) }}</span>
+                      </button>
+                      <BaseDropdown :modelValue="projectMenuOpenId === `q-${project.id}`"
+                        @update:modelValue="(open) => setProjectMenuOpen(`q-${project.id}`, open)"
+                        position="bottom" align="right" width="w-32" wrapperClass="shrink-0"
+                        panelClass="rounded-md brand-btn dark:bg-[#1b1b1d] py-1">
+                        <template #trigger="{ toggle }">
+                          <button
+                            class="flex h-6 w-6 items-center justify-center opacity-55 transition-opacity duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)] hover:opacity-100"
+                            title="更多操作" @click.stop="toggle">
+                            <i class="fa-solid fa-ellipsis text-[9px]"></i>
+                          </button>
+                        </template>
+                        <template #default="{ close }">
+                          <button @click.stop="close(); renameProject(project)"
+                            class="flex w-full items-center gap-2 px-3 py-1.5 text-xs text-gray-700 transition-colors duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)] hover:bg-gray-50 hover:text-gray-900 dark:text-[#d0d6e0] dark:hover:bg-white/[0.05]">
+                            <i class="fa-solid fa-pen text-[10px] w-3 text-center text-gray-400 dark:text-[#62666d]"></i>
+                            重命名
+                          </button>
+                          <button @click.stop="close(); deleteProject(project)"
+                            class="flex w-full items-center gap-2 px-3 py-1.5 text-xs text-rose-500 transition-colors duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)] hover:bg-rose-50 dark:text-rose-400 dark:hover:bg-rose-500/10">
+                            <i class="fa-solid fa-trash text-[10px] w-3 text-center"></i>
+                            删除
+                          </button>
+                        </template>
+                      </BaseDropdown>
+                    </div>
+                    <div v-if="!loadingProjects && errorBankProjects.length === 0"
+                      class="ml-5 mr-1 rounded-md bg-gray-50/70 px-2.5 py-2 text-xs text-gray-400 dark:bg-white/[0.025] dark:text-[#62666d]">
+                      <div class="mb-1.5">还没有错题库</div>
+                      <button class="accent-text font-medium transition-opacity duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)] hover:opacity-80" @click.stop="emit('create-project', 'question')">
+                        <i class="fa-solid fa-plus mr-1 text-[10px]"></i>新建错题库
+                      </button>
+                    </div>
+                  </template>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section>
+              <div
+                class="flex items-center justify-between transition-all duration-300 ease-[var(--sidebar-transition-timing)]"
+                :class="isNarrow ? 'max-h-0 overflow-hidden p-0 opacity-0' : 'mt-5 max-h-7 pb-1.5 pl-2.5 pr-0 opacity-100'">
+                <button @click="toggleProjectGroup('notes')"
+                  class="flex h-6 items-center gap-1.5 overflow-hidden text-xs font-medium text-gray-400 transition-colors duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)] hover:text-gray-700 dark:text-[#62666d] dark:hover:text-[#9aa0aa]">
+                  <span>我的笔记本</span>
+                  <i class="fa-solid fa-play text-[8px] text-gray-400 dark:text-[#62666d] transition-transform duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)]"
+                    :class="projectGroupsCollapsed.notes ? '' : 'rotate-90'"></i>
+                </button>
+                <button class="flex h-6 w-6 items-center justify-center rounded-md text-gray-500 transition-colors duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)] hover:bg-gray-100 hover:text-gray-700 dark:text-[#8a8f98] dark:hover:bg-white/[0.04] dark:hover:text-[#d0d6e0]"
+                  title="新建笔记本" @click.stop="emit('create-project', 'note')">
+                  <i class="fa-solid fa-plus text-[10px]"></i>
+                </button>
+              </div>
+              <div class="grid transition-[grid-template-rows] duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)]"
+                :class="isNarrow || !projectGroupsCollapsed.notes ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'">
+                <div class="min-h-0"
+                  :class="projectMenuOpenId?.startsWith('n-') && !projectGroupsCollapsed.notes ? 'overflow-visible' : 'overflow-hidden'">
+                  <div class="flex flex-col gap-1 pb-px">
+                  <BaseTooltip v-if="isNarrow" text="我的笔记本" placement="right">
+                    <button @click="setView('notes')"
+                      class="flex w-full items-center justify-center rounded-lg px-3 py-2 text-sm font-medium"
+                      :class="currentView === 'notes' ? 'brand-gradient-bg text-white shadow-sm' : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-[#8a8f98] dark:hover:bg-white/[0.04] dark:hover:text-[#d0d6e0]'">
+                      <i class="fa-solid fa-book-open w-4 text-center text-sm"></i>
+                    </button>
+                  </BaseTooltip>
+                  <template v-else>
+                    <div v-for="project in noteProjects" :key="`n-${project.id}`"
+                      class="group relative ml-5 flex min-h-7 w-[calc(100%-1.25rem)] items-center rounded-md text-xs font-medium transition-colors duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)]"
+                      :class="currentView === 'notes' && String(activeProjectId) === String(project.id)
+                        ? projectActiveClass
+                        : projectInactiveClass">
+                      <button @click="selectProjectView(project, 'notes')"
+                        class="flex min-w-0 flex-1 items-center gap-2.5 rounded-md px-2.5 py-1 text-left">
+                        <i class="fa-solid fa-book-open w-3.5 shrink-0 text-center text-[11px] opacity-90"></i>
+                        <span class="min-w-0 truncate">{{ projectDisplayName(project) }}</span>
+                      </button>
+                      <BaseDropdown :modelValue="projectMenuOpenId === `n-${project.id}`"
+                        @update:modelValue="(open) => setProjectMenuOpen(`n-${project.id}`, open)"
+                        position="bottom" align="right" width="w-32" wrapperClass="shrink-0"
+                        panelClass="rounded-md brand-btn dark:bg-[#1b1b1d] py-1">
+                        <template #trigger="{ toggle }">
+                          <button
+                            class="flex h-6 w-6 items-center justify-center opacity-55 transition-opacity duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)] hover:opacity-100"
+                            title="更多操作" @click.stop="toggle">
+                            <i class="fa-solid fa-ellipsis text-[9px]"></i>
+                          </button>
+                        </template>
+                        <template #default="{ close }">
+                          <button @click.stop="close(); renameProject(project)"
+                            class="flex w-full items-center gap-2 px-3 py-1.5 text-xs text-gray-700 transition-colors duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)] hover:bg-gray-50 hover:text-gray-900 dark:text-[#d0d6e0] dark:hover:bg-white/[0.05]">
+                            <i class="fa-solid fa-pen text-[10px] w-3 text-center text-gray-400 dark:text-[#62666d]"></i>
+                            重命名
+                          </button>
+                          <button @click.stop="close(); deleteProject(project)"
+                            class="flex w-full items-center gap-2 px-3 py-1.5 text-xs text-rose-500 transition-colors duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)] hover:bg-rose-50 dark:text-rose-400 dark:hover:bg-rose-500/10">
+                            <i class="fa-solid fa-trash text-[10px] w-3 text-center"></i>
+                            删除
+                          </button>
+                        </template>
+                      </BaseDropdown>
+                    </div>
+                    <div v-if="!loadingProjects && noteProjects.length === 0"
+                      class="ml-5 mr-1 rounded-md bg-gray-50/70 px-2.5 py-2 text-xs text-gray-400 dark:bg-white/[0.025] dark:text-[#62666d]">
+                      <div class="mb-1.5">还没有笔记本</div>
+                      <button class="accent-text font-medium transition-opacity duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)] hover:opacity-80" @click.stop="emit('create-project', 'note')">
+                        <i class="fa-solid fa-plus mr-1 text-[10px]"></i>新建笔记本
+                      </button>
+                    </div>
+                  </template>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <template v-for="(group, gi) in lowerNavGroups" :key="`lower-${gi}`">
               <!-- 分组标题（可折叠） -->
               <button v-if="group.label" @click="group.collapsible && toggleGroup(gi)"
                 class="flex items-center gap-1 overflow-hidden text-xs font-medium uppercase tracking-[0.15em] text-gray-400 transition-all duration-300 ease-[var(--sidebar-transition-timing)] hover:text-gray-700 dark:text-[#62666d] dark:hover:text-[#8a8f98]"
@@ -270,27 +565,28 @@ const userQuotaSummary = computed(() => {
         <!-- AI 对话历史列表 -->
         <div class="mt-2 flex min-h-0 flex-1 flex-col transition-all duration-300 ease-[var(--sidebar-transition-timing)]"
           :class="isNarrow ? 'px-3' : 'px-4'">
-          <div class="flex items-center justify-between mt-6 px-3 pb-2 transition-all duration-300 ease-[var(--sidebar-transition-timing)]">
-            <button @click="emit('update:chatCollapsed', !chatCollapsed)"
-              class="flex items-center gap-1 overflow-hidden text-xs font-medium uppercase tracking-[0.15em] text-gray-400 transition-all duration-300 ease-[var(--sidebar-transition-timing)] hover:text-gray-700 dark:text-[#62666d] dark:hover:text-[#8a8f98] cursor-pointer"
+          <div class="flex items-center justify-between mt-5 pb-1.5 pl-2.5 pr-0 transition-all duration-300 ease-[var(--sidebar-transition-timing)]">
+            <button @click="toggleChatCollapsed"
+              class="flex h-6 items-center gap-1.5 overflow-hidden text-xs font-medium text-gray-400 transition-all duration-300 ease-[var(--sidebar-transition-timing)] hover:text-gray-700 dark:text-[#62666d] dark:hover:text-[#9aa0aa] cursor-pointer"
               :class="isNarrow ? 'pointer-events-none max-w-0 -translate-x-1 opacity-0' : 'max-w-[80px] translate-x-0 opacity-100'">
               <span>对话</span>
               <i class="fa-solid fa-play text-[8px] text-gray-400 dark:text-[#62666d] transition-transform duration-200"
                 :class="chatCollapsed ? '' : 'rotate-90'"></i>
             </button>
             <button @click="createChat"
-              class="overflow-hidden text-gray-500 transition-all duration-300 ease-[var(--sidebar-transition-timing)] hover:text-gray-700 dark:text-[#8a8f98] dark:hover:text-[#d0d6e0]"
-              :class="isNarrow ? 'pointer-events-none w-0 -translate-x-1 opacity-0' : 'w-4 translate-x-0 opacity-100'"
+              class="flex items-center justify-center overflow-hidden rounded-md text-gray-500 transition-all duration-300 ease-[var(--sidebar-transition-timing)] hover:bg-gray-100 hover:text-gray-700 dark:text-[#8a8f98] dark:hover:bg-white/[0.04] dark:hover:text-[#d0d6e0]"
+              :class="isNarrow ? 'pointer-events-none h-0 w-0 -translate-x-1 opacity-0' : 'h-6 w-6 translate-x-0 opacity-100'"
               title="新对话">
               <i class="fa-solid fa-plus text-[10px]"></i>
             </button>
           </div>
           <!-- 折叠动画 -->
-          <div class="grid min-h-0 flex-1 transition-[grid-template-rows] duration-200 ease-out"
+          <div class="grid min-h-0 flex-1 transition-[grid-template-rows] duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)]"
             :class="isNarrow || !chatCollapsed ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'">
             <div class="flex min-h-0 flex-col overflow-hidden">
               <div :ref="(el) => $emit('update:chatListRef', el)"
-                class="relative h-full overflow-y-auto pb-2 custom-scrollbar"
+                class="relative h-full overflow-x-hidden pb-2 custom-scrollbar"
+                :class="chatScrollReady ? 'overflow-y-auto' : 'overflow-y-hidden'"
                 @click="emit('update:chatMenuOpenId', null)">
 
                 <div v-if="aiChatSessions.length === 0"
@@ -299,21 +595,21 @@ const userQuotaSummary = computed(() => {
                   暂无对话
                 </div>
                 <div v-for="s in aiChatSessions" :key="s.id" :ref="el => chatBtnRefs[s.id] = el"
-                  class="group relative mb-px flex cursor-pointer items-center rounded-lg text-sm font-medium outline-none transition-[width,height,padding,margin] duration-300"
+                  class="group relative mb-px flex cursor-pointer items-center rounded-md text-sm font-medium outline-none transition-[width,height,padding,margin] duration-300"
                   :class="[
                     chatMenuOpenId === s.id ? 'z-20' : 'z-10',
                     activeAiChatId === s.id && currentView === 'ai-chat'
                       ? 'brand-gradient-bg text-white shadow-sm border-none'
                       : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-[#8a8f98] dark:hover:bg-white/[0.04] dark:hover:text-[#d0d6e0] transition-colors duration-150',
-                    'w-full px-3 py-2 gap-3'
+                    'w-full gap-2.5 py-1.5 pl-2.5 pr-0'
                   ]" @click="renamingChatId !== s.id && selectChat(s)">
                   <BaseTooltip :text="s.title" placement="right" :disabled="!isNarrow">
-                    <i class="fa-solid fa-message w-4 shrink-0 text-center text-sm transition-colors"></i>
+                    <i class="fa-solid fa-message w-3.5 shrink-0 text-center text-xs transition-colors"></i>
                   </BaseTooltip>
 
                   <div
                     class="flex min-w-0 flex-1 items-center gap-2 overflow-visible transition-all duration-300 ease-[var(--sidebar-transition-timing)]"
-                    :class="isNarrow ? 'pointer-events-none max-w-0 -translate-x-1 opacity-0' : 'max-w-[180px] translate-x-0 opacity-100'">
+                    :class="isNarrow ? 'pointer-events-none max-w-0 -translate-x-1 opacity-0' : 'max-w-none translate-x-0 opacity-100'">
                     <!-- 重命名输入框 -->
                     <input v-if="renamingChatId === s.id" :value="renameText"
                       @input="emit('update:renameText', $event.target.value)" data-rename-input @click.stop
@@ -322,31 +618,30 @@ const userQuotaSummary = computed(() => {
                       class="flex-1 min-w-0 bg-transparent text-xs outline-none border-b border-gray-300 py-0.5 text-gray-900 dark:border-white/[0.12] dark:text-[#f7f8f8]" />
                     <span v-else class="relative z-10 flex-1 truncate">{{ s.title }}</span>
 
-                    <!-- 三个点按钮 -->
-                    <button @click.stop="emit('toggle-chat-menu', s.id)"
-                      class="shrink-0 opacity-0 group-hover:opacity-100 text-gray-400 hover:text-gray-700 dark:text-[#62666d] dark:hover:text-[#d0d6e0] transition-all ">
-                      <i class="fa-solid fa-ellipsis text-[10px]"></i>
-                    </button>
-
-                    <!-- Dropdown 菜单 -->
-                    <Transition enter-active-class="transition duration-100 ease-out"
-                      enter-from-class="opacity-0 scale-95" enter-to-class="opacity-100 scale-100"
-                      leave-active-class="transition duration-75 ease-in" leave-from-class="opacity-100 scale-100"
-                      leave-to-class="opacity-0 scale-95">
-                      <div v-if="chatMenuOpenId === s.id"
-                        class="absolute right-2 top-full mt-1 z-50 w-32 rounded-md brand-btn overflow-hidden"
-                        @click.stop>
-                        <button @click="emit('start-rename-chat', s)"
+                    <BaseDropdown :modelValue="chatMenuOpenId === s.id"
+                      @update:modelValue="(open) => setChatMenuOpen(s.id, open)"
+                      position="bottom" align="right" width="w-32" wrapperClass="shrink-0"
+                      panelClass="rounded-md brand-btn dark:bg-[#1b1b1d] py-1">
+                      <template #trigger="{ toggle }">
+                        <button
+                          class="flex h-6 w-6 items-center justify-center opacity-55 transition-opacity hover:opacity-100"
+                          title="更多操作" @click.stop="toggle">
+                          <i class="fa-solid fa-ellipsis text-[9px]"></i>
+                        </button>
+                      </template>
+                      <template #default="{ close }">
+                        <button @click.stop="close(); emit('start-rename-chat', s)"
                           class="flex w-full items-center gap-2 px-3 py-1.5 text-xs text-gray-700 hover:bg-gray-50 hover:text-gray-900 dark:text-[#d0d6e0] dark:hover:bg-white/[0.05] transition-colors">
                           <i class="fa-solid fa-pen text-[10px] w-3 text-center text-gray-400 dark:text-[#62666d]"></i>
                           重命名
                         </button>
-                        <button @click="emit('update:chatMenuOpenId', null); emit('delete-ai-chat', s.id)"
+                        <button @click.stop="close(); emit('delete-ai-chat', s.id)"
                           class="flex w-full items-center gap-2 px-3 py-1.5 text-xs text-rose-500 hover:bg-rose-50 dark:text-rose-400 dark:hover:bg-rose-500/10 transition-colors">
-                          <i class="fa-solid fa-trash text-[10px] w-4 text-center"></i> 删除
+                          <i class="fa-solid fa-trash text-[10px] w-3 text-center"></i>
+                          删除
                         </button>
-                      </div>
-                    </Transition>
+                      </template>
+                    </BaseDropdown>
                   </div>
                 </div>
               </div>
@@ -356,7 +651,7 @@ const userQuotaSummary = computed(() => {
       </div>
 
       <!-- 底部用户区 -->
-      <div class="relative p-2">
+      <div class="relative p-1.5">
         <BaseDropdown :modelValue="userMenuOpen" @update:modelValue="(val) => emit('update:userMenuOpen', val)"
           :position="isNarrow ? 'right' : 'top'" :align="isNarrow ? 'end' : 'center'"
           :width="isNarrow ? 'w-48' : 'w-full'" :offset="isNarrow ? 'ml-4' : 'mb-1'"
@@ -370,9 +665,9 @@ const userQuotaSummary = computed(() => {
           <template #trigger="{ toggle }">
             <!-- 用户信息 -->
             <button @click.stop="toggle"
-              class="flex w-full items-center gap-2 px-2 py-1.5 rounded-md hover:bg-gray-100 dark:hover:bg-white/[0.04] transition-all">
+              class="flex w-full items-center gap-2 rounded-md px-2 py-1 hover:bg-gray-100 dark:bg-white/[0.025] dark:hover:bg-white/[0.045] transition-all">
               <div
-                class="h-8 w-8 shrink-0 rounded-xl relative overflow-hidden flex items-center justify-center text-white text-sm font-medium"
+                class="h-7 w-7 shrink-0 rounded-lg relative overflow-hidden flex items-center justify-center text-white text-xs font-medium"
                 style="background: linear-gradient(to bottom, rgb(var(--accent-rgb) / 0.9), rgb(var(--accent-strong-rgb) / 0.9)); box-shadow: inset 0 1px 0 0 rgba(255,255,255,0.12);">
                 <img v-if="currentUser?.avatar_url" :src="currentUser.avatar_url" alt="用户头像"
                   class="h-full w-full object-cover" />
@@ -385,7 +680,7 @@ const userQuotaSummary = computed(() => {
               <div
                 class="min-w-0 flex-1 overflow-hidden text-left transition-all duration-300 ease-[var(--sidebar-transition-timing)]"
                 :class="isNarrow ? 'max-w-0 -translate-x-1 opacity-0' : 'max-w-[156px] translate-x-0 opacity-100'">
-                <p class="text-sm text-gray-900 dark:text-[#f7f8f8] truncate leading-tight transition-colors">{{
+                <p class="text-sm font-medium text-gray-900 dark:text-[#f7f8f8] truncate leading-tight transition-colors">{{
                   userDisplayName }}
                 </p>
                 <p v-if="userQuotaSummary"

--- a/frontend/src/components/workspace/StatusBar.vue
+++ b/frontend/src/components/workspace/StatusBar.vue
@@ -1,46 +1,9 @@
 <script setup>
-/**
- * StatusBar.vue
- * 状态栏（引擎状态 + 模型选择）
- */
-import { computed, ref, watch } from 'vue'
-import { useToast } from '@/composables/useToast.js'
-import {
-  Listbox,
-  ListboxButton,
-  ListboxOptions,
-  ListboxOption,
-} from '@headlessui/vue'
-import deepseekLogo from '@/assets/deepseek.svg'
-import ernieLogo from '@/assets/ernie.svg'
-
-// Tooltip 相关状态
-const tooltipVisible = ref(false)
-const tooltipText = ref('')
-const tooltipPosition = ref({ x: 0, y: 0 })
-
-// 显示 tooltip
-const showTooltip = (event, text) => {
-  if (!text || text.length <= 20) return // 短文本不需要 tooltip
-
-  tooltipText.value = text
-  const rect = event.currentTarget.getBoundingClientRect()
-  tooltipPosition.value = {
-    x: rect.left + rect.width / 2,
-    y: rect.top - 8
-  }
-  tooltipVisible.value = true
-}
-
-// 隐藏 tooltip
-const hideTooltip = () => {
-  tooltipVisible.value = false
-}
+import ModelProviderSelect from '@/components/workspace/ModelProviderSelect.vue'
 
 const emit = defineEmits(['update:selectedLlmOptionId'])
-const { pushToast } = useToast()
 
-const props = defineProps({
+defineProps({
   statusLoading: { type: Boolean, default: true },
   statusError: { type: String, default: '' },
   statusPills: { type: Array, default: () => [] },
@@ -49,103 +12,30 @@ const props = defineProps({
   disabled: { type: Boolean, default: false },
   noModels: { type: Boolean, default: false },
 })
-
-const modelLogos = { openai: deepseekLogo, anthropic: ernieLogo }
-
-// 构建分组模型列表
-const groupedOptions = computed(() => {
-  if (!props.modelOptionsData || !props.modelOptionsData.groups) return []
-
-  const items = []
-  for (const group of props.modelOptionsData.groups) {
-    const groupOptions = (props.modelOptionsData.options || []).filter(o => o.source === group.key)
-    if (groupOptions.length === 0) continue
-
-    items.push({ type: 'group', label: group.label })
-    for (const opt of groupOptions) {
-      items.push({
-        type: 'model',
-        optionId: opt.option_id,
-        provider: opt.category,
-        providerName: opt.provider_name,
-        modelName: opt.model_name,
-        label: opt.label,
-        configured: opt.configured,
-        available: opt.available,
-        isDefault: opt.is_default,
-        reason: opt.reason,
-      })
-    }
-  }
-  return items
-})
-
-// 当前选中的配置对象
-const currentOption = computed(() => {
-  if (!props.modelOptionsData || !props.modelOptionsData.options) return null
-  return props.modelOptionsData.options.find(o => o.option_id === props.selectedLlmOptionId) || null
-})
-
-const selectedLabel = computed(() => {
-  if (props.noModels) return '暂无模型'
-  if (!currentOption.value) return '选择模型'
-  return currentOption.value.label || currentOption.value.model_name
-})
-
-// ---- 模型检查状态 ----
-const isChecking = ref(false)
-const showResult = ref(true)
-
-watch(() => props.selectedLlmOptionId, () => {
-  isChecking.value = true
-  showResult.value = false
-
-  if (pushToast) {
-    pushToast('info', '正在检查模型状态...', 1000)
-  }
-
-  setTimeout(() => {
-    isChecking.value = false
-    showResult.value = true
-
-    if (pushToast) {
-      if (modelStatusError.value) {
-        pushToast('error', modelStatusError.value, 3000)
-      } else if (currentOption.value) {
-        pushToast('success', `${currentOption.value.provider_name} 状态验证成功`, 2000)
-      }
-    }
-  }, 1000)
-})
-
-const modelStatusError = computed(() => {
-  if (!showResult.value || !currentOption.value) return ''
-  if (!currentOption.value.available) return currentOption.value.reason || '模型不可用'
-  return ''
-})
 </script>
 
 <template>
-  <div class="relative z-20 flex flex-wrap items-center gap-4 text-sm shrink-0">
+  <div class="relative z-20 flex shrink-0 flex-wrap items-center gap-4 text-sm">
     <div class="flex items-center gap-2.5">
-      <span class="text-xs font-medium uppercase tracking-[0.15em] text-gray-500 dark:text-[#62666d] transition-colors">
+      <span class="text-xs font-medium uppercase tracking-[0.15em] text-gray-500 transition-colors dark:text-[#62666d]">
         引擎状态
       </span>
     </div>
 
-    <!-- 分隔符 -->
-    <div class="h-4 w-px bg-gray-300 dark:bg-white/[0.08] transition-colors"></div>
+    <div class="h-4 w-px bg-gray-300 transition-colors dark:bg-white/[0.08]"></div>
 
-    <!-- 全局系统错误 -->
-    <span v-if="statusError"
-      class="inline-flex items-center gap-2 rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-1.5 text-xs font-medium text-rose-500 dark:text-rose-400 transition-colors">
+    <span
+      v-if="statusError"
+      class="inline-flex items-center gap-2 rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-1.5 text-xs font-medium text-rose-500 transition-colors dark:text-rose-400"
+    >
       <i class="fa-solid fa-circle-exclamation animate-pulse"></i>
       {{ statusError }}
     </span>
 
-    <!-- Pills -->
     <div v-if="!statusError" class="flex flex-wrap items-center gap-2.5">
-      <span v-for="p in statusPills" :key="p.key"
+      <span
+        v-for="p in statusPills"
+        :key="p.key"
         class="inline-flex items-center gap-2 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors"
         :class="p.loading
           ? 'border-amber-500/20 bg-amber-500/10 text-amber-600 dark:text-amber-400'
@@ -154,151 +44,35 @@ const modelStatusError = computed(() => {
             : p.ok
               ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
               : 'border-rose-500/20 bg-rose-500/10 text-rose-500 dark:text-rose-400'
-          ">
+        "
+      >
         <div class="relative h-2.5 w-2.5 shrink-0">
           <Transition name="icon-pop">
-            <i :key="p.loading ? 'loading' : p.isPlaceholder ? 'placeholder' : p.ok ? 'ok' : 'error'"
+            <i
+              :key="p.loading ? 'loading' : p.isPlaceholder ? 'placeholder' : p.ok ? 'ok' : 'error'"
               class="fa-solid absolute inset-0 flex items-center justify-center text-[10px]"
-              :class="p.loading ? 'fa-spinner animate-spin' : p.isPlaceholder ? 'fa-hourglass-start' : p.ok ? 'fa-check' : 'fa-xmark'"></i>
+              :class="p.loading ? 'fa-spinner animate-spin' : p.isPlaceholder ? 'fa-hourglass-start' : p.ok ? 'fa-check' : 'fa-xmark'"
+            ></i>
           </Transition>
         </div>
         {{ p.label }}
       </span>
     </div>
 
-    <!-- 模型下拉选择器 (按 provider 分组) -->
     <div v-if="!statusError" class="ml-auto flex items-center gap-2">
-      <Listbox :model-value="selectedLlmOptionId" @update:model-value="(v) => emit('update:selectedLlmOptionId', v)"
-        :disabled="disabled || noModels">
-        <div class="relative w-56 min-w-0">
-          <ListboxButton
-            class="group relative flex w-full cursor-pointer items-center justify-between gap-4 rounded-md border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.02] px-3 py-1.5 text-left text-xs font-medium text-gray-900 dark:text-[#d0d6e0] transition-colors hover:bg-gray-50 dark:hover:bg-white/[0.05] hover:border-gray-300 dark:hover:border-white/[0.12]"
-            :disabled="disabled">
-            <div class="flex items-center gap-2.5 min-w-0 flex-1">
-              <div
-                class="relative flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-gray-100 dark:bg-white/[0.05] accent-text transition-colors">
-                <Transition name="fade" mode="out-in">
-                  <img v-if="currentOption && modelLogos[currentOption.category]" :key="currentOption.category"
-                    :src="modelLogos[currentOption.category]" class="h-3.5 w-3.5 object-contain" alt="" />
-                  <i v-else key="default-bot" class="fa-solid fa-robot text-[10px]"></i>
-                </Transition>
-                <!-- 状态指示点 -->
-                <div v-if="currentOption || statusLoading"
-                  class="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full border border-white dark:border-[#0f1011] transition-colors"
-                  :class="(statusLoading || isChecking) ? 'bg-amber-400 animate-pulse' : (!currentOption.available) ? 'bg-rose-500' : 'bg-emerald-500'">
-                </div>
-              </div>
-              <span
-                class="block min-w-0 flex-1 truncate text-xs font-medium tracking-tight text-gray-900 dark:text-[#d0d6e0] transition-colors"
-                @mouseenter="showTooltip($event, selectedLabel)" @mouseleave="hideTooltip">
-                {{ selectedLabel }}
-              </span>
-            </div>
-            <div class="flex items-center gap-2">
-              <div class="relative h-2.5 w-2.5 shrink-0">
-                <Transition name="icon-pop">
-                  <i v-if="isChecking || statusLoading" key="checking"
-                    class="fa-solid fa-spinner animate-spin absolute inset-0 flex items-center justify-center text-[10px] text-amber-500"></i>
-                  <i v-else-if="currentOption && !currentOption.available" key="error"
-                    class="fa-solid fa-xmark absolute inset-0 flex items-center justify-center text-[10px] text-rose-500"></i>
-                  <i v-else-if="currentOption" key="ok"
-                    class="fa-solid fa-check absolute inset-0 flex items-center justify-center text-[10px] text-emerald-500"></i>
-                </Transition>
-              </div>
-              <i
-                class="fa-solid fa-chevron-down shrink-0 text-[10px] text-gray-400 dark:text-[#62666d] transition-all duration-300 group-aria-expanded:rotate-180"></i>
-            </div>
-          </ListboxButton>
-
-          <Transition enter-active-class="transition duration-200 ease-out"
-            enter-from-class="transform scale-95 opacity-0 -translate-y-2"
-            enter-to-class="transform scale-100 opacity-100 translate-y-0"
-            leave-active-class="transition duration-100 ease-in"
-            leave-from-class="transform scale-100 opacity-100 translate-y-0"
-            leave-to-class="transform scale-95 opacity-0 -translate-y-2">
-            <ListboxOptions
-              class="absolute right-0 z-50 mt-2 max-h-72 w-full overflow-auto rounded-md border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-[#15151e] text-base shadow-lg focus:outline-none sm:text-sm transition-colors">
-              <template v-for="(item, idx) in groupedOptions" :key="idx">
-                <!-- 分组标题 -->
-                <li v-if="item.type === 'group'"
-                  class="select-none px-4 text-[10px] font-medium uppercase tracking-widest text-gray-500 dark:text-[#62666d] transition-colors"
-                  :class="idx > 0 ? 'mt-1 border-t border-gray-100 dark:border-white/[0.05] pt-2' : ''">
-                  <div class="flex items-center gap-2">
-                    {{ item.label }}
-                  </div>
-                </li>
-                <!-- 模型选项 -->
-                <ListboxOption v-else :value="item.optionId" :disabled="!item.available" as="template"
-                  v-slot="{ active, selected, disabled: optDisabled }">
-                  <li class="relative cursor-pointer select-none py-2.5 pl-10 pr-4 transition-colors" :class="[
-                    active ? 'bg-gray-100 dark:bg-white/[0.05]' : '',
-                    optDisabled ? 'opacity-40 cursor-not-allowed' : ''
-                  ]">
-                    <div class="flex items-center justify-between gap-2 min-w-0"
-                      @mouseenter="showTooltip($event, item.label)" @mouseleave="hideTooltip">
-                      <div class="flex items-center gap-2 min-w-0">
-                        <img v-if="modelLogos[item.provider]" :src="modelLogos[item.provider]"
-                          class="h-3.5 w-3.5 object-contain opacity-60 shrink-0" alt="" />
-                        <span class="truncate text-sm transition-colors"
-                          :class="[selected ? 'font-medium accent-text dark:text-white' : 'font-medium text-gray-700 dark:text-[#d0d6e0]']">
-                          {{ item.label }}
-                        </span>
-                      </div>
-                      <span v-if="item.isDefault"
-                        class="shrink-0 rounded bg-gray-100 px-1 py-0.5 text-[9px] font-bold text-gray-400 dark:bg-white/5 dark:text-[#62666d] transition-colors">默认</span>
-                    </div>
-                    <span v-if="selected"
-                      class="absolute inset-y-0 left-0 flex items-center pl-3 accent-text dark:text-white transition-colors">
-                      <i class="fa-solid fa-check text-sm"></i>
-                    </span>
-                  </li>
-                </ListboxOption>
-              </template>
-            </ListboxOptions>
-          </Transition>
-        </div>
-      </Listbox>
+      <ModelProviderSelect
+        :model-value="selectedLlmOptionId"
+        :model-options-data="modelOptionsData"
+        :disabled="disabled"
+        :no-models="noModels"
+        :status-loading="statusLoading"
+        @update:model-value="(value) => emit('update:selectedLlmOptionId', value)"
+      />
     </div>
   </div>
-
-  <!-- Tooltip 组件 -->
-  <Teleport to="body">
-    <Transition enter-active-class="transition duration-200 ease-out"
-      enter-from-class="opacity-0 scale-95 translate-y-1" enter-to-class="opacity-100 scale-100 translate-y-0"
-      leave-active-class="transition duration-150 ease-in" leave-from-class="opacity-100 scale-100 translate-y-0"
-      leave-to-class="opacity-0 scale-95 translate-y-1">
-      <div v-if="tooltipVisible && tooltipText" class="fixed z-[9999] pointer-events-none" :style="{
-        left: `${tooltipPosition.x}px`,
-        top: `${tooltipPosition.y}px`,
-        transform: 'translateX(-50%) translateY(-100%)'
-      }">
-        <div class="relative">
-          <!-- 箭头 -->
-          <div class="absolute left-1/2 top-full -translate-x-1/2 w-2 h-2">
-            <div class="w-2 h-2 bg-[#191a1b] rotate-45"></div>
-          </div>
-
-          <!-- 内容 -->
-          <div class="bg-[#191a1b] text-[#d0d6e0] px-3 py-2 rounded-lg text-xs font-medium whitespace-nowrap">
-            {{ tooltipText }}
-          </div>
-        </div>
-      </div>
-    </Transition>
-  </Teleport>
 </template>
 
 <style scoped>
-.fade-enter-active,
-.fade-leave-active {
-  transition: opacity 0.2s ease;
-}
-
-.fade-enter-from,
-.fade-leave-to {
-  opacity: 0;
-}
-
 .icon-pop-enter-active {
   transition: all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
 }

--- a/frontend/src/composables/useProjects.js
+++ b/frontend/src/composables/useProjects.js
@@ -1,0 +1,119 @@
+import { computed, ref } from 'vue'
+import * as api from '@/api.js'
+
+const STORAGE_KEYS = {
+  question: 'active_question_project_id_v1',
+  note: 'active_note_project_id_v1',
+}
+
+const projects = ref([])
+const activeQuestionProjectId = ref(null)
+const activeNoteProjectId = ref(null)
+const loadingProjects = ref(false)
+
+const questionProjects = computed(() => projects.value.filter(p => (p.project_type || 'question') === 'question'))
+const noteProjects = computed(() => projects.value.filter(p => p.project_type === 'note'))
+const activeQuestionProject = computed(() =>
+  questionProjects.value.find(p => String(p.id) === String(activeQuestionProjectId.value)) || null
+)
+const activeNoteProject = computed(() =>
+  noteProjects.value.find(p => String(p.id) === String(activeNoteProjectId.value)) || null
+)
+
+function sortProjects(list) {
+  return [...list].sort((a, b) => {
+    const typeCompare = String(a.project_type || 'question').localeCompare(String(b.project_type || 'question'))
+    if (typeCompare) return typeCompare
+    const aTime = Date.parse(a.updated_at || a.created_at || '') || 0
+    const bTime = Date.parse(b.updated_at || b.created_at || '') || 0
+    if (aTime !== bTime) return bTime - aTime
+    return Number(b.id || 0) - Number(a.id || 0)
+  })
+}
+
+function normalizeType(projectType) {
+  return projectType === 'note' ? 'note' : 'question'
+}
+
+function persistActiveProject(id, projectType = 'question') {
+  const key = STORAGE_KEYS[normalizeType(projectType)]
+  try {
+    if (id) localStorage.setItem(key, String(id))
+    else localStorage.removeItem(key)
+  } catch (_) { }
+}
+
+function setActiveProject(id, projectType) {
+  const type = normalizeType(projectType || projects.value.find(p => String(p.id) === String(id))?.project_type)
+  const value = id ? Number(id) : null
+  if (type === 'note') activeNoteProjectId.value = value
+  else activeQuestionProjectId.value = value
+  persistActiveProject(value, type)
+}
+
+function pickActiveProject(list, projectType) {
+  let saved = null
+  try { saved = localStorage.getItem(STORAGE_KEYS[projectType]) } catch (_) { }
+  const savedExists = saved && list.some(p => String(p.id) === String(saved))
+  return savedExists ? saved : (list[0]?.id || null)
+}
+
+async function loadProjects() {
+  loadingProjects.value = true
+  try {
+    const list = await api.fetchProjects()
+    projects.value = sortProjects(list.filter(p => !p.is_default))
+    setActiveProject(pickActiveProject(questionProjects.value, 'question'), 'question')
+    setActiveProject(pickActiveProject(noteProjects.value, 'note'), 'note')
+    return projects.value
+  } finally {
+    loadingProjects.value = false
+  }
+}
+
+async function createAndSelectProject(name, projectType = 'question') {
+  const type = normalizeType(projectType)
+  const project = await api.createProject({ name, project_type: type })
+  projects.value = sortProjects([project, ...projects.value.filter(p => p.id !== project.id)])
+  setActiveProject(project.id, type)
+  return project
+}
+
+async function renameProject(projectId, name) {
+  const project = await api.updateProject(projectId, { name })
+  projects.value = sortProjects(projects.value.map(p => p.id === project.id ? project : p))
+  return project
+}
+
+async function removeProject(projectId) {
+  const project = projects.value.find(p => p.id === projectId)
+  const type = normalizeType(project?.project_type)
+  await api.deleteProject(projectId)
+  projects.value = projects.value.filter(p => p.id !== projectId)
+  if (type === 'note' && String(activeNoteProjectId.value) === String(projectId)) {
+    setActiveProject(noteProjects.value[0]?.id || null, 'note')
+  }
+  if (type === 'question' && String(activeQuestionProjectId.value) === String(projectId)) {
+    setActiveProject(questionProjects.value[0]?.id || null, 'question')
+  }
+}
+
+export function useProjects() {
+  return {
+    projects,
+    questionProjects,
+    noteProjects,
+    activeProject: activeQuestionProject,
+    activeProjectId: activeQuestionProjectId,
+    activeQuestionProject,
+    activeQuestionProjectId,
+    activeNoteProject,
+    activeNoteProjectId,
+    loadingProjects,
+    loadProjects,
+    setActiveProject,
+    createAndSelectProject,
+    renameProject,
+    removeProject,
+  }
+}

--- a/frontend/src/composables/useSplitPipeline.js
+++ b/frontend/src/composables/useSplitPipeline.js
@@ -1,11 +1,13 @@
 import { ref } from 'vue'
 import * as api from '@/api.js'
 import { useAuth } from '@/composables/useAuth.js'
+import { useProjects } from '@/composables/useProjects.js'
 
 const QUOTA_EXCEEDED_CODE = 'DAILY_FREE_QUOTA_EXCEEDED'
 
 export function useSplitPipeline(pushToast, currentView, step, S, uploadReady, splitting, splitCompleted, uploadMode, selectedLlmOption, questions, selectedIds, pendingFiles, typesetMath) {
   const { setQuotaSnapshot, refreshCurrentUser } = useAuth()
+  const { activeQuestionProjectId, activeNoteProjectId, loadProjects } = useProjects()
   const eraseLoading = ref(false)
   const eraseImages = ref([])
   const eraseDone = ref(false)
@@ -131,6 +133,10 @@ export function useSplitPipeline(pushToast, currentView, step, S, uploadReady, s
   }
 
   const doNoteOrganize = async () => {
+    if (!activeNoteProjectId.value) {
+      pushToast('error', '请先创建并选择一个笔记本')
+      return
+    }
     splitting.value = true
     step.value = S.value.SPLIT
     pushToast('info', '正在调用AI整理笔记，请稍候...', 3000)
@@ -154,6 +160,7 @@ export function useSplitPipeline(pushToast, currentView, step, S, uploadReady, s
       if (selectedLlmOption.value?.provider_id) {
         formData.append('provider_id', selectedLlmOption.value.provider_id)
       }
+      formData.append('project_id', activeNoteProjectId.value)
 
       await new Promise((resolve, reject) => {
         api.createNote(formData, {
@@ -161,6 +168,7 @@ export function useSplitPipeline(pushToast, currentView, step, S, uploadReady, s
           onError: (error) => reject(error),
         })
       })
+      await loadProjects()
 
       splitCompleted.value = true
       step.value = S.value.EXPORT
@@ -205,17 +213,22 @@ export function useSplitPipeline(pushToast, currentView, step, S, uploadReady, s
     }
   }
 
-  const doSaveToDb = async (errorBankRef) => {
-    if (!selectedIds.size) { pushToast('error', '请至少选择一道题目！'); return }
+  const doSaveToDb = async (targetProjectId, errorBankRef) => {
+    if (!selectedIds.size) { pushToast('error', '请至少选择一道题目！'); return false }
     try {
+      const projectId = targetProjectId || activeQuestionProjectId.value
+      if (!projectId) { pushToast('error', '请先创建并选择一个错题库'); return false }
       const answers = questions.value
         .filter(q => selectedIds.has(q.uid) && (q.answer || q.user_answer))
         .map(q => ({ uid: q.uid, answer: q.answer || '', user_answer: q.user_answer || '' }))
-      const data = await api.saveToDb(Array.from(selectedIds), answers)
+      const data = await api.saveToDb(Array.from(selectedIds), answers, projectId)
+      await loadProjects()
       pushToast('success', data.message || '已导入错题库')
       errorBankRef?.value?.refresh()
+      return true
     } catch (e) {
       pushToast('error', '导入失败: ' + (e instanceof Error ? e.message : String(e)))
+      return false
     }
   }
 

--- a/frontend/src/composables/useWorkspaceNav.js
+++ b/frontend/src/composables/useWorkspaceNav.js
@@ -34,22 +34,7 @@ const NAV_GROUPS = [
     label: null,
     items: [
       { id: 'workspace', label: '录入工作台', icon: 'fa-wand-magic-sparkles', match: (v) => WORKSPACE_VIEWS.has(v) },
-    ],
-  },
-  {
-    label: '数据',
-    collapsible: true,
-    items: [
       { id: 'dashboard', label: '数据面板', icon: 'fa-chart-pie', match: (v) => v === 'dashboard' },
-      { id: 'error-bank', label: '错题库', icon: 'fa-database', match: (v) => v === 'error-bank' },
-      { id: 'notes', label: '笔记库', icon: 'fa-book-open', match: (v) => v === 'notes' },
-    ],
-  },
-  {
-    label: '更多',
-    collapsible: true,
-    items: [
-      { id: 'review-disabled', label: '刷题', icon: 'fa-clock-rotate-left', disabled: true },
     ],
   },
 ]

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -389,11 +389,7 @@ aside {
 }
 
 @media (prefers-reduced-motion: reduce) {
-
-  *,
-  *::before,
-  *::after {
-    transition-duration: 0.01ms !important;
-    animation-duration: 0.01ms !important;
+  html {
+    scroll-behavior: auto;
   }
 }

--- a/frontend/src/views/app/AppLayout.vue
+++ b/frontend/src/views/app/AppLayout.vue
@@ -16,8 +16,12 @@ import { useAiChatSessions } from '@/composables/useAiChatSessions.js'
 import { useWorkspaceNav } from '@/composables/useWorkspaceNav.js'
 import { useChatSession } from '@/composables/useChatSession.js'
 import { useToast } from '@/composables/useToast.js'
+import { useProjects } from '@/composables/useProjects.js'
 import SidebarNav from '@/components/workspace/SidebarNav.vue'
 import ImageModal from '@/components/base/ImageModal.vue'
+import BaseModal from '@/components/base/BaseModal.vue'
+import BaseButton from '@/components/base/BaseButton.vue'
+import BaseInput from '@/components/base/BaseInput.vue'
 import WorkspaceBackground from '@/components/workspace/WorkspaceBackground.vue'
 import AnswerInputModal from '@/components/workspace/AnswerInputModal.vue'
 import WorkspaceView from '@/views/app/WorkspaceView.vue'
@@ -35,6 +39,10 @@ const { currentUser, clearCurrentUser } = useAuth()
 const { loading: globalLoading } = usePageTransition()
 const { isDark, toggleTheme, initTheme } = useTheme()
 const { pushToast } = useToast()
+const {
+  projects, activeQuestionProjectId, activeNoteProjectId, loadingProjects,
+  loadProjects, setActiveProject, createAndSelectProject, renameProject, removeProject,
+} = useProjects()
 const { modalOpen, modalSrc, modalScale, closeModal } = useImageModal()
 const { doFetchStatus, doFetchModelOptions } = useSystemStatus()
 const {
@@ -72,6 +80,23 @@ const {
 // ── 认证 ────────────────────────────────────────────────
 const theme = computed(() => isDark.value ? 'dark' : 'light')
 const userMenuOpen = ref(false)
+const projectDialogOpen = ref(false)
+const projectDialogName = ref('')
+const projectDialogType = ref('question')
+const projectDialogMode = ref('create')
+const projectDialogTarget = ref(null)
+const projectDialogSaving = ref(false)
+const deleteProjectDialogOpen = ref(false)
+const deleteProjectTarget = ref(null)
+const deleteProjectSaving = ref(false)
+const projectDialogTitle = computed(() => {
+  if (projectDialogMode.value === 'rename') return '重命名'
+  return projectDialogType.value === 'note' ? '新建笔记本' : '新建错题库'
+})
+const projectDialogPlaceholder = computed(() => projectDialogType.value === 'note' ? '比如：语文笔记、数学公式' : '比如：数学错题、语文错题')
+const sidebarActiveProjectId = computed(() =>
+  currentView.value === 'notes' ? activeNoteProjectId.value : activeQuestionProjectId.value
+)
 
 const handleLogout = async () => {
   try { await fetch('/api/auth/logout', { method: 'POST' }) } catch (_) { }
@@ -117,6 +142,87 @@ const updateRenamingChatId = createRefSetter(renamingChatId)
 const updateNavRef = createRefSetter(navRef)
 const updateChatListRef = createRefSetter(chatListRef)
 
+const openProjectDialog = (projectType = 'question') => {
+  projectDialogMode.value = 'create'
+  projectDialogTarget.value = null
+  projectDialogType.value = projectType === 'note' ? 'note' : 'question'
+  projectDialogName.value = ''
+  projectDialogOpen.value = true
+  nextTick(() => {
+    document.querySelector('[data-project-name-input] input')?.focus()
+  })
+}
+
+const closeProjectDialog = () => {
+  if (projectDialogSaving.value) return
+  projectDialogOpen.value = false
+  projectDialogName.value = ''
+  projectDialogTarget.value = null
+}
+
+const openRenameProjectDialog = (project) => {
+  if (!project || project.is_default) return
+  projectDialogMode.value = 'rename'
+  projectDialogTarget.value = project
+  projectDialogType.value = project.project_type === 'note' ? 'note' : 'question'
+  projectDialogName.value = project.name || ''
+  projectDialogOpen.value = true
+  nextTick(() => {
+    const input = document.querySelector('[data-project-name-input] input')
+    input?.focus()
+    input?.select()
+  })
+}
+
+const handleCreateProject = async () => {
+  const name = projectDialogName.value.trim()
+  if (!name || projectDialogSaving.value) return
+  projectDialogSaving.value = true
+  try {
+    if (projectDialogMode.value === 'rename') {
+      await renameProject(projectDialogTarget.value.id, name)
+      pushToast('success', '项目已重命名')
+    } else {
+      await createAndSelectProject(name, projectDialogType.value)
+      pushToast('success', '项目已创建')
+    }
+    projectDialogOpen.value = false
+    projectDialogName.value = ''
+    projectDialogTarget.value = null
+  } catch (e) {
+    pushToast('error', e instanceof Error ? e.message : (projectDialogMode.value === 'rename' ? '重命名失败' : '创建项目失败'))
+  } finally {
+    projectDialogSaving.value = false
+  }
+}
+
+const handleDeleteProject = async (project) => {
+  if (!project || project.is_default) return
+  deleteProjectTarget.value = project
+  deleteProjectDialogOpen.value = true
+}
+
+const closeDeleteProjectDialog = () => {
+  if (deleteProjectSaving.value) return
+  deleteProjectDialogOpen.value = false
+  deleteProjectTarget.value = null
+}
+
+const confirmDeleteProject = async () => {
+  const project = deleteProjectTarget.value
+  if (!project || project.is_default || deleteProjectSaving.value) return
+  deleteProjectSaving.value = true
+  try {
+    await removeProject(project.id)
+    deleteProjectDialogOpen.value = false
+    deleteProjectTarget.value = null
+    pushToast('success', '项目已删除')
+  } catch (e) {
+    pushToast('error', e instanceof Error ? e.message : '删除项目失败')
+  } finally {
+    deleteProjectSaving.value = false
+  }
+}
 
 // ── 键盘事件 ────────────────────────────────────────────
 const onKeydown = (e) => {
@@ -134,6 +240,7 @@ onMounted(() => {
   document.addEventListener('keydown', onKeydown)
   document.addEventListener('click', closeChatMenu)
   loadAiChatSessions()
+  loadProjects().catch((e) => pushToast('error', e instanceof Error ? e.message : '加载项目失败'))
   nextTick(updateIndicator)
   watch(() => activeAiChatId.value, () => nextTick(updateIndicator))
 
@@ -178,6 +285,7 @@ onBeforeUnmount(() => {
       :active-ai-chat-id="activeAiChatId" :chat-list-ref="chatListRef" :chat-btn-refs="chatBtnRefs"
       :chat-indicator-style="chatIndicatorStyle" :chat-indicator-transition="chatIndicatorTransition"
       :chat-menu-open-id="chatMenuOpenId" :renaming-chat-id="renamingChatId" :rename-text="renameText"
+      :projects="projects" :active-project-id="sidebarActiveProjectId" :loading-projects="loadingProjects"
       :user-menu-open="userMenuOpen" :sidebar-mode="sidebarMode" :is-mobile="isMobile"
       :mobile-drawer-open="mobileDrawerOpen" @update:current-view="updateCurrentView"
       @update:current-settings-sub-view="updateCurrentSettingsSubView" @update:collapsed-groups="updateCollapsedGroups"
@@ -185,7 +293,9 @@ onBeforeUnmount(() => {
       @update:chat-menu-open-id="updateChatMenuOpenId" @update:rename-text="updateRenameText"
       @update:renaming-chat-id="updateRenamingChatId" @update:nav-ref="updateNavRef"
       @update:chat-list-ref="updateChatListRef" @navigate-home="navigateToHome" @logout="handleLogout"
-      @toggle-theme="toggleTheme" @create-ai-chat="createAiChat" @select-ai-chat="selectAiChat"
+      @toggle-theme="toggleTheme" @select-project="setActiveProject" @create-project="openProjectDialog"
+      @rename-project="openRenameProjectDialog" @delete-project="handleDeleteProject"
+      @create-ai-chat="createAiChat" @select-ai-chat="selectAiChat"
       @start-rename-chat="startRenameChat" @confirm-rename-chat="confirmRenameChat" @delete-ai-chat="deleteAiChat"
       @toggle-chat-menu="toggleChatMenu" @toggle-sidebar="toggleSidebar" />
 
@@ -232,6 +342,43 @@ onBeforeUnmount(() => {
       <AnswerInputModal :open="answerModalOpen" :text="answerModalText" :saving="answerModalSaving"
         @update:open="(v) => answerModalOpen = v" @update:text="(v) => answerModalText = v"
         @confirm="saveAnswerAndChat" />
+      <BaseModal :open="projectDialogOpen" :title="projectDialogTitle" icon="fa-folder-plus" iconBg="accent-bg-soft"
+        iconClass="accent-text" maxWidth="max-w-[28rem]" bodyClass="px-6 pb-3 pt-1"
+        @close="closeProjectDialog">
+        <form class="space-y-4" @submit.prevent="handleCreateProject">
+          <BaseInput v-model="projectDialogName" label="名称" :placeholder="projectDialogPlaceholder" maxlength="100"
+            data-project-name-input />
+        </form>
+        <template #footer>
+          <BaseButton variant="secondary" size="sm" :disabled="projectDialogSaving" @click="closeProjectDialog">
+            取消
+          </BaseButton>
+          <BaseButton variant="primary" size="sm" :disabled="projectDialogSaving || !projectDialogName.trim()"
+            @click="handleCreateProject">
+            {{ projectDialogSaving ? '处理中...' : (projectDialogMode === 'rename' ? '保存' : '创建') }}
+          </BaseButton>
+        </template>
+      </BaseModal>
+      <BaseModal :open="deleteProjectDialogOpen" title="删除项目" icon="fa-trash"
+        iconBg="bg-rose-50 dark:bg-rose-500/10" iconClass="text-rose-600 dark:text-rose-300"
+        maxWidth="max-w-[28rem]" bodyClass="px-6 pb-3 pt-1" @close="closeDeleteProjectDialog">
+        <div class="space-y-3 text-sm text-slate-600 dark:text-[#aeb6c2]">
+          <p>
+            确定删除“<span class="font-semibold text-slate-900 dark:text-[#f7f8f8]">{{ deleteProjectTarget?.name }}</span>”吗？
+          </p>
+          <p class="text-xs text-slate-400 dark:text-[#737b86]">
+            默认项目不能删除；已有内容的项目会被系统阻止删除。
+          </p>
+        </div>
+        <template #footer>
+          <BaseButton variant="secondary" size="sm" :disabled="deleteProjectSaving" @click="closeDeleteProjectDialog">
+            取消
+          </BaseButton>
+          <BaseButton variant="primary" size="sm" :disabled="deleteProjectSaving" @click="confirmDeleteProject">
+            {{ deleteProjectSaving ? '删除中...' : '删除' }}
+          </BaseButton>
+        </template>
+      </BaseModal>
     </Teleport>
   </div>
 </template>

--- a/frontend/src/views/app/ChatPageView.vue
+++ b/frontend/src/views/app/ChatPageView.vue
@@ -31,6 +31,7 @@ const inputText = ref('')
 const streaming = ref(false)
 const messagesContainer = ref(null)
 const deepThink = ref(false)
+const hasConversationContent = computed(() => messages.value.length > 0 || streaming.value)
 
 watch(sessionId, (id) => {
   if (id) loadMessages()
@@ -177,14 +178,14 @@ function autoResize() {
         <MessageSquarePlus class="w-4 h-4" />
       </button>
     </template>
-    <div class="flex flex-col h-full">
+    <div class="flex h-full min-h-0 flex-col overflow-hidden">
       <!-- 消息区域（含空状态） -->
-      <div ref="messagesContainer" class="flex-1 overflow-y-auto custom-scrollbar">
-        <div class="mx-auto max-w-5xl px-4 sm:px-8">
+      <div ref="messagesContainer" class="min-h-0 flex-1 custom-scrollbar"
+        :class="hasConversationContent ? 'overflow-y-auto' : 'overflow-hidden'">
+        <div class="mx-auto flex h-full max-w-5xl flex-col px-4 sm:px-8">
 
           <!-- 空状态：居中问候 -->
-          <div v-if="messages.length === 0 && !streaming" class="flex flex-col items-center justify-center"
-            style="min-height: calc(100vh - 200px)">
+          <div v-if="messages.length === 0 && !streaming" class="flex min-h-0 flex-1 flex-col items-center justify-center">
             <p class="text-2xl font-bold text-gray-900 dark:text-[#f7f8f8]">
               Hi，{{ username || '同学' }}
             </p>

--- a/frontend/src/views/app/DashboardView.vue
+++ b/frontend/src/views/app/DashboardView.vue
@@ -4,6 +4,7 @@ import * as api from '@/api.js'
 import { useTheme } from '@/composables/useTheme.js'
 import { useToast } from '@/composables/useToast.js'
 import { useWorkspaceNav } from '@/composables/useWorkspaceNav.js'
+import { useProjects } from '@/composables/useProjects.js'
 import ContentPanel from '@/components/workspace/ContentPanel.vue'
 import BaseSelect from '@/components/base/BaseSelect.vue'
 import BaseCard from '@/components/base/BaseCard.vue'
@@ -12,6 +13,7 @@ import StatCard from '@/components/dashboard/StatCard.vue'
 const { isDark, accentColorId } = useTheme()
 const { pushToast } = useToast()
 const { currentView } = useWorkspaceNav()
+const { activeQuestionProjectId } = useProjects()
 const theme = computed(() => isDark.value ? 'dark' : 'light')
 
 // ---- 统计数据 ----
@@ -47,9 +49,23 @@ const chartColorWithAlpha = (color, alpha) => color === 'accent' ? accentRgba(al
 
 // ---- 数据加载 ----
 const loadStats = async () => {
+  if (!activeQuestionProjectId.value) {
+    stats.value = {
+      total_questions: 0,
+      review_stats: {},
+      today_mastered: 0,
+      daily_counts: [],
+      tag_stats: [],
+      tag_status_stats: [],
+      tag_type_stats: { tags: [], types: [], data: [] },
+      subjects: [],
+    }
+    statsLoading.value = false
+    return
+  }
   statsLoading.value = true
   try {
-    const data = await api.fetchDashboardStats(selectedSubject.value || undefined)
+    const data = await api.fetchDashboardStats(selectedSubject.value || undefined, activeQuestionProjectId.value)
     stats.value = data
   } catch (e) {
     pushToast('error', '加载统计数据失败')
@@ -60,6 +76,10 @@ const loadStats = async () => {
 
 // ---- 学科切换 ----
 watch(selectedSubject, () => { loadStats() })
+watch(activeQuestionProjectId, () => {
+  selectedSubject.value = ''
+  loadStats()
+})
 
 // ---- 图表初始化 ----
 const initCharts = async () => {

--- a/frontend/src/views/app/ErrorBankView.vue
+++ b/frontend/src/views/app/ErrorBankView.vue
@@ -425,48 +425,48 @@ onBeforeUnmount(() => {
                     leave-to-class="opacity-0 scale-95 -translate-y-1">
                     <div v-if="hoverMenuId === question.id" :style="hoverMenuStyle" @mouseenter="onMenuContentEnter"
                       @mouseleave="onMenuContentLeave"
-                      class="w-44 overflow-hidden rounded-2xl border border-slate-200/60 bg-white/95 p-1.5 shadow-xl dark:border-white/10 dark:bg-[#12121A]/90 dark:bg-gradient-to-b dark:from-white/[0.08] dark:to-transparent dark:shadow-[0_20px_50px_rgba(0,0,0,0.6)]">
+                      class="w-44 overflow-hidden rounded-lg border border-slate-200/70 bg-white p-1 shadow-xl shadow-black/10 dark:border-white/[0.08] dark:bg-[#151617] dark:shadow-black/30">
                       <div
-                        class="px-3 pb-1 pt-2 text-[11px] font-black uppercase tracking-widest text-slate-400 dark:text-slate-500">
+                        class="px-3 pb-1.5 pt-1.5 text-[11px] font-medium text-slate-400 dark:text-[#777b84]">
                         复习状态</div>
                       <button @click.stop="quickMarkStatus(question, '待复习')"
-                        class="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold transition-all"
-                        :class="!question.review_status || question.review_status === '待复习' ? 'bg-rose-500/10 text-rose-600 dark:bg-rose-500/20 dark:text-rose-400' : 'text-slate-600 hover:bg-rose-500/10 hover:text-rose-600 dark:text-slate-300 dark:hover:bg-rose-500/20 dark:hover:text-rose-400'">
+                        class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm font-semibold transition-colors"
+                        :class="!question.review_status || question.review_status === '待复习' ? 'bg-rose-500/10 text-rose-600 dark:bg-rose-500/16 dark:text-rose-300' : 'text-slate-600 hover:bg-rose-500/10 hover:text-rose-600 dark:text-slate-300 dark:hover:bg-rose-500/12 dark:hover:text-rose-300'">
                         <i class="fa-solid fa-clock text-xs"></i>待复习
                         <i v-if="!question.review_status || question.review_status === '待复习'"
                           class="fa-solid fa-check ml-auto text-[10px]"></i>
                       </button>
                       <button @click.stop="quickMarkStatus(question, '复习中')"
-                        class="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold transition-all"
-                        :class="question.review_status === '复习中' ? 'bg-amber-500/10 text-amber-600 dark:bg-amber-500/20 dark:text-amber-400' : 'text-slate-600 hover:bg-amber-500/10 hover:text-amber-600 dark:text-slate-300 dark:hover:bg-amber-500/20 dark:hover:text-amber-400'">
+                        class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm font-semibold transition-colors"
+                        :class="question.review_status === '复习中' ? 'bg-amber-500/10 text-amber-600 dark:bg-amber-500/14 dark:text-amber-300' : 'text-slate-600 hover:bg-amber-500/10 hover:text-amber-600 dark:text-slate-300 dark:hover:bg-amber-500/12 dark:hover:text-amber-300'">
                         <i class="fa-solid fa-spinner text-xs"></i>复习中
                         <i v-if="question.review_status === '复习中'" class="fa-solid fa-check ml-auto text-[10px]"></i>
                       </button>
                       <button @click.stop="quickMarkStatus(question, '已掌握')"
-                        class="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold transition-all"
-                        :class="question.review_status === '已掌握' ? 'bg-emerald-500/10 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-400' : 'text-slate-600 hover:bg-emerald-500/10 hover:text-emerald-600 dark:text-slate-300 dark:hover:bg-emerald-500/20 dark:hover:text-emerald-400'">
+                        class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm font-semibold transition-colors"
+                        :class="question.review_status === '已掌握' ? 'bg-emerald-500/10 text-emerald-600 dark:bg-emerald-500/14 dark:text-emerald-300' : 'text-slate-600 hover:bg-emerald-500/10 hover:text-emerald-600 dark:text-slate-300 dark:hover:bg-emerald-500/12 dark:hover:text-emerald-300'">
                         <i class="fa-solid fa-circle-check text-xs"></i>已掌握
                         <i v-if="question.review_status === '已掌握'" class="fa-solid fa-check ml-auto text-[10px]"></i>
                       </button>
-                      <div class="mx-2 my-1.5 border-t border-slate-100 dark:border-white/5"></div>
+                      <div class="mx-2 my-1.5 border-t border-slate-100 dark:border-white/[0.06]"></div>
                       <div
-                        class="px-3 pb-1 text-[11px] font-black uppercase tracking-widest text-slate-400 dark:text-slate-500">
+                        class="px-3 pb-1 text-[11px] font-medium text-slate-400 dark:text-[#777b84]">
                         操作</div>
                       <button @click.stop="openEditDialog(question, 'question'); hoverMenuId = null"
-                        class="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold text-slate-600 transition-all hover:bg-blue-500/10 hover:text-blue-600 dark:text-slate-300 dark:hover:bg-blue-500/20 dark:hover:text-blue-400">
+                        class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm font-semibold text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-white/[0.045] dark:hover:text-[#f7f8f8]">
                         <i class="fa-solid fa-pen-to-square text-xs"></i>编辑
                       </button>
                       <button @click.stop="openEditDialog(question, 'user_answer'); hoverMenuId = null"
-                        class="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold text-slate-600 transition-all hover:bg-blue-500/10 hover:text-blue-600 dark:text-slate-300 dark:hover:bg-blue-500/20 dark:hover:text-blue-400">
+                        class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm font-semibold text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-white/[0.045] dark:hover:text-[#f7f8f8]">
                         <i class="fa-solid fa-note-sticky text-xs"></i>记笔记
                       </button>
                       <button @click.stop="openChat(question); hoverMenuId = null"
-                        class="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold text-slate-600 transition-all hover:bg-[rgb(var(--accent-rgb)/0.12)] hover:text-[rgb(var(--accent-rgb))] dark:text-slate-300">
+                        class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm font-semibold text-slate-600 transition-colors hover:bg-[rgb(var(--accent-rgb)/0.10)] hover:text-[rgb(var(--accent-rgb))] dark:text-slate-300 dark:hover:bg-[rgb(var(--accent-rgb)/0.12)]">
                         <i class="fa-solid fa-wand-magic-sparkles text-xs"></i>AI 辅导
                       </button>
-                      <div class="mx-2 my-1.5 border-t border-slate-100 dark:border-white/5"></div>
+                      <div class="mx-2 my-1.5 border-t border-slate-100 dark:border-white/[0.06]"></div>
                       <button @click.stop="doDelete(question); hoverMenuId = null"
-                        class="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-bold text-rose-500 transition-all hover:bg-rose-500/10 dark:text-rose-400 dark:hover:bg-rose-500/20">
+                        class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm font-semibold text-rose-500 transition-colors hover:bg-rose-500/10 dark:text-rose-400 dark:hover:bg-rose-500/12">
                         <i class="fa-solid fa-trash-can text-xs"></i>删除题目
                       </button>
                     </div>

--- a/frontend/src/views/app/ErrorBankView.vue
+++ b/frontend/src/views/app/ErrorBankView.vue
@@ -19,13 +19,16 @@ import { useImageModal } from '@/composables/useImageModal.js'
 import { useWorkspaceNav } from '@/composables/useWorkspaceNav.js'
 import { useChatSession } from '@/composables/useChatSession.js'
 import { useTheme } from '@/composables/useTheme.js'
+import { useProjects } from '@/composables/useProjects.js'
 
 const { pushToast } = useToast()
 const { openModal } = useImageModal()
 const { currentView } = useWorkspaceNav()
 const { openChat } = useChatSession()
 const { isDark } = useTheme()
+const { activeQuestionProjectId, questionProjects } = useProjects()
 const theme = computed(() => isDark.value ? 'dark' : 'light')
+const hasQuestionProject = computed(() => questionProjects.value.length > 0)
 
 // ---- 筛选条件 ----
 const openFilter = ref('')
@@ -101,6 +104,14 @@ const totalText = computed(() => `共收录 ${grandTotal.value} 道题目`)
 // ---- 查询 ----
 let debounceTimer = null
 const doQuery = async () => {
+  if (!activeQuestionProjectId.value) {
+    items.value = []
+    total.value = 0
+    grandTotal.value = 0
+    totalPages.value = 0
+    loading.value = false
+    return
+  }
   loading.value = true
   try {
     const params = { page: page.value, page_size: pageSize.value }
@@ -109,6 +120,7 @@ const doQuery = async () => {
     if (filters.question_type) params.question_type = filters.question_type
     if (filters.keyword) params.keyword = filters.keyword
     if (filters.review_status) params.review_status = filters.review_status
+    if (activeQuestionProjectId.value) params.project_id = activeQuestionProjectId.value
 
     const data = await api.fetchErrorBank(params)
     items.value = data.items || []
@@ -276,17 +288,27 @@ const pageButtons = computed(() => {
 })
 
 const refreshTags = async () => {
-  const raw = await api.fetchTagNames(filters.subject || undefined)
+  if (!activeQuestionProjectId.value) {
+    tagNames.value = []
+    return
+  }
+  const raw = await api.fetchTagNames(filters.subject || undefined, activeQuestionProjectId.value)
   tagNames.value = [...new Set(raw)]
 }
 
 const scrollContainerRef = ref(null)
 
 const loadFilters = async () => {
+  if (!activeQuestionProjectId.value) {
+    subjects.value = []
+    questionTypes.value = []
+    tagNames.value = []
+    return
+  }
   try {
     const [s, qt] = await Promise.all([
-      api.fetchSubjects(),
-      api.fetchQuestionTypes(),
+      api.fetchSubjects(activeQuestionProjectId.value),
+      api.fetchQuestionTypes(activeQuestionProjectId.value),
     ])
     subjects.value = s
     questionTypes.value = qt
@@ -309,6 +331,10 @@ const reloadTags = async () => {
 }
 
 watch(() => filters.subject, () => { reloadTags() })
+watch(activeQuestionProjectId, () => {
+  resetFilters()
+  loadFilters()
+})
 
 onMounted(() => { loadFilters(); doQuery() })
 
@@ -373,8 +399,9 @@ onBeforeUnmount(() => {
           <QuestionItemSkeleton v-if="loading && !items.length" />
 
           <!-- 空状态 -->
-          <EmptyState v-else-if="!loading && !items.length" icon="fa-solid fa-layer-group" title="暂无匹配记录"
-            description="调整筛选条件，或者开始新的录入">
+          <EmptyState v-else-if="!loading && !items.length" icon="fa-solid fa-layer-group"
+            :title="hasQuestionProject ? '暂无匹配记录' : '还没有错题库'"
+            :description="hasQuestionProject ? '调整筛选条件，或者开始新的录入' : '先在左侧创建一个错题库，再录入题目'">
             <BaseButton @click="currentView = 'workspace'" variant="primary" size="sm">
               <i class="fa-solid fa-plus"></i> 录入新题目
             </BaseButton>

--- a/frontend/src/views/app/NoteView.vue
+++ b/frontend/src/views/app/NoteView.vue
@@ -14,6 +14,7 @@ import { useToast } from '@/composables/useToast.js'
 import { useSystemStatus } from '@/composables/useSystemStatus.js'
 import { useAuth } from '@/composables/useAuth.js'
 import BaseViewSettingsPopover from '@/components/base/BaseViewSettingsPopover.vue'
+import { useProjects } from '@/composables/useProjects.js'
 
 const QUOTA_EXCEEDED_CODE = 'DAILY_FREE_QUOTA_EXCEEDED'
 
@@ -22,6 +23,8 @@ const router = useRouter()
 const { pushToast } = useToast()
 const { selectedLlmOption } = useSystemStatus()
 const { setQuotaSnapshot, refreshCurrentUser } = useAuth()
+const { activeNoteProjectId, noteProjects } = useProjects()
+const hasNoteProject = computed(() => noteProjects.value.length > 0)
 
 const noteContentRef = ref(null)
 
@@ -71,6 +74,12 @@ const editContent = ref('')
 
 // ---- 加载笔记列表 ----
 async function loadNotes() {
+  if (!activeNoteProjectId.value) {
+    notes.value = []
+    total.value = 0
+    loading.value = false
+    return
+  }
   loading.value = true
   try {
     const data = await api.fetchNotes({
@@ -79,6 +88,7 @@ async function loadNotes() {
       subject: filters.subject || undefined,
       knowledge_tag: filters.tag || undefined,
       keyword: filters.keyword || undefined,
+      project_id: activeNoteProjectId.value || undefined,
     })
     notes.value = data.items
     total.value = data.total
@@ -91,14 +101,22 @@ async function loadNotes() {
 
 // 加载筛选选项
 async function loadFilterOptions() {
+  if (!activeNoteProjectId.value) {
+    subjects.value = []
+    return
+  }
   try {
-    subjects.value = await api.fetchNoteSubjects()
+    subjects.value = await api.fetchNoteSubjects(activeNoteProjectId.value)
   } catch (_) { }
 }
 
 async function loadTags() {
+  if (!activeNoteProjectId.value) {
+    tagNames.value = []
+    return
+  }
   try {
-    tagNames.value = await api.fetchNoteTagNames(filters.subject || undefined)
+    tagNames.value = await api.fetchNoteTagNames(filters.subject || undefined, activeNoteProjectId.value)
   } catch (_) { }
 }
 
@@ -110,6 +128,15 @@ onMounted(() => {
 watch([page, () => filters.subject, () => filters.tag], () => { page.value === 1 ? loadNotes() : (page.value = 1) })
 watch(() => filters.subject, () => {
   filters.tag = ''
+  loadTags()
+})
+watch(activeNoteProjectId, () => {
+  filters.subject = ''
+  filters.tag = ''
+  page.value = 1
+  selectedNote.value = null
+  loadNotes()
+  loadFilterOptions()
   loadTags()
 })
 
@@ -276,8 +303,9 @@ function goToWorkspace() {
 
           <!-- Notes Grid -->
           <div class="relative flex-1 flex flex-col">
-            <EmptyState v-if="!loading && notes.length === 0" icon="fa-solid fa-book-open" title="还没有笔记"
-              description="上传手写笔记或板书照片，AI 自动整理为结构化知识点">
+            <EmptyState v-if="!loading && notes.length === 0" icon="fa-solid fa-book-open"
+              :title="hasNoteProject ? '还没有笔记' : '还没有笔记本'"
+              :description="hasNoteProject ? '上传手写笔记或板书照片，AI 自动整理为结构化知识点' : '先在左侧创建一个笔记本，再录入笔记'">
               <BaseButton @click="goToWorkspace" variant="primary" size="sm">
                 <i class="fa-solid fa-plus"></i> 录入新笔记
               </BaseButton>

--- a/frontend/src/views/app/ReviewView.vue
+++ b/frontend/src/views/app/ReviewView.vue
@@ -13,6 +13,8 @@ import { useImageModal } from '@/composables/useImageModal.js'
 import { useWorkspaceNav } from '@/composables/useWorkspaceNav.js'
 import { useChatSession } from '@/composables/useChatSession.js'
 import { useTheme } from '@/composables/useTheme.js'
+import { useSystemStatus } from '@/composables/useSystemStatus.js'
+import { useProjects } from '@/composables/useProjects.js'
 
 const { pushToast } = useToast()
 const { openModal } = useImageModal()
@@ -20,6 +22,7 @@ const { currentView } = useWorkspaceNav()
 const { openChat } = useChatSession()
 const { isDark } = useTheme()
 const { selectedLlmOption } = useSystemStatus()
+const { activeQuestionProjectId } = useProjects()
 const theme = computed(() => isDark.value ? 'dark' : 'light')
 
 const answerEditId = ref(null)
@@ -48,17 +51,28 @@ const aiAnalyzing = ref(false)
 
 // ---- 数据加载 ----
 const loadSubjects = async () => {
+  if (!activeQuestionProjectId.value) {
+    subjects.value = []
+    return
+  }
   try {
-    const data = await api.fetchDashboardStats()
+    const data = await api.fetchDashboardStats(undefined, activeQuestionProjectId.value)
     subjects.value = data?.subjects || []
   } catch (_) { }
 }
 
 const loadReviewItems = async () => {
+  if (!activeQuestionProjectId.value) {
+    reviewItems.value = []
+    reviewTotal.value = 0
+    reviewLoading.value = false
+    return
+  }
   reviewLoading.value = true
   try {
     const params = { review_status: '待复习', page: 1, page_size: 20 }
     if (selectedSubject.value) params.subject = selectedSubject.value
+    if (activeQuestionProjectId.value) params.project_id = activeQuestionProjectId.value
     const data = await api.fetchErrorBank(params)
     reviewItems.value = data.items || []
     reviewTotal.value = data.total || 0
@@ -73,6 +87,10 @@ const loadReviewItems = async () => {
 const loadAll = () => { loadSubjects(); loadReviewItems() }
 
 watch(selectedSubject, () => { loadReviewItems() })
+watch(activeQuestionProjectId, () => {
+  selectedSubject.value = ''
+  loadAll()
+})
 
 // ---- 题目操作 ----
 const typesetMath = async () => {

--- a/frontend/src/views/app/SplitHistoryView.vue
+++ b/frontend/src/views/app/SplitHistoryView.vue
@@ -87,9 +87,18 @@ const loadToWorkspace = () => {
 }
 
 // ---- 格式化 ----
+const parseApiDate = (iso) => {
+  if (!iso) return ''
+  const value = String(iso)
+  const normalized = /(?:Z|[+-]\d{2}:?\d{2})$/.test(value) ? value : `${value}Z`
+  const d = new Date(normalized)
+  return Number.isNaN(d.getTime()) ? null : d
+}
+
 const formatDate = (iso) => {
   if (!iso) return ''
-  const d = new Date(iso)
+  const d = parseApiDate(iso)
+  if (!d) return ''
   const now = new Date()
   const diffMs = now - d
   const diffMin = Math.floor(diffMs / 60000)
@@ -109,7 +118,8 @@ const formatDate = (iso) => {
 
 const formatFullDate = (iso) => {
   if (!iso) return ''
-  const d = new Date(iso)
+  const d = parseApiDate(iso)
+  if (!d) return ''
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}`
 }
 
@@ -148,7 +158,7 @@ defineExpose({ refresh: loadRecords })
 </script>
 
 <template>
-  <div v-show="visible" class="flex h-full flex-col overflow-hidden">
+  <div class="flex h-full flex-col overflow-hidden">
     <div class="relative flex h-full flex-col">
       <!-- 页头 -->
       <div class="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-white/[0.05] shrink-0 transition-colors">
@@ -181,8 +191,8 @@ defineExpose({ refresh: loadRecords })
           <div
             v-for="(r, idx) in records"
             :key="r.id"
-            class="group cursor-pointer border-b border-gray-200 dark:border-white/[0.05] px-4 py-3 transition-colors hover:bg-gray-50 dark:hover:bg-white/[0.03]"
-            :class="activeRecord?.id === r.id ? 'bg-gray-100 dark:bg-white/[0.04]' : ''"
+            class="group cursor-pointer border-gray-200 px-4 py-3 transition-colors hover:bg-gray-50 dark:border-white/[0.05] dark:hover:bg-white/[0.03]"
+            :class="activeRecord?.id === r.id ? 'bg-gray-100 dark:bg-white/[0.04]' : 'border-b'"
             @click="openDetail(r)"
           >
             <!-- 一行：科目 + 时间 + 题数 -->
@@ -191,66 +201,58 @@ defineExpose({ refresh: loadRecords })
               <span class="text-xs tabular-nums accent-text">{{ r.question_count }} 题</span>
             </div>
             <!-- 二行：文件数 + 时间 -->
-            <div class="flex items-center gap-2 text-xs text-gray-500 dark:text-[#62666d] transition-colors">
+            <div class="flex items-center gap-2 text-xs text-gray-500 no-underline dark:text-[#62666d] transition-colors [&_*]:no-underline">
               <span>{{ (r.file_names || []).length }} 个文件</span>
               <span>·</span>
               <span :title="formatFullDate(r.created_at)">{{ formatDate(r.created_at) }}</span>
             </div>
 
             <!-- 展开详情面板 -->
-            <Transition
-              enter-active-class="transition-all duration-400 ease-out"
-              enter-from-class="max-h-0 opacity-0"
-              enter-to-class="max-h-[2000px] opacity-100"
-              leave-active-class="transition-all duration-300 ease-in"
-              leave-from-class="max-h-[2000px] opacity-100"
-              leave-to-class="max-h-0 opacity-0"
-            >
-              <div v-if="activeRecord?.id === r.id" class="overflow-hidden border-t border-slate-200/40 dark:border-white/5">
+            <Transition name="split-record-expand">
+              <div v-if="activeRecord?.id === r.id" class="split-record-detail">
+                <div class="split-record-detail-inner">
                 <!-- 加载中 -->
                 <div v-if="detailLoading" class="flex items-center justify-center py-10">
                   <div class="h-7 w-7 animate-spin rounded-full border-[3px] border-slate-200 border-t-[rgb(var(--accent-rgb))] dark:border-slate-700"></div>
                 </div>
 
                 <!-- 题目列表 -->
-                <div v-else class="split-history-questions px-5 py-4">
+                <div v-else class="split-history-questions">
                   <!-- 工具栏 -->
-                  <div class="mb-4 flex flex-wrap items-center justify-between gap-2">
-                    <div class="flex items-center gap-2">
-                      <button
-                        @click.stop="selectAllQuestions"
-                        class="rounded-lg border border-slate-200/60 bg-white/60 px-3 py-1.5 text-xs font-bold text-slate-600 transition-all hover:bg-white dark:border-white/10 dark:bg-white/5 dark:text-slate-300 dark:hover:bg-white/10"
-                      >全选</button>
+                  <div class="border-b border-slate-200/40 dark:border-white/5">
+                    <div class="flex items-center gap-2 py-2">
                       <button
                         v-if="selectedIds.size > 0"
                         @click.stop="deselectAllQuestions"
-                        class="rounded-lg border border-slate-200/60 bg-white/60 px-3 py-1.5 text-xs font-bold text-slate-500 transition-all hover:bg-white dark:border-white/10 dark:bg-white/5 dark:text-slate-400 dark:hover:bg-white/10"
-                      >取消选择</button>
-                      <span v-if="selectedIds.size > 0" class="ml-1 text-xs font-semibold accent-text">
-                        已选 {{ selectedIds.size }} / {{ activeQuestions.length }}
-                      </span>
-                    </div>
+                        class="shrink-0 rounded-lg border border-slate-200/60 bg-white/60 px-3 py-2 text-xs font-bold text-slate-500 transition-all hover:bg-white dark:border-white/10 dark:bg-white/5 dark:text-slate-400 dark:hover:bg-white/10"
+                      >取消</button>
+                      <button
+                        v-else
+                        @click.stop="selectAllQuestions"
+                        class="shrink-0 rounded-lg border border-slate-200/60 bg-white/60 px-3 py-2 text-xs font-bold text-slate-600 transition-all hover:bg-white dark:border-white/10 dark:bg-white/5 dark:text-slate-300 dark:hover:bg-white/10"
+                      >全选</button>
                     <button
                       @click.stop="loadToWorkspace"
-                      class="inline-flex items-center gap-2 rounded-xl accent-bg px-4 py-2 text-xs font-bold text-white shadow-sm transition-all hover:shadow-md"
+                      class="inline-flex min-w-0 flex-1 items-center justify-center gap-2 rounded-lg accent-bg px-3 py-2 text-xs font-bold text-white shadow-sm transition-all hover:shadow-md"
                     >
                       <i class="fa-solid fa-arrow-right-to-bracket"></i>
-                      {{ selectedIds.size > 0 ? `加载选中 (${selectedIds.size})` : '全部加载到工作台' }}
+                      <span class="truncate">{{ selectedIds.size > 0 ? `加载选中 ${selectedIds.size}` : '全部加载' }}</span>
                     </button>
+                    </div>
                   </div>
 
                   <!-- 题目网格 -->
-                  <div class="grid grid-cols-1 gap-2.5 lg:grid-cols-2">
+                  <div class="grid grid-cols-1 gap-2.5">
                     <div
                       v-for="q in activeQuestions"
                       :key="q.uid"
                       @click.stop="toggleSelect(q.uid)"
-                      class="cursor-pointer rounded-xl border p-3.5 transition-all duration-200"
+                      class="cursor-pointer rounded-lg border p-3 transition-all duration-200"
                       :class="selectedIds.has(q.uid)
                         ? 'accent-border accent-bg-muted ring-1 ring-[rgb(var(--accent-rgb)/0.3)]'
                         : 'border-slate-200/50 bg-white/50 hover:border-[rgb(var(--accent-rgb)/0.35)] hover:bg-white/80 dark:border-white/[0.05] dark:bg-white/[0.02] dark:hover:border-[rgb(var(--accent-rgb)/0.25)]'"
                     >
-                      <div class="mb-2 flex items-center gap-2">
+                      <div class="mb-2 flex items-start gap-2">
                         <!-- 选中指示 -->
                         <div
                           class="flex h-5 w-5 shrink-0 items-center justify-center rounded-md border text-[10px] transition-colors"
@@ -275,7 +277,7 @@ defineExpose({ refresh: loadRecords })
                         </span>
                       </div>
                       <!-- 题目内容 -->
-                      <div class="line-clamp-2 text-xs leading-relaxed text-slate-600 dark:text-slate-400">
+                      <div class="line-clamp-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">
                         <template v-if="(q.content_blocks || q.content_json)?.length">
                           <template v-for="(b, i) in (q.content_blocks || q.content_json)" :key="i">
                             <span v-if="b.block_type === 'text'" v-html="isHtml(b.content) ? sanitizeHtml(b.content) : b.content"></span>
@@ -300,6 +302,7 @@ defineExpose({ refresh: loadRecords })
                     此记录无题目数据
                   </div>
                 </div>
+                </div>
               </div>
             </Transition>
           </div>
@@ -308,3 +311,41 @@ defineExpose({ refresh: loadRecords })
     </div>
   </div>
 </template>
+
+<style scoped>
+.split-record-detail {
+  display: grid;
+  grid-template-rows: 1fr;
+  opacity: 1;
+  overflow: hidden;
+  transform: translateY(0);
+  transition:
+    grid-template-rows 320ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 220ms ease,
+    transform 320ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.split-record-detail-inner {
+  min-height: 0;
+  overflow: hidden;
+}
+
+.split-record-expand-enter-from,
+.split-record-expand-leave-to {
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transform: translateY(-4px);
+}
+
+.split-record-expand-enter-to,
+.split-record-expand-leave-from {
+  grid-template-rows: 1fr;
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.split-record-expand-leave-active {
+  transition-duration: 260ms;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+</style>

--- a/frontend/src/views/app/WorkspaceView.vue
+++ b/frontend/src/views/app/WorkspaceView.vue
@@ -12,11 +12,14 @@ import { useWorkspaceNav } from '@/composables/useWorkspaceNav.js'
 import { useQuestionList } from '@/composables/useQuestionList.js'
 import { useFileUpload } from '@/composables/useFileUpload.js'
 import { useSplitPipeline } from '@/composables/useSplitPipeline.js'
+import { useProjects } from '@/composables/useProjects.js'
 import ContentPanel from '@/components/workspace/ContentPanel.vue'
 import SelectionPanel from '@/components/workspace/SelectionPanel.vue'
 import UploadStage from '@/components/workspace/UploadStage.vue'
 import ReviewStage from '@/components/workspace/ReviewStage.vue'
 import SplitHistory from '@/views/app/SplitHistoryView.vue'
+import BaseModal from '@/components/base/BaseModal.vue'
+import BaseButton from '@/components/base/BaseButton.vue'
 
 const WORKSPACE_STATE_KEY = 'workspace_split_state_v1'
 
@@ -24,6 +27,7 @@ const route = useRoute()
 const { pushToast } = useToast()
 const { openModal } = useImageModal()
 const { currentView } = useWorkspaceNav()
+const { questionProjects, activeQuestionProjectId, setActiveProject } = useProjects()
 const {
   statusLoading, statusError,
   providerOptions, hasConfiguredModel, statusPills,
@@ -123,11 +127,14 @@ const doReset = async () => {
 const {
   eraseEnabled, eraseLoading, eraseImages, eraseDone,
   ocrLoading, ocrPages, ocrDone,
-  startProcess, doErase, doOcr, doSplit, doExport, doSaveToDb,
+  startProcess, doErase, doOcr, doSplit, doSaveToDb,
 } = useSplitPipeline(pushToast, currentView, step, S, uploadReady, splitting, splitCompleted, uploadMode, selectedLlmOption, questions, selectedIds, pendingFiles, typesetMath)
 
 const reviewStageRef = ref(null)
 const restoringWorkspaceState = ref(true)
+const importDialogOpen = ref(false)
+const importTargetProjectId = ref(null)
+const importSaving = ref(false)
 const hasReviewContent = computed(() => {
   if (eraseLoading.value) return true
   if (eraseDone.value) return true
@@ -151,6 +158,38 @@ const handleBack = async () => {
   eraseImages.value = []; eraseDone.value = false
   ocrPages.value = []; ocrDone.value = false
   currentView.value = 'workspace'
+}
+
+const openImportDialog = () => {
+  if (!selectedIds.size) {
+    pushToast('error', '请至少选择一道题目！')
+    return
+  }
+  if (!questionProjects.value.length) {
+    pushToast('error', '请先创建一个错题库')
+    return
+  }
+  importTargetProjectId.value = activeQuestionProjectId.value || questionProjects.value[0]?.id || null
+  importDialogOpen.value = true
+}
+
+const closeImportDialog = () => {
+  if (importSaving.value) return
+  importDialogOpen.value = false
+}
+
+const confirmImportToProject = async () => {
+  if (!importTargetProjectId.value || importSaving.value) return
+  importSaving.value = true
+  try {
+    const saved = await doSaveToDb(importTargetProjectId.value)
+    if (saved) {
+      setActiveProject(importTargetProjectId.value, 'question')
+      importDialogOpen.value = false
+    }
+  } finally {
+    importSaving.value = false
+  }
 }
 
 // ── 键盘事件 ────────────────────────────────────────────
@@ -212,7 +251,7 @@ onBeforeUnmount(() => {
     <Transition name="flip" mode="out-in">
       <!-- 第一页：上传与分析 -->
       <ContentPanel v-if="currentView === 'workspace'" key="upload" title="智能录入与分析" :steps="workspaceSteps"
-        :current-step="step - 1">
+        :current-step="step - 1" :sidebar-open="showSplitHistory">
         <template #toolbar>
           <button @click="showSplitHistory = !showSplitHistory"
             class="inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium transition-colors"
@@ -224,7 +263,7 @@ onBeforeUnmount(() => {
           </button>
         </template>
 
-        <template v-if="showSplitHistory" #sidebar>
+        <template #sidebar>
           <SplitHistory :theme="theme" :visible="showSplitHistory" @push-toast="pushToast" @open-image="openModal"
             @load-record="(r) => { handleLoadRecord(r); showSplitHistory = false }"
             @go-workspace="currentView = splitCompleted ? 'workspace_review' : 'workspace'" />
@@ -282,7 +321,37 @@ onBeforeUnmount(() => {
     </Transition>
 
     <!-- 浮动选择面板 -->
-    <SelectionPanel :visible="currentView === 'workspace_review'" :count="selectedIds.size" export-label="导出错题本"
-      :show-save="true" @export="doExport" @save="doSaveToDb" @clear="deselectAll" />
+    <SelectionPanel :visible="currentView === 'workspace_review'" :count="selectedIds.size" :show-export="false"
+      :show-save="true" @save="openImportDialog" @clear="deselectAll" />
+
+    <BaseModal :open="importDialogOpen" title="导入错题库" icon="fa-database" iconBg="accent-bg-soft"
+      iconClass="accent-text" maxWidth="max-w-[30rem]" bodyClass="px-6 pb-3 pt-1" @close="closeImportDialog">
+      <div class="space-y-3">
+        <p class="text-sm text-slate-500 dark:text-[#8a8f98]">
+          将 {{ selectedIds.size }} 道已选题目导入到：
+        </p>
+        <div class="max-h-64 space-y-2 overflow-y-auto pr-1 custom-scrollbar">
+          <button v-for="project in questionProjects" :key="project.id" type="button"
+            class="flex w-full items-center gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors"
+            :class="String(importTargetProjectId) === String(project.id)
+              ? 'border-[rgb(var(--accent-rgb)/0.35)] bg-[rgb(var(--accent-rgb)/0.12)] text-[rgb(var(--accent-strong-rgb))] dark:text-[rgb(var(--accent-hover-rgb))]'
+              : 'border-slate-200/70 bg-white/50 text-slate-600 hover:border-slate-300 hover:bg-slate-50 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-[#aeb6c2] dark:hover:bg-white/[0.05]'"
+            @click="importTargetProjectId = project.id">
+            <i class="fa-solid fa-database w-4 text-center text-xs"></i>
+            <span class="min-w-0 flex-1 truncate text-sm font-medium">{{ project.name }}</span>
+            <i v-if="String(importTargetProjectId) === String(project.id)" class="fa-solid fa-check text-xs"></i>
+          </button>
+        </div>
+      </div>
+      <template #footer>
+        <BaseButton variant="secondary" size="sm" :disabled="importSaving" @click="closeImportDialog">
+          取消
+        </BaseButton>
+        <BaseButton variant="primary" size="sm" :disabled="importSaving || !importTargetProjectId"
+          @click="confirmImportToProject">
+          {{ importSaving ? '导入中...' : '确认导入' }}
+        </BaseButton>
+      </template>
+    </BaseModal>
   </div>
 </template>


### PR DESCRIPTION
﻿## 变更内容

- 新增项目数据模型、CRUD、路由和迁移逻辑，支持错题库与笔记本按用户项目管理
- 将错题、笔记、统计和复习等接口接入 project_id，支持按当前项目筛选和归属数据
- 新增前端项目状态管理，侧边栏分组展示我的错题库、我的笔记本和 AI 对话
- 移除默认错题库和默认笔记本展示逻辑，空项目时保留占空和创建入口
- 支持项目创建、重命名、删除确认，并统一项目与对话的 dropdown menu 行为
- 修复 dropdown 被遮挡、点击后瞬间关闭、多个菜单同时打开和三点按钮显示不一致的问题
- 精修侧边栏视觉层级，统一 active 主题色、子项尺寸、项目缩进和折叠展开动画
- 录入工作台和数据面板保持置顶，项目列表和对话列表独立收缩展开
- 工作台导入错题库前弹出项目选择 dialog，按用户选择的目标错题库保存题目
- 调整选择面板按钮主题，隐藏错题本导出入口，保留导入错题库作为当前工作流
- 分割历史侧边栏支持拖拽宽度、收缩动画和内容淡出位移过渡
- 优化分割历史记录展开动画、全选/加载布局、题目卡片密度和移动端阅读体验
- 修复分割历史 UTC 时间缺少时区标记导致刚创建记录显示 8 小时前的问题
- 修复空 AI 对话页出现多余滚动条的问题
- 调整全局主题色变量使用，统一深浅色下按钮、图标和激活态反馈
- 新增符合当前工作区 UI 风格的模型 Provider 选择组件，支持平台托管 / 我的 Provider 来源切换
- 精简 StatusBar 结构，将模型选择逻辑拆分为独立组件并保留模型状态校验反馈
- 优化错题卡片操作 dropdown menu 样式，统一圆角、背景、阴影、分隔线和 hover 反馈
- 为左侧导航主视图和系统设置视图增加 90 度 3D 换面过渡
- 修复底部用户区域脱离主导航面导致切换时错层、残留和左下角异常显示的问题

## 验证
- python -m compileall backend
- git diff --check
- npm run build
