### PR TITLE
fix: 删除项目时清理孤立批次并完善题目详情

### DIFF
--- a/backend/db/crud/projects.py
+++ b/backend/db/crud/projects.py
@@ -1,4 +1,4 @@
-﻿"""Project CRUD helpers."""
+"""Project CRUD helpers."""
 
 from typing import List, Optional
 
@@ -119,11 +119,17 @@ def delete_project(db: Session, project_id: int, user_id=None) -> bool:
         return False
     if project.is_default:
         raise ValueError("DEFAULT_PROJECT_IMMUTABLE")
+
+    # 检查是否有题目或笔记
     has_questions = db.query(Question.id).filter(Question.project_id == project.id).first()
     has_notes = db.query(Note.id).filter(Note.project_id == project.id).first()
-    has_batches = db.query(UploadBatch.id).filter(UploadBatch.project_id == project.id).first()
-    if has_questions or has_notes or has_batches:
+
+    if has_questions or has_notes:
         raise ValueError("PROJECT_NOT_EMPTY")
+
+    # 如果没有题目和笔记了，自动清理关联的空批次（UploadBatch）
+    db.query(UploadBatch).filter(UploadBatch.project_id == project.id).delete()
+
     db.delete(project)
     db.commit()
     return True

--- a/backend/db/crud/questions.py
+++ b/backend/db/crud/questions.py
@@ -395,12 +395,20 @@ def delete_question(db: Session, question_id: int, user_id=None) -> bool:
         return False
 
     try:
+        batch_id = question.batch_id
         # 删除关联的标签映射
         db.query(QuestionTagMapping).filter(QuestionTagMapping.question_id == question_id).delete()
 
         # 删除题目
         db.delete(question)
         db.commit()
+
+        # 检查批次是否已空，若空则清理
+        if batch_id:
+            other_q = db.query(Question.id).filter(Question.batch_id == batch_id).first()
+            if not other_q:
+                db.query(UploadBatch).filter(UploadBatch.id == batch_id).delete()
+                db.commit()
     except Exception as e:
         db.rollback()
         logger.error(f"删除题目 {question_id} 失败: {e}")

--- a/backend/db/crud/questions.py
+++ b/backend/db/crud/questions.py
@@ -401,14 +401,14 @@ def delete_question(db: Session, question_id: int, user_id=None) -> bool:
 
         # 删除题目
         db.delete(question)
-        db.commit()
 
         # 检查批次是否已空，若空则清理
         if batch_id:
             other_q = db.query(Question.id).filter(Question.batch_id == batch_id).first()
             if not other_q:
                 db.query(UploadBatch).filter(UploadBatch.id == batch_id).delete()
-                db.commit()
+
+        db.commit()
     except Exception as e:
         db.rollback()
         logger.error(f"删除题目 {question_id} 失败: {e}")

--- a/backend/db/migrate.py
+++ b/backend/db/migrate.py
@@ -21,12 +21,150 @@ from db import crud
 def _add_column_if_missing(conn, table: str, column: str, col_type: str, default=None):
     """安全地给已有表添加列，若已存在则跳过"""
     from sqlalchemy import text, inspect
+
     inspector = inspect(conn)
     existing = [c["name"] for c in inspector.get_columns(table)]
     if column not in existing:
         default_clause = f" DEFAULT {default}" if default is not None else ""
-        conn.execute(text(f"ALTER TABLE {table} ADD COLUMN {column} {col_type}{default_clause}"))
+        conn.execute(
+            text(f"ALTER TABLE {table} ADD COLUMN {column} {col_type}{default_clause}")
+        )
         print(f"[migrate] 已添加列: {table}.{column}")
+
+
+def _ensure_default_question_project(db, user_id: int, name: str):
+    from db.models import Project
+
+    project = (
+        db.query(Project)
+        .filter(
+            Project.user_id == user_id,
+            Project.project_type == "question",
+            Project.name == name,
+        )
+        .first()
+    )
+    if project:
+        return project
+
+    project = Project(
+        user_id=user_id,
+        name=name,
+        project_type="question",
+        description="",
+        color="#2563eb",
+        icon="database",
+        is_default=False,
+    )
+    db.add(project)
+    db.flush()
+    return project
+
+
+def _migrate_legacy_questions_for_user(db, user_id: int, project_id: int):
+    import hashlib
+    from db.models import Question, QuestionTagMapping, UploadBatch
+
+    legacy_questions = (
+        db.query(Question)
+        .filter(Question.user_id == user_id, Question.project_id == None)
+        .all()
+    )
+    if not legacy_questions:
+        return 0, 0
+
+    migrated = 0
+    merged = 0
+    batch_ids = set()
+
+    for q in legacy_questions:
+        if q.batch_id:
+            batch_ids.add(q.batch_id)
+
+        base_hash = (q.content_hash or "").strip()
+        scoped_hash = (
+            hashlib.sha256(f"{project_id}:{base_hash}".encode()).hexdigest()
+            if base_hash
+            else ""
+        )
+
+        existing = None
+        if base_hash:
+            candidates = [base_hash]
+            if scoped_hash:
+                candidates.append(scoped_hash)
+            existing = (
+                db.query(Question)
+                .filter(
+                    Question.user_id == user_id,
+                    Question.project_id == project_id,
+                    Question.content_hash.in_(candidates),
+                )
+                .first()
+            )
+
+        if existing:
+            if (
+                existing.answer is None or str(existing.answer).strip() == ""
+            ) and q.answer:
+                existing.answer = q.answer
+            if (
+                existing.user_answer is None or str(existing.user_answer).strip() == ""
+            ) and q.user_answer:
+                existing.user_answer = q.user_answer
+            if (
+                (
+                    existing.review_status is None
+                    or str(existing.review_status).strip() == ""
+                    or existing.review_status == "待复习"
+                )
+                and q.review_status
+                and q.review_status != "待复习"
+            ):
+                existing.review_status = q.review_status
+
+            old_mappings = (
+                db.query(QuestionTagMapping)
+                .filter(QuestionTagMapping.question_id == q.id)
+                .all()
+            )
+            if old_mappings:
+                existing_tag_ids = {
+                    m.tag_id
+                    for m in db.query(QuestionTagMapping)
+                    .filter(QuestionTagMapping.question_id == existing.id)
+                    .all()
+                }
+                for m in old_mappings:
+                    if m.tag_id not in existing_tag_ids:
+                        db.add(
+                            QuestionTagMapping(question_id=existing.id, tag_id=m.tag_id)
+                        )
+                db.query(QuestionTagMapping).filter(
+                    QuestionTagMapping.question_id == q.id
+                ).delete()
+
+            db.delete(q)
+            merged += 1
+            continue
+
+        q.project_id = project_id
+        if base_hash and scoped_hash:
+            q.content_hash = scoped_hash
+        migrated += 1
+
+    if batch_ids:
+        (
+            db.query(UploadBatch)
+            .filter(
+                UploadBatch.user_id == user_id,
+                UploadBatch.id.in_(list(batch_ids)),
+                UploadBatch.project_id == None,
+            )
+            .update({UploadBatch.project_id: project_id}, synchronize_session=False)
+        )
+
+    return migrated, merged
 
 
 def migrate():
@@ -46,23 +184,40 @@ def migrate():
         _add_column_if_missing(conn, "upload_batches", "project_id", "INTEGER")
         _add_column_if_missing(conn, "questions", "project_id", "INTEGER")
         _add_column_if_missing(conn, "notes", "project_id", "INTEGER")
-        _add_column_if_missing(conn, "projects", "project_type", "VARCHAR(20)", "'question'")
+        _add_column_if_missing(
+            conn, "projects", "project_type", "VARCHAR(20)", "'question'"
+        )
         _add_column_if_missing(conn, "chat_sessions", "public_id", "TEXT")
         conn.commit()
 
     # 回填 chat_sessions.public_id（历史数据兼容）
     import uuid
     from db.models import ChatSession
+
     with SessionLocal() as db:
-        rows = db.query(ChatSession).filter((ChatSession.public_id == None) | (ChatSession.public_id == "")).all()
+        rows = (
+            db.query(ChatSession)
+            .filter((ChatSession.public_id == None) | (ChatSession.public_id == ""))
+            .all()
+        )
         if rows:
             for s in rows:
                 s.public_id = str(uuid.uuid4())
             db.commit()
 
     default_users = [
-        {"email": "admin@admin.com",  "username": "Admin",  "password": "123456", "is_admin": True},
-        {"email": "admin2@admin.com", "username": "Admin2", "password": "123456", "is_admin": True},
+        {
+            "email": "admin@admin.com",
+            "username": "Admin",
+            "password": "123456",
+            "is_admin": True,
+        },
+        {
+            "email": "admin2@admin.com",
+            "username": "Admin2",
+            "password": "123456",
+            "is_admin": True,
+        },
     ]
     with SessionLocal() as db:
         for u in default_users:
@@ -75,6 +230,30 @@ def migrate():
                     is_admin=u["is_admin"],
                 )
                 print(f"[migrate] 已创建默认用户: {u['username']} ({u['email']})")
+
+    from db.models import User
+
+    with SessionLocal() as db:
+        users = db.query(User).all()
+        total_users = 0
+        total_migrated = 0
+        total_merged = 0
+        project_name = "默认错题库"
+
+        for user in users:
+            total_users += 1
+            project = _ensure_default_question_project(db, user.id, project_name)
+            migrated, merged = _migrate_legacy_questions_for_user(
+                db, user.id, project.id
+            )
+            total_migrated += migrated
+            total_merged += merged
+
+        if total_migrated or total_merged:
+            db.commit()
+            print(
+                f"[migrate] 已迁移旧错题到项目“{project_name}”: 用户 {total_users}，迁移 {total_migrated}，合并去重 {total_merged}"
+            )
 
 
 def rebuild():

--- a/backend/db/migrate.py
+++ b/backend/db/migrate.py
@@ -45,7 +45,11 @@ def _ensure_default_question_project(db, user_id: int, name: str):
         .first()
     )
     if project:
-        return project
+        changed = False
+        if not project.is_default:
+            project.is_default = True
+            changed = True
+        return project, changed
 
     project = Project(
         user_id=user_id,
@@ -54,11 +58,11 @@ def _ensure_default_question_project(db, user_id: int, name: str):
         description="",
         color="#2563eb",
         icon="database",
-        is_default=False,
+        is_default=True,
     )
     db.add(project)
     db.flush()
-    return project
+    return project, True
 
 
 def _migrate_legacy_questions_for_user(db, user_id: int, project_id: int):
@@ -236,23 +240,26 @@ def migrate():
     with SessionLocal() as db:
         users = db.query(User).all()
         total_users = 0
+        total_created_or_updated = 0
         total_migrated = 0
         total_merged = 0
         project_name = "默认错题库"
 
         for user in users:
             total_users += 1
-            project = _ensure_default_question_project(db, user.id, project_name)
+            project, project_changed = _ensure_default_question_project(db, user.id, project_name)
+            if project_changed:
+                total_created_or_updated += 1
             migrated, merged = _migrate_legacy_questions_for_user(
                 db, user.id, project.id
             )
             total_migrated += migrated
             total_merged += merged
 
-        if total_migrated or total_merged:
+        if total_created_or_updated or total_migrated or total_merged:
             db.commit()
             print(
-                f"[migrate] 已迁移旧错题到项目“{project_name}”: 用户 {total_users}，迁移 {total_migrated}，合并去重 {total_merged}"
+                f"[migrate] 已确保默认错题库并迁移旧错题: 用户 {total_users}，默认库更新 {total_created_or_updated}，迁移 {total_migrated}，合并去重 {total_merged}"
             )
 
 

--- a/frontend/src/components/question/EditNoteDialog.vue
+++ b/frontend/src/components/question/EditNoteDialog.vue
@@ -143,10 +143,11 @@ const config = () => {
         <div v-show="previewMode" ref="questionContentRef"
           class="rounded-xl border border-slate-200/60 bg-slate-50/60 p-4 dark:border-white/10 dark:bg-white/[0.03] min-h-[100px] html-preview-content">
           <div v-if="isHtml(draft)" v-html="sanitizeHtml(draft)"
-            class="text-sm font-bold leading-relaxed text-slate-700 dark:text-slate-200 overflow-x-auto w-full">
+            class="text-[15px] font-medium leading-relaxed text-slate-700 dark:text-slate-200 overflow-x-auto w-full">
           </div>
-          <p v-else class="text-sm font-bold leading-relaxed text-slate-700 dark:text-slate-200 whitespace-pre-wrap">{{
-            draft }}</p>
+          <p v-else
+            class="text-[15px] font-medium leading-relaxed text-slate-700 dark:text-slate-200 whitespace-pre-wrap">{{
+              draft }}</p>
 
           <div v-if="question?.content_json?.some(b => b.block_type === 'image' && b.content)"
             class="mt-3 flex flex-wrap gap-2">
@@ -155,7 +156,7 @@ const config = () => {
           </div>
           <div v-if="question?.options_json?.length" class="mt-3 grid grid-cols-2 gap-1.5">
             <div v-for="(opt, idx) in question.options_json" :key="idx"
-              class="flex items-start gap-2 rounded-lg border border-slate-100 bg-slate-50/50 px-3 py-1.5 text-xs font-bold text-slate-600 dark:border-white/5 dark:bg-white/[0.02] dark:text-slate-400">
+              class="flex items-start gap-2 rounded-lg border border-slate-100 bg-slate-50/50 px-3 py-1.5 text-[15px] font-medium text-slate-600 dark:border-white/5 dark:bg-white/[0.02] dark:text-slate-400">
               <span class="shrink-0 text-slate-400">{{ String.fromCharCode(65 + idx) }}.</span>
               <span>{{ String(opt).replace(/^[A-Da-d][.、．]\s*/, '') }}</span>
             </div>
@@ -191,18 +192,18 @@ const config = () => {
 
 <style scoped>
 .html-preview-content :deep(table) {
-  @apply my-4 w-full rounded-xl border border-slate-200 bg-white/50 text-sm overflow-hidden dark:bg-white/[0.02] dark:border-white/10;
+  @apply my-4 w-full max-w-full rounded-xl border border-slate-200 bg-white/50 text-[14px] overflow-hidden dark:bg-white/[0.02] dark:border-white/10;
   display: block;
   overflow-x: auto;
   white-space: nowrap;
 }
 
 .html-preview-content :deep(th) {
-  @apply bg-slate-100 p-3 text-left font-black dark:bg-white/5 dark:text-slate-300;
+  @apply bg-slate-100/80 px-4 py-2.5 text-left font-bold text-slate-600 dark:bg-white/5 dark:text-slate-300 whitespace-nowrap;
 }
 
 .html-preview-content :deep(td) {
-  @apply border-t border-slate-100 p-3 dark:border-white/10 dark:text-slate-300;
+  @apply border-t border-slate-100/80 px-4 py-2.5 dark:border-white/10 dark:text-slate-300 whitespace-nowrap;
 }
 
 .html-preview-content :deep(ul) {

--- a/frontend/src/components/question/QuestionDetailModal.vue
+++ b/frontend/src/components/question/QuestionDetailModal.vue
@@ -6,6 +6,7 @@
 import { ref, computed, watch, nextTick, onBeforeUnmount } from 'vue'
 import { isHtml, sanitizeHtml, formatOption } from '@/utils.js'
 import * as api from '@/api.js'
+import { useSystemStatus } from '@/composables/useSystemStatus.js'
 
 const props = defineProps({
   open: { type: Boolean, default: false },
@@ -160,7 +161,7 @@ const changeReviewStatus = async (status) => {
 }
 
 const reviewStatusOptions = [
-  { value: '待复习', icon: 'fa-clock', color: 'orange' },
+  { value: '待复习', icon: 'fa-clock', color: 'rose' },
   { value: '复习中', icon: 'fa-spinner', color: 'amber' },
   { value: '已掌握', icon: 'fa-circle-check', color: 'emerald' },
 ]
@@ -168,21 +169,22 @@ const reviewStatusOptions = [
 
 <template>
   <Teleport to="body">
-    <Transition name="modal-fade">
-      <div v-if="open" class="fixed inset-0 z-[100] flex items-center justify-center p-4 sm:p-6">
-        <!-- 遮罩层 -->
-        <div class="absolute inset-0 bg-slate-950/60" @click="emit('close')"></div>
+    <Transition name="dialog-overlay" appear>
+      <div v-if="open" class="dialog-backdrop fixed inset-0 z-[100] bg-black/40" @click="emit('close')"></div>
+    </Transition>
 
+    <Transition name="dialog-content" appear>
+      <div v-if="open" class="fixed inset-0 z-[101] flex items-center justify-center p-4 sm:p-6"
+        @click.self="emit('close')">
         <!-- 弹窗主体 -->
         <div
-          class="relative flex h-full max-h-[90vh] w-full max-w-5xl flex-col overflow-hidden rounded-[2.5rem] border border-white/10 bg-white shadow-2xl transition-all dark:bg-[#0F111A]">
+          class="relative flex h-full max-h-[90vh] w-full max-w-5xl flex-col overflow-hidden rounded-2xl border border-slate-200/60 bg-white shadow-2xl transition-all dark:border-[#2f3336] dark:bg-[#1b1b1d]">
 
           <!-- 头部控制栏 -->
           <div
             class="flex shrink-0 items-center justify-between border-b border-slate-100 bg-slate-50/50 px-8 py-5 dark:border-white/5 dark:bg-white/5">
             <div class="flex items-center gap-4">
-              <div
-                class="flex h-10 w-10 items-center justify-center rounded-xl accent-bg text-white shadow-lg">
+              <div class="flex h-10 w-10 items-center justify-center rounded-xl accent-bg text-white shadow-lg">
                 <i class="fa-solid fa-file-lines text-lg"></i>
               </div>
               <div>
@@ -197,7 +199,7 @@ const reviewStatusOptions = [
                 <button v-for="opt in reviewStatusOptions" :key="opt.value" @click="changeReviewStatus(opt.value)"
                   class="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[10px] font-black uppercase tracking-wider transition-all"
                   :class="(question?.review_status || '待复习') === opt.value
-                    ? opt.color === 'emerald' ? 'bg-emerald-500 text-white shadow-sm' : opt.color === 'amber' ? 'bg-amber-500 text-white shadow-sm' : 'bg-orange-500 text-white shadow-sm'
+                    ? opt.color === 'emerald' ? 'bg-emerald-500 text-white shadow-sm' : opt.color === 'amber' ? 'bg-amber-500 text-white shadow-sm' : 'bg-rose-500 text-white shadow-sm'
                     : 'text-slate-400 hover:text-slate-600 dark:hover:text-slate-300'">
                   <i class="fa-solid" :class="opt.icon"></i> {{ opt.value }}
                 </button>
@@ -218,15 +220,17 @@ const reviewStatusOptions = [
           <!-- 内容主体 -->
           <div class="flex min-h-0 flex-1 flex-col overflow-hidden md:flex-row">
             <!-- 左侧：题干内容 (滚动区) -->
-            <div class="flex-1 overflow-y-auto border-r border-slate-100 p-8 dark:border-white/5">
+            <div
+              class="flex-1 overflow-y-auto border-r border-slate-100 p-8 dark:border-white/5 bg-slate-50/60 dark:bg-transparent">
               <!-- 核心题干 -->
               <div class="question-view">
                 <template v-for="(b, i) in question?.content_json" :key="i">
                   <div v-if="b.block_type === 'text' && isHtml(b.content)" v-html="sanitizeHtml(b.content)"
-                    class="question-text mb-6 text-lg font-bold leading-relaxed text-slate-800 dark:text-slate-200">
+                    class="question-text mb-6 text-[15px] font-medium leading-relaxed text-slate-800 dark:text-slate-200">
                   </div>
                   <p v-else-if="b.block_type === 'text'"
-                    class="mb-6 text-lg font-bold leading-relaxed text-slate-800 dark:text-slate-200">{{ b.content }}
+                    class="mb-6 text-[15px] font-medium leading-relaxed text-slate-800 dark:text-slate-200">{{ b.content
+                    }}
                   </p>
                   <img v-else-if="b.block_type === 'image'" :src="b.content"
                     class="mb-6 max-w-full cursor-zoom-in rounded-2xl border border-slate-200 shadow-sm dark:border-white/10"
@@ -243,7 +247,7 @@ const reviewStatusOptions = [
                 <!-- 选项 -->
                 <div v-if="question?.options_json" class="mt-8 grid gap-3">
                   <div v-for="(opt, idx) in question.options_json" :key="idx"
-                    class="rounded-2xl border border-slate-100 bg-slate-50/50 p-4 text-sm font-bold text-slate-700 dark:border-white/5 dark:bg-white/5 dark:text-slate-300">
+                    class="rounded-2xl border border-slate-100 bg-slate-50/50 p-4 text-[15px] font-medium text-slate-700 dark:border-white/5 dark:bg-white/5 dark:text-slate-300">
                     {{ formatOption(opt) }}
                   </div>
                 </div>
@@ -251,7 +255,7 @@ const reviewStatusOptions = [
             </div>
 
             <!-- 右侧：交互与分析 (侧边栏) -->
-            <div class="flex w-full flex-col overflow-hidden bg-slate-50/30 md:w-[400px] dark:bg-black/20">
+            <div class="flex w-full flex-col overflow-hidden bg-white md:w-[400px] dark:bg-[#1b1b1d]">
               <!-- Tab 切换 -->
               <div class="flex shrink-0 border-b border-slate-100 dark:border-white/5">
                 <button @click="activeTab = 'content'"
@@ -275,8 +279,7 @@ const reviewStatusOptions = [
                     <textarea v-model="answerText" rows="4" placeholder="录入正确答案或标准解析…（支持 Markdown / LaTeX）"
                       class="w-full rounded-2xl border border-slate-200 bg-white p-4 text-sm font-medium outline-none transition-all focus:border-emerald-500 focus:ring-4 focus:ring-emerald-500/5 dark:border-white/5 dark:bg-white/5 dark:text-white"></textarea>
                   </div>
-                  <button @click="saveCorrectAnswer" :disabled="isAnswerSaving"
-                    class="flex w-full items-center justify-center gap-2 rounded-2xl border border-emerald-500/30 bg-emerald-50/80 py-3 text-sm font-bold text-emerald-700 transition-all hover:bg-emerald-100 disabled:opacity-50 dark:border-emerald-500/20 dark:bg-emerald-500/5 dark:text-emerald-400 h-12">
+                  <button @click="saveCorrectAnswer" :disabled="isAnswerSaving" class="btn-success w-full h-12">
                     <i class="fa-solid" :class="isAnswerSaving ? 'fa-circle-notch fa-spin' : 'fa-save'"></i>
                     {{ isAnswerSaving ? '同步中...' : '保存正确答案' }}
                   </button>
@@ -289,7 +292,7 @@ const reviewStatusOptions = [
                       <i class="fa-solid fa-pen-to-square mr-1"></i>我的错因/心得笔记
                     </label>
                     <textarea v-model="userAnswer" rows="4" placeholder="记录下当时的解题思路，或者标记这里错在哪里了..."
-                      class="w-full rounded-2xl border border-slate-200 bg-white p-4 text-sm font-medium outline-none transition-all focus:border-blue-500 focus:ring-4 focus:ring-blue-500/5 dark:border-white/5 dark:bg-white/5 dark:text-white"></textarea>
+                      class="w-full rounded-2xl border border-slate-200 bg-white p-4 text-sm font-medium outline-none transition-all focus:border-[rgb(var(--accent-rgb)/0.4)] focus:ring-4 focus:ring-[rgb(var(--accent-rgb)/0.05)] dark:border-white/5 dark:bg-white/5 dark:text-white"></textarea>
                   </div>
                   <button @click="saveAnswer" :disabled="isSaving" class="btn-primary w-full h-12">
                     <i class="fa-solid" :class="isSaving ? 'fa-circle-notch fa-spin' : 'fa-save'"></i>
@@ -315,10 +318,9 @@ const reviewStatusOptions = [
                     <p class="text-xs font-black uppercase tracking-widest accent-text animate-pulse">分析中...</p>
                   </div>
                   <div v-else-if="aiReport" class="space-y-8 animate-in slide-in-from-bottom-4 duration-500">
-                    <div class="rounded-2xl border accent-border accent-bg-muted p-5">
-                      <h4
-                        class="mb-3 flex items-center gap-2 text-xs font-black uppercase accent-text">
-                        <i class="fa-solid fa-microchip"></i> 认知诊断诊断报告
+                    <div class="rounded-2xl border accent-border accent-bg-soft p-5">
+                      <h4 class="mb-3 flex items-center gap-2 text-xs font-black uppercase accent-text">
+                        <i class="fa-solid fa-microchip"></i> 认知诊断报告
                       </h4>
                       <p class="text-sm font-medium leading-relaxed text-slate-700 dark:text-slate-300">
                         {{ typedText }}<span
@@ -354,15 +356,30 @@ const reviewStatusOptions = [
 </template>
 
 <style scoped>
-.modal-fade-enter-active,
-.modal-fade-leave-active {
-  transition: all 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+.dialog-backdrop {
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 }
 
-.modal-fade-enter-from,
-.modal-fade-leave-to {
+.dialog-overlay-enter-active,
+.dialog-overlay-leave-active {
+  transition: opacity 0.22s ease, backdrop-filter 0.22s ease, -webkit-backdrop-filter 0.22s ease;
+}
+
+.dialog-overlay-enter-from,
+.dialog-overlay-leave-to {
   opacity: 0;
-  transform: scale(0.95);
+}
+
+.dialog-content-enter-active,
+.dialog-content-leave-active {
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.dialog-content-enter-from,
+.dialog-content-leave-to {
+  opacity: 0;
+  transform: scale(0.96) translateY(8px);
 }
 
 @keyframes blink {
@@ -382,17 +399,18 @@ const reviewStatusOptions = [
 }
 
 .question-text :deep(table) {
-  @apply my-6 w-full rounded-xl border border-slate-200 bg-white/50 text-sm overflow-hidden dark:bg-white/[0.02] dark:border-white/10;
+  @apply my-6 w-full max-w-full rounded-xl border border-slate-200 bg-white/50 text-[14px] overflow-hidden dark:bg-white/[0.02] dark:border-white/10;
   display: block;
   overflow-x: auto;
+  white-space: nowrap;
 }
 
 .question-text :deep(th) {
-  @apply bg-slate-100 p-3 text-left font-black dark:bg-white/5 dark:text-slate-300;
+  @apply bg-slate-100/80 px-4 py-2.5 text-left font-bold text-slate-600 dark:bg-white/5 dark:text-slate-300 whitespace-nowrap;
 }
 
 .question-text :deep(td) {
-  @apply border-t border-slate-100 p-3 dark:border-white/10 dark:text-slate-300;
+  @apply border-t border-slate-100/80 px-4 py-2.5 dark:border-white/10 dark:text-slate-300 whitespace-nowrap;
 }
 
 .question-text :deep(ul) {

--- a/frontend/src/components/workspace/SidebarNav.vue
+++ b/frontend/src/components/workspace/SidebarNav.vue
@@ -213,11 +213,11 @@ const userQuotaSummary = computed(() => {
 <template>
   <!-- ================== 侧边栏容器 ================== -->
   <aside
-    class="sidebar-3d-stage flex min-h-0 flex-col z-20 transition-all duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)] bg-transparent overflow-hidden"
+    class="sidebar-3d-stage flex min-h-0 flex-col z-20 transition-all duration-[var(--sidebar-transition-duration)] ease-[var(--sidebar-transition-timing)] overflow-hidden"
     :class="[
       isMobile
-        ? 'fixed inset-y-0 left-0 w-64 transform ' + (mobileDrawerOpen ? 'translate-x-0' : '-translate-x-full')
-        : 'hidden lg:flex lg:fixed lg:left-0 lg:top-0 lg:bottom-0 ' + (isNarrow ? 'w-16' : 'w-64')
+        ? 'fixed inset-y-0 left-0 w-64 transform bg-white dark:bg-[#1b1b1d] shadow-2xl ' + (mobileDrawerOpen ? 'translate-x-0' : '-translate-x-full')
+        : 'hidden lg:flex lg:fixed lg:left-0 lg:top-0 lg:bottom-0 bg-transparent ' + (isNarrow ? 'w-16' : 'w-64')
     ]">
 
     <!-- 设置视图 -->

--- a/frontend/src/views/app/AppLayout.vue
+++ b/frontend/src/views/app/AppLayout.vue
@@ -273,7 +273,7 @@ onBeforeUnmount(() => {
       leave-active-class="transition duration-[var(--mask-transition-duration)] ease-out" leave-from-class="opacity-100"
       leave-to-class="opacity-0">
       <div v-if="isMobile && mobileDrawerOpen"
-        class="fixed inset-0 z-[15] bg-black/40 dark:bg-black/60 backdrop-blur-[2px]" @click="closeDrawer"></div>
+        class="fixed inset-0 z-[15] bg-black/40 dark:bg-black/60 backdrop-blur-md" @click="closeDrawer"></div>
     </Transition>
 
     <!-- 侧边栏导航 -->

--- a/frontend/src/views/app/ErrorBankView.vue
+++ b/frontend/src/views/app/ErrorBankView.vue
@@ -13,6 +13,7 @@ import QuestionItem from '@/components/question/QuestionItem.vue'
 import EmptyState from '@/components/base/EmptyState.vue'
 import QuestionItemSkeleton from '@/components/question/QuestionItemSkeleton.vue'
 import EditNoteDialog from '@/components/question/EditNoteDialog.vue'
+import QuestionDetailModal from '@/components/question/QuestionDetailModal.vue'
 import SelectionPanel from '@/components/workspace/SelectionPanel.vue'
 import { useToast } from '@/composables/useToast.js'
 import { useImageModal } from '@/composables/useImageModal.js'
@@ -77,6 +78,20 @@ const subjects = ref([])
 const questionTypes = ref([])
 const tagNames = ref([])
 const { selectMode, selectedIds, toggleSelectMode, toggleSelect, clearSelection } = useSelectableList()
+
+// ---- 详情弹窗 ----
+const detailOpen = ref(false)
+const detailQuestion = ref(null)
+
+const openDetail = (q) => {
+  detailQuestion.value = q
+  detailOpen.value = true
+}
+
+const onDetailClose = () => {
+  detailOpen.value = false
+  detailQuestion.value = null
+}
 
 
 // ---- 知识点多选标签 ----
@@ -410,7 +425,8 @@ onBeforeUnmount(() => {
           <!-- 列表（有旧数据时保留，遮罩覆盖） -->
           <div v-else class="space-y-4">
             <QuestionItem v-for="q in items" :key="q.id" :question="q" :selectable="selectMode"
-              :selected="selectedIds.has(q.id)" :show-status="true" @toggle-select="toggleSelect">
+              :selected="selectedIds.has(q.id)" :show-status="true" @toggle-select="toggleSelect"
+              @click="openDetail">
               <template #actions="{ question }">
                 <button @mouseenter="onMenuEnter(question.id, $event.currentTarget)" @mouseleave="onMenuLeave"
                   class="flex h-8 w-8 items-center justify-center rounded-xl text-slate-400 transition-all hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-white/5 dark:hover:text-slate-300">
@@ -522,6 +538,10 @@ onBeforeUnmount(() => {
         : (dialogQuestion?.[dialogField] || '')"
         :value-answer="dialogField === 'question' ? (dialogQuestion?.answer || '') : ''" :saving="dialogSaving"
         @close="dialogOpen = false" @save="onDialogSave" />
+
+      <QuestionDetailModal :open="detailOpen" :question="detailQuestion" @close="onDetailClose"
+        @open-image="openModal" @deleted="doQuery" @push-toast="pushToast" @start-chat="openChat"
+        @answer-saved="doQuery" @review-status-changed="doQuery" />
     </div>
   </ContentPanel>
 </template>


### PR DESCRIPTION
## 概要

- 包含原 PR #124 的全部改动：删除项目时自动清理孤立的空批次数据，并新增题目详情弹窗
- 已基于当前最新 `main` 更新分支，包含已合并的 PR #125：修复 pr-121 review 发现的安全、状态与渲染问题
- 修复默认错题库迁移逻辑：确保新建或更新的默认错题库会被提交，并标记为不可删除
- 将“删除题目”和“清理空上传批次”放在同一个事务中，避免出现部分提交状态

## 验证

- `npm run build`
- `python -m compileall .`

## 说明

该 PR 替代 #124。原 #124 的分支位于 fork 仓库中，当前维护环境无法直接 push 修复，因此创建此 PR 作为修正版合入。