### PR TITLE
fix: 优化上传分题流程与持久化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,6 @@ dataset/
 # 环境变量
 .env
 backend/.env
+*.pem
 PR.md
 TODO.md

--- a/backend/db/__init__.py
+++ b/backend/db/__init__.py
@@ -110,6 +110,12 @@ def _migrate_schema():
 
         # chat_sessions 表：question_id 需要改为 nullable
         # SQLite 不支持 ALTER COLUMN，需要重建表
+        cursor.execute("PRAGMA table_info(split_records)")
+        split_record_columns = {row[1] for row in cursor.fetchall()}
+        if 'original_images_json' not in split_record_columns:
+            cursor.execute("ALTER TABLE split_records ADD COLUMN original_images_json TEXT")
+            conn.commit()
+
         cursor.execute("PRAGMA table_info(chat_sessions)")
         cs_columns = {row[1]: row for row in cursor.fetchall()}
         if 'title' not in cs_columns:

--- a/backend/db/crud/split_records.py
+++ b/backend/db/crud/split_records.py
@@ -21,6 +21,7 @@ def save_split_record(
     model_provider: str,
     file_names: List[str],
     questions: List[Dict],
+    original_images: Optional[List[Dict]] = None,
     user_id=None,
 ) -> SplitRecord:
     """保存一次分割操作的完整结果，超过上限自动清理最旧记录"""
@@ -29,6 +30,7 @@ def save_split_record(
         subject=subject,
         model_provider=model_provider,
         file_names_json=json.dumps(file_names, ensure_ascii=False),
+        original_images_json=json.dumps(original_images or [], ensure_ascii=False),
         questions_json=json.dumps(questions, ensure_ascii=False),
         question_count=len(questions),
     )

--- a/backend/db/migrate.py
+++ b/backend/db/migrate.py
@@ -190,6 +190,7 @@ def migrate():
         _add_column_if_missing(conn, "upload_batches", "project_id", "INTEGER")
         _add_column_if_missing(conn, "questions", "project_id", "INTEGER")
         _add_column_if_missing(conn, "notes", "project_id", "INTEGER")
+        _add_column_if_missing(conn, "split_records", "original_images_json", "TEXT")
         _add_column_if_missing(
             conn, "projects", "project_type", "VARCHAR(20)", "'question'"
         )

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -214,6 +214,7 @@ class SplitRecord(Base):
     subject = Column(String(50))
     model_provider = Column(String(20))
     file_names_json = Column(Text)
+    original_images_json = Column(Text)
     questions_json = Column(Text)
     question_count = Column(Integer, default=0)
     created_at = Column(DateTime, default=datetime.utcnow, index=True)

--- a/backend/routes/questions.py
+++ b/backend/routes/questions.py
@@ -519,7 +519,7 @@ def save_to_db():
             return jsonify({'success': False, 'error': '请选择至少一道题目'}), 400
 
         run_id = data.get('run_id')
-        record_id = data.get('record_id')
+        record_id = data.get('record_id') or data.get('split_record_id')
         user_id = session.get('user_id')
 
         # 优先从 SplitRecord 读取（历史记录导入场景）
@@ -591,6 +591,8 @@ def save_to_db():
             'success': True,
             'message': f'已导入 {result["created"]} 道题目（跳过 {result["duplicates"]} 道重复）',
             'run_id': run_id,
+            'record_id': record_id,
+            'split_record_id': record_id,
             'created': result['created'],
             'duplicates': result['duplicates'],
         })

--- a/backend/routes/upload.py
+++ b/backend/routes/upload.py
@@ -62,13 +62,49 @@ def _isoformat_utc(dt) -> Optional[str]:
     return dt.isoformat().replace("+00:00", "Z")
 
 
+def _is_image_file(path: str) -> bool:
+    return PurePath(path).suffix.lower().lstrip(".") in {
+        "jpg",
+        "jpeg",
+        "png",
+        "webp",
+        "bmp",
+    }
+
+
+def _build_original_image_payload(session_files: list[dict]) -> list[dict]:
+    images = []
+    for item in session_files:
+        filename = item.get("filename") or "Unknown"
+        filepath = item.get("filepath") or ""
+        stored_name = os.path.basename(filepath) if filepath else ""
+        is_image = bool(filepath and _is_image_file(filepath))
+        image_url = f"/api/image/{stored_name}" if is_image and stored_name else None
+        images.append(
+            {
+                "filename": filename,
+                "stored_name": stored_name,
+                "url": image_url,
+                "image_url": image_url,
+                "is_image": is_image,
+            }
+        )
+    return images
+
+
 def _serialize_split_record(r) -> dict:
     """将 SplitRecord ORM 对象序列化为前端 JSON 格式"""
+    original_images = (
+        json.loads(r.original_images_json)
+        if getattr(r, "original_images_json", None)
+        else []
+    )
     return {
         "id": r.id,
         "subject": r.subject,
         "model_provider": r.model_provider,
         "file_names": json.loads(r.file_names_json) if r.file_names_json else [],
+        "original_images": original_images,
         "question_count": r.question_count,
         "created_at": _isoformat_utc(r.created_at),
     }
@@ -801,10 +837,13 @@ def split_questions():
 
             with session_lock:
                 us = get_user_session(user_id)
-                file_names = [
-                    us["session_files"].get(k, {}).get("filename", "Unknown")
-                    for k in us["session_file_order"]
+                session_files = [
+                    us["session_files"].get(k, {}) for k in us["session_file_order"]
                 ]
+                file_names = [
+                    item.get("filename", "Unknown") for item in session_files
+                ]
+                original_images = _build_original_image_payload(session_files)
 
             with SessionLocal() as db:
                 run_store.mark_succeeded(
@@ -815,7 +854,13 @@ def split_questions():
                     question_count=len(questions),
                 )
                 crud.save_split_record(
-                    db, subject, model_provider, file_names, questions, user_id=user_id
+                    db,
+                    subject,
+                    model_provider,
+                    file_names,
+                    questions,
+                    original_images=original_images,
+                    user_id=user_id,
                 )
         except Exception:
             logger.warning("保存分割记录失败，不影响主流程", exc_info=True)

--- a/backend/tests/test_crud.py
+++ b/backend/tests/test_crud.py
@@ -39,12 +39,41 @@ from db.crud import (
     update_review_status,
     get_review_status_stats,
     get_daily_counts,
+    save_split_record,
+    get_recent_split_records,
     create_workflow_run,
     get_workflow_run,
     get_latest_workflow_run,
     update_workflow_run,
 )
 from db.models import ProviderConfig, User
+from routes.upload import _serialize_split_record
+
+
+class TestSplitRecords:
+    def test_recent_records_include_original_uploaded_image(self, db):
+        original_images = [
+            {
+                "filename": "note.jpg",
+                "stored_name": "stored-note.jpg",
+                "url": "/api/image/stored-note.jpg",
+                "image_url": "/api/image/stored-note.jpg",
+                "is_image": True,
+            }
+        ]
+        save_split_record(
+            db,
+            subject="math",
+            model_provider="openai",
+            file_names=["note.jpg"],
+            questions=[{"question_id": "1"}],
+            original_images=original_images,
+        )
+
+        record = get_recent_split_records(db, limit=1)[0]
+        payload = _serialize_split_record(record)
+
+        assert payload["original_images"] == original_images
 
 
 # ═══════════════════════════════════════════════════════════

--- a/backend/tests/test_web_routes.py
+++ b/backend/tests/test_web_routes.py
@@ -595,6 +595,45 @@ class TestMultiUserWorkflowRunIsolation:
         assert saved[0].user_id == TEST_USER_ID
         assert "import me" in saved[0].content_json
 
+    def test_save_to_db_imports_split_record_without_run_id(self, client, test_db):
+        project = crud.create_project(test_db, "History Bank", user_id=TEST_USER_ID)
+        record = crud.save_split_record(
+            test_db,
+            subject="数学",
+            model_provider="openai",
+            file_names=["history.jpg"],
+            questions=[
+                {
+                    "uid": "hist_0",
+                    "question_id": "1",
+                    "question_type": "选择题",
+                    "content_blocks": [{"block_type": "text", "content": "from history"}],
+                    "has_formula": False,
+                    "has_image": False,
+                }
+            ],
+            user_id=TEST_USER_ID,
+        )
+
+        resp = client.post(
+            "/api/save-to-db",
+            json={
+                "split_record_id": record.id,
+                "selected_ids": ["hist_0"],
+                "project_id": project.id,
+            },
+        )
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["split_record_id"] == record.id
+
+        saved = test_db.query(Question).all()
+        assert len(saved) == 1
+        assert saved[0].user_id == TEST_USER_ID
+        assert "from history" in saved[0].content_json
+
 
 # ── PATCH /api/question/<id>/review-status ────────────
 

--- a/frontend/src/components/base/BaseButton.vue
+++ b/frontend/src/components/base/BaseButton.vue
@@ -33,7 +33,7 @@ const bindProps = computed(() => {
     v-bind="bindProps"
     :class="[
       'base-button relative overflow-hidden inline-flex items-center justify-center font-medium gap-2 disabled:opacity-50 disabled:cursor-not-allowed',
-      size === 'sm' ? 'h-8 px-4 text-xs rounded-lg' : 'h-10 px-6 text-sm rounded-xl',
+      size === 'sm' ? 'h-8 px-4 text-xs rounded-md' : 'h-10 px-6 text-sm rounded-lg',
       {
         'base-button--primary': variant === 'primary',
         'base-button--secondary': variant === 'secondary',

--- a/frontend/src/components/base/BaseInput.vue
+++ b/frontend/src/components/base/BaseInput.vue
@@ -77,7 +77,7 @@ const inputType = computed(() => {
           :spellcheck="spellcheck"
           data-gramm="false"
           :class="[
-            'w-full h-10 px-4 rounded-xl border bg-white dark:bg-white/[0.03] text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-white/25 focus:outline-none focus:ring-0 focus:ring-offset-0 transition-all text-sm outline-none [&::-ms-reveal]:hidden [&::-ms-clear]:hidden',
+            'w-full h-10 px-4 rounded-lg border bg-white dark:bg-white/[0.03] text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-white/25 focus:outline-none focus:ring-0 focus:ring-offset-0 transition-all text-sm outline-none [&::-ms-reveal]:hidden [&::-ms-clear]:hidden',
             error ? 'border-rose-500/50 focus:border-rose-500/50' : 'border-gray-200 dark:border-white/[0.08] focus:border-[rgb(var(--accent-rgb)/0.4)] dark:focus:border-[rgb(var(--accent-rgb)/0.4)]',
             type === 'password' ? 'pr-11' : '',
             inputClass

--- a/frontend/src/components/base/BaseLogo.vue
+++ b/frontend/src/components/base/BaseLogo.vue
@@ -17,7 +17,7 @@ defineProps({
       {
         'p-1.5 rounded-lg': size === 'sm',
         'p-2 rounded-xl': size === 'md',
-        'p-3 rounded-2xl': size === 'lg',
+        'p-3 rounded-xl': size === 'lg',
       },
     ]"
   >

--- a/frontend/src/components/base/BaseModal.vue
+++ b/frontend/src/components/base/BaseModal.vue
@@ -42,13 +42,13 @@ const backdropStyle = computed(() => ({
         @click.self="emit('close')"
       >
         <div
-          class="relative w-full rounded-2xl border border-slate-200/60 bg-white shadow-2xl dark:border-[#2f3336] dark:bg-[#1b1b1d]"
+          class="relative w-full rounded-xl border border-slate-200/60 bg-white shadow-2xl dark:border-[#2f3336] dark:bg-[#1b1b1d]"
           :class="maxWidth"
         >
           <slot name="header" :close="close">
             <div class="flex items-center justify-between px-6 pt-5 pb-4">
               <div class="flex items-center gap-3">
-                <div v-if="$slots.icon || icon" class="flex h-9 w-9 items-center justify-center rounded-xl" :class="iconBg">
+                <div v-if="$slots.icon || icon" class="flex h-9 w-9 items-center justify-center rounded-lg" :class="iconBg">
                   <slot name="icon">
                     <i class="fa-solid text-base" :class="[icon, iconClass]"></i>
                   </slot>
@@ -70,7 +70,7 @@ const backdropStyle = computed(() => ({
             <slot />
           </div>
 
-          <div v-if="$slots.footer" class="flex min-h-16 items-center justify-end gap-2 rounded-b-2xl border-t border-slate-200/60 px-6 py-3 dark:border-[#2f3336]">
+          <div v-if="$slots.footer" class="flex min-h-16 items-center justify-end gap-2 rounded-b-xl border-t border-slate-200/60 px-6 py-3 dark:border-[#2f3336]">
             <slot name="footer" />
           </div>
         </div>

--- a/frontend/src/components/base/BaseToolbarButton.vue
+++ b/frontend/src/components/base/BaseToolbarButton.vue
@@ -19,7 +19,7 @@ const emit = defineEmits(['click'])
     type="button"
     :title="title"
     :disabled="disabled"
-    class="inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+    class="inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
     :class="[
       active
         ? 'bg-gray-200 text-gray-900 dark:bg-white/[0.08] dark:text-[#f7f8f8]'

--- a/frontend/src/components/features/app/layout/ChatSearchDialog.vue
+++ b/frontend/src/components/features/app/layout/ChatSearchDialog.vue
@@ -85,7 +85,7 @@ watch(() => props.open, async (open) => {
         @keydown.esc="close"
       >
         <section
-          class="flex max-h-[min(42rem,calc(100vh-3rem))] w-full max-w-[42.5rem] flex-col overflow-hidden rounded-2xl border border-slate-200/70 bg-white text-slate-900 shadow-2xl shadow-slate-950/20 dark:border-white/[0.08] dark:bg-[#2f2f2f] dark:text-[#f4f4f4] dark:shadow-black/40"
+          class="flex max-h-[min(42rem,calc(100vh-3rem))] w-full max-w-[42.5rem] flex-col overflow-hidden rounded-xl border border-slate-200/70 bg-white text-slate-900 shadow-2xl shadow-slate-950/20 dark:border-white/[0.08] dark:bg-[#2f2f2f] dark:text-[#f4f4f4] dark:shadow-black/40"
           role="dialog"
           aria-modal="true"
           aria-label="搜索聊天"

--- a/frontend/src/components/features/app/layout/ContentPanel.vue
+++ b/frontend/src/components/features/app/layout/ContentPanel.vue
@@ -106,7 +106,7 @@ onBeforeUnmount(stopSidebarResize)
     </header>
 
     <div class="flex flex-1 overflow-hidden p-3">
-      <div class="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <div class="flex min-h-0 flex-1 flex-col overflow-y-auto pr-2">
         <slot></slot>
       </div>
 

--- a/frontend/src/components/features/app/layout/SidebarNav.vue
+++ b/frontend/src/components/features/app/layout/SidebarNav.vue
@@ -904,7 +904,7 @@ const userQuotaSummary = computed(() => {
 
 .custom-scrollbar::-webkit-scrollbar-thumb {
   background: rgba(0, 0, 0, 0.1);
-  border-radius: 10px;
+  border-radius: 999px;
 }
 
 .dark .custom-scrollbar::-webkit-scrollbar-thumb {

--- a/frontend/src/components/features/app/question/QuestionCard.vue
+++ b/frontend/src/components/features/app/question/QuestionCard.vue
@@ -75,7 +75,7 @@ const cancelUserAnswer = () => { editingUserAnswer.value = false }
 
 <template>
   <BaseCard class="question-card group relative overflow-hidden transition-shadow hover:shadow-md cursor-pointer"
-    padding="p-6" rounded="rounded-2xl" :class="selected
+    padding="p-6" rounded="rounded-xl" :class="selected
       ? 'accent-border shadow-[rgb(var(--accent-rgb)/0.1)] dark:shadow-[rgb(var(--accent-rgb)/0.2)]'
       : 'hover:border-[rgb(var(--accent-rgb)/0.4)] dark:hover:!border-white/15'
       " @click="emit('toggle', question.uid)">
@@ -130,7 +130,7 @@ const cancelUserAnswer = () => { editingUserAnswer.value = false }
             class="my-4 text-base font-medium leading-relaxed text-gray-800 dark:text-[#d0d6e0] whitespace-pre-wrap">{{
               b.content }}</p>
           <img v-else-if="b.block_type === 'image' && b.content" :src="b.content"
-            class="my-6 max-h-[400px] cursor-zoom-in rounded-2xl border border-gray-100 dark:border-white/5 shadow-sm transition-transform hover:scale-[1.01]"
+            class="my-6 max-h-[400px] cursor-zoom-in rounded-xl border border-gray-100 dark:border-white/5 shadow-sm transition-transform hover:scale-[1.01]"
             @click.stop="() => emit('open-image', b.content)" />
         </div>
       </template>
@@ -138,7 +138,7 @@ const cancelUserAnswer = () => { editingUserAnswer.value = false }
       <!-- 兜底渲染：无选项配对时独立展示 -->
       <div v-if="extraImages.length && !optionImages" class="my-4 flex flex-wrap gap-2">
         <img v-for="(src, i) in extraImages" :key="'extra-' + i" :src="src"
-          class="max-h-[200px] cursor-zoom-in rounded-2xl border border-gray-100 dark:border-white/5 object-contain shadow-sm transition-transform hover:scale-[1.01]"
+          class="max-h-[200px] cursor-zoom-in rounded-xl border border-gray-100 dark:border-white/5 object-contain shadow-sm transition-transform hover:scale-[1.01]"
           @click.stop="() => emit('open-image', src)" />
       </div>
 

--- a/frontend/src/components/features/app/question/QuestionDetailModal.vue
+++ b/frontend/src/components/features/app/question/QuestionDetailModal.vue
@@ -179,7 +179,7 @@ const reviewStatusOptions = [
         @click.self="emit('close')">
         <!-- 弹窗主体 -->
         <div
-          class="relative flex h-full max-h-[90vh] w-full max-w-5xl flex-col overflow-hidden rounded-2xl border border-slate-200/60 bg-white shadow-2xl transition-all dark:border-[#2f3336] dark:bg-[#1b1b1d]">
+          class="relative flex h-full max-h-[90vh] w-full max-w-5xl flex-col overflow-hidden rounded-xl border border-slate-200/60 bg-white shadow-2xl transition-all dark:border-[#2f3336] dark:bg-[#1b1b1d]">
 
           <!-- 头部控制栏 -->
           <div
@@ -234,21 +234,21 @@ const reviewStatusOptions = [
                     }}
                   </p>
                   <img v-else-if="b.block_type === 'image'" :src="b.content"
-                    class="mb-6 max-w-full cursor-zoom-in rounded-2xl border border-slate-200 shadow-sm dark:border-white/10"
+                    class="mb-6 max-w-full cursor-zoom-in rounded-xl border border-slate-200 shadow-sm dark:border-white/10"
                     @click="emit('open-image', b.content)" />
                 </template>
 
                 <!-- 兜底渲染 image_refs 中未嵌入 content_json 的图片 -->
                 <div v-if="extraImages.length" class="mb-6 flex flex-wrap gap-3">
                   <img v-for="(src, i) in extraImages" :key="'extra-' + i" :src="src"
-                    class="max-h-[240px] cursor-zoom-in rounded-2xl border border-slate-200 object-contain shadow-sm dark:border-white/10"
+                    class="max-h-[240px] cursor-zoom-in rounded-xl border border-slate-200 object-contain shadow-sm dark:border-white/10"
                     @click="emit('open-image', src)" />
                 </div>
 
                 <!-- 选项 -->
                 <div v-if="question?.options_json" class="mt-8 grid gap-3">
                   <div v-for="(opt, idx) in question.options_json" :key="idx"
-                    class="rounded-2xl border border-slate-100 bg-slate-50/50 p-4 text-[15px] font-medium text-slate-700 dark:border-white/5 dark:bg-white/5 dark:text-slate-300">
+                    class="rounded-xl border border-slate-100 bg-slate-50/50 p-4 text-[15px] font-medium text-slate-700 dark:border-white/5 dark:bg-white/5 dark:text-slate-300">
                     {{ formatOption(opt) }}
                   </div>
                 </div>
@@ -278,7 +278,7 @@ const reviewStatusOptions = [
                       <i class="fa-solid fa-circle-check mr-1"></i>正确答案/解析
                     </label>
                     <textarea v-model="answerText" rows="4" placeholder="录入正确答案或标准解析…（支持 Markdown / LaTeX）"
-                      class="w-full rounded-2xl border border-slate-200 bg-white p-4 text-sm font-medium outline-none transition-all focus:border-emerald-500 focus:ring-4 focus:ring-emerald-500/5 dark:border-white/5 dark:bg-white/5 dark:text-white"></textarea>
+                      class="w-full rounded-lg border border-slate-200 bg-white p-4 text-sm font-medium outline-none transition-all focus:border-emerald-500 focus:ring-4 focus:ring-emerald-500/5 dark:border-white/5 dark:bg-white/5 dark:text-white"></textarea>
                   </div>
                   <button @click="saveCorrectAnswer" :disabled="isAnswerSaving" class="btn-success w-full h-12">
                     <i class="fa-solid" :class="isAnswerSaving ? 'fa-circle-notch fa-spin' : 'fa-save'"></i>
@@ -293,18 +293,18 @@ const reviewStatusOptions = [
                       <i class="fa-solid fa-pen-to-square mr-1"></i>我的错因/心得笔记
                     </label>
                     <textarea v-model="userAnswer" rows="4" placeholder="记录下当时的解题思路，或者标记这里错在哪里了..."
-                      class="w-full rounded-2xl border border-slate-200 bg-white p-4 text-sm font-medium outline-none transition-all focus:border-[rgb(var(--accent-rgb)/0.4)] focus:ring-4 focus:ring-[rgb(var(--accent-rgb)/0.05)] dark:border-white/5 dark:bg-white/5 dark:text-white"></textarea>
+                      class="w-full rounded-lg border border-slate-200 bg-white p-4 text-sm font-medium outline-none transition-all focus:border-[rgb(var(--accent-rgb)/0.4)] focus:ring-4 focus:ring-[rgb(var(--accent-rgb)/0.05)] dark:border-white/5 dark:bg-white/5 dark:text-white"></textarea>
                   </div>
                   <button @click="saveAnswer" :disabled="isSaving" class="btn-primary w-full h-12">
                     <i class="fa-solid" :class="isSaving ? 'fa-circle-notch fa-spin' : 'fa-save'"></i>
                     {{ isSaving ? '同步中...' : '保存学习笔记' }}
                   </button>
                   <button @click="triggerAiAnalysis"
-                    class="group flex w-full items-center justify-center gap-2 rounded-2xl border accent-border accent-bg-muted py-4 text-sm font-black accent-text transition-all hover:bg-[rgb(var(--accent-rgb)/0.12)]">
+                    class="group flex w-full items-center justify-center gap-2 rounded-lg border accent-border accent-bg-muted py-4 text-sm font-black accent-text transition-all hover:bg-[rgb(var(--accent-rgb)/0.12)]">
                     <i class="fa-solid fa-wand-magic-sparkles animate-pulse"></i> 召唤 AI 助教分析
                   </button>
                   <button @click="emit('start-chat', question); emit('close')"
-                    class="group flex w-full items-center justify-center gap-2 rounded-2xl border accent-border accent-bg-muted py-4 text-sm font-black accent-text transition-all hover:bg-[rgb(var(--accent-rgb)/0.12)]">
+                    class="group flex w-full items-center justify-center gap-2 rounded-lg border accent-border accent-bg-muted py-4 text-sm font-black accent-text transition-all hover:bg-[rgb(var(--accent-rgb)/0.12)]">
                     <i class="fa-solid fa-comments"></i> AI 辅导对话
                   </button>
                 </div>
@@ -319,7 +319,7 @@ const reviewStatusOptions = [
                     <p class="text-xs font-black uppercase tracking-widest accent-text animate-pulse">分析中...</p>
                   </div>
                   <div v-else-if="aiReport" class="space-y-8 animate-in slide-in-from-bottom-4 duration-500">
-                    <div class="rounded-2xl border accent-border accent-bg-soft p-5">
+                    <div class="rounded-xl border accent-border accent-bg-soft p-5">
                       <h4 class="mb-3 flex items-center gap-2 text-xs font-black uppercase accent-text">
                         <i class="fa-solid fa-microchip"></i> 认知诊断报告
                       </h4>

--- a/frontend/src/components/features/app/question/QuestionItemSkeleton.vue
+++ b/frontend/src/components/features/app/question/QuestionItemSkeleton.vue
@@ -12,7 +12,7 @@ defineProps({
   <div class="space-y-4">
     <div
       v-for="i in count" :key="i"
-      class="animate-pulse rounded-2xl border border-slate-200/60 bg-white/70 p-6 shadow-sm dark:border-white/10 dark:bg-white/[0.03]"
+      class="animate-pulse rounded-xl border border-slate-200/60 bg-white/70 p-6 shadow-sm dark:border-white/10 dark:bg-white/[0.03]"
     >
       <div class="flex items-start gap-4">
         <!-- 内容区：精确复刻 QuestionItem 的 min-w-0 flex-1 -->

--- a/frontend/src/components/features/app/review/AiAnalysisModal.vue
+++ b/frontend/src/components/features/app/review/AiAnalysisModal.vue
@@ -20,7 +20,7 @@ const emit = defineEmits(['close'])
         <div class="absolute inset-0 bg-slate-950/60" @click="emit('close')"></div>
 
         <!-- 弹窗主体 -->
-        <div class="relative flex max-h-[85vh] w-full max-w-3xl flex-col overflow-hidden rounded-[2rem] border border-white/10 bg-white shadow-2xl dark:bg-[#0F111A]">
+        <div class="relative flex max-h-[85vh] w-full max-w-3xl flex-col overflow-hidden rounded-xl border border-white/10 bg-white shadow-2xl dark:bg-[#0F111A]">
 
           <!-- 头部 -->
           <div class="flex items-center justify-between border-b border-slate-100 bg-[rgb(var(--accent-rgb)/0.08)] px-8 py-5 dark:border-white/5 dark:bg-[rgb(var(--accent-rgb)/0.06)]">
@@ -52,7 +52,7 @@ const emit = defineEmits(['close'])
             <!-- 分析结果 -->
             <div v-else-if="analysis" class="space-y-8">
               <!-- 综合诊断 -->
-              <div class="rounded-2xl border accent-border accent-bg-muted p-6">
+              <div class="rounded-xl border accent-border accent-bg-muted p-6">
                 <h4 class="mb-3 flex items-center gap-2 text-xs font-black uppercase tracking-widest accent-text">
                   <i class="fa-solid fa-stethoscope"></i> 综合诊断
                 </h4>

--- a/frontend/src/components/features/app/shared/ViewSettingsPopover.vue
+++ b/frontend/src/components/features/app/shared/ViewSettingsPopover.vue
@@ -84,7 +84,7 @@ const labelClass = "font-medium text-gray-500 dark:text-[#8a8f98] shrink-0 w-16"
                         v-for="status in [{ v: '', l: '全部' }, { v: '待复习', l: '待复习' }, { v: '复习中', l: '复习中' }, { v: '已掌握', l: '已掌握' }]"
                         :key="status.v" role="tab" :aria-selected="filters.review_status === status.v"
                         @click="filters.review_status = status.v"
-                        class="flex-1 flex items-center justify-center py-1 rounded-[6px] text-[12px] font-medium transition-all duration-200"
+                        class="flex-1 flex items-center justify-center py-1 rounded-md text-[12px] font-medium transition-all duration-200"
                         :class="filters.review_status === status.v
                             ? 'bg-white dark:bg-white/[0.08] accent-text dark:text-[#f7f8f8] shadow-[0_1px_3px_rgba(0,0,0,0.1)] dark:shadow-none border border-gray-200/50 dark:border-white/[0.1]'
                             : 'text-gray-500 dark:text-[#8a8f98] hover:text-gray-700 dark:hover:text-[#d0d6e0] border border-transparent'">

--- a/frontend/src/components/features/app/workspace/ActionBar.vue
+++ b/frontend/src/components/features/app/workspace/ActionBar.vue
@@ -10,6 +10,7 @@ const props = defineProps({
   splitting: { type: Boolean, default: false },
   splitCompleted: { type: Boolean, default: false },
   uploadMode: { type: String, default: 'exam' },
+  workflowMode: { type: String, default: 'manual' },
   eraseEnabled: { type: Boolean, default: false },
 })
 
@@ -24,12 +25,26 @@ const emit = defineEmits(['split', 'export', 'save-to-db'])
     <button
       type="button"
       class="group relative inline-flex h-14 items-center justify-center sm:w-auto w-full disabled:cursor-not-allowed disabled:opacity-50"
-      :disabled="!splitEnabled"
+      :disabled="workflowMode === 'manual' ? !splitEnabled : true"
       @click="emit('split')"
     >
       <!-- 按钮本体 -->
-      <span class="relative overflow-hidden inline-flex h-full w-full items-center justify-center gap-2 rounded-md px-8 text-sm font-medium text-white brand-btn transition-colors">
-        <template v-if="splitting">
+      <span class="relative overflow-hidden inline-flex h-full w-full items-center justify-center gap-2 rounded-lg px-8 text-sm font-medium text-white brand-btn transition-colors">
+        <template v-if="workflowMode === 'auto'">
+          <template v-if="splitting">
+            <i class="fa-solid fa-spinner fa-spin text-gray-600 dark:text-white/80"></i>
+            <span class="text-gray-900 dark:text-white">{{ uploadMode === 'note' ? '正在自动整理笔记...' : '正在自动处理...' }}</span>
+          </template>
+          <template v-else-if="splitCompleted">
+            <i class="fa-solid fa-check-double text-emerald-500 dark:text-emerald-400"></i>
+            <span class="text-gray-900 dark:text-white">{{ uploadMode === 'note' ? '整理已完成' : '解析已完成' }}</span>
+          </template>
+          <template v-else>
+            <i class="fa-solid fa-bolt text-gray-600 dark:text-white/80"></i>
+            <span class="text-gray-900 dark:text-white">上传后自动处理到导出阶段</span>
+          </template>
+        </template>
+        <template v-else-if="splitting">
           <i class="fa-solid fa-spinner fa-spin" :class="uploadMode === 'note' ? 'text-emerald-500 dark:text-emerald-400' : 'text-gray-600 dark:text-white/80'"></i>
           <span class="text-gray-900 dark:text-white">{{ uploadMode === 'note' ? '正在整理笔记...' : '正在智能分割...' }}</span>
         </template>

--- a/frontend/src/components/features/app/workspace/FileList.vue
+++ b/frontend/src/components/features/app/workspace/FileList.vue
@@ -29,7 +29,7 @@ const emit = defineEmits(['remove-file'])
         <div
           v-for="item in pendingFiles"
           :key="item.key"
-          class="relative flex items-center gap-2.5 overflow-hidden rounded-md border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.02] px-3 py-2 transition-colors"
+          class="relative flex items-center gap-2.5 overflow-hidden rounded-lg border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.02] px-3 py-2 transition-colors"
         >
           <!-- 进度条背景 -->
           <div
@@ -56,7 +56,7 @@ const emit = defineEmits(['remove-file'])
 
           <button
             type="button"
-            class="absolute right-1.5 top-1.5 flex h-4 w-4 items-center justify-center rounded text-gray-400 dark:text-[#62666d] transition-colors hover:text-rose-500 dark:hover:text-rose-400"
+            class="absolute right-1.5 top-1.5 flex h-4 w-4 items-center justify-center rounded-md text-gray-400 dark:text-[#62666d] transition-colors hover:text-rose-500 dark:hover:text-rose-400"
             :disabled="splitting || splitCompleted"
             @click.stop="() => emit('remove-file', item.key)"
           >

--- a/frontend/src/components/features/app/workspace/FileUploader.vue
+++ b/frontend/src/components/features/app/workspace/FileUploader.vue
@@ -4,6 +4,7 @@
  * 文件上传拖拽区
  */
 import { ref } from 'vue'
+import ModelProviderSelect from '@/components/features/app/workspace/ModelProviderSelect.vue'
 
 const props = defineProps({
   pendingFiles: { type: Array, default: () => [] },
@@ -15,9 +16,13 @@ const props = defineProps({
   splitCompleted: { type: Boolean, default: false },
   expand: { type: Boolean, default: false },
   disabled: { type: Boolean, default: false },
+  modelOptionsData: { type: Object, default: null },
+  selectedLlmOptionId: { type: String, default: '' },
+  noModels: { type: Boolean, default: false },
+  statusLoading: { type: Boolean, default: false },
 })
 
-const emit = defineEmits(['upload', 'remove-file'])
+const emit = defineEmits(['upload', 'remove-file', 'update:selected-llm-option-id'])
 
 const fileInputEl = ref(null)
 const uploadHover = ref(false)
@@ -44,7 +49,7 @@ const onClickZone = () => {
 <template>
   <div :class="{ 'flex flex-col flex-1': expand }">
     <div
-      class="group relative flex flex-col items-center justify-center rounded-md border transition-colors"
+      class="group relative flex flex-col items-center justify-center rounded-xl border transition-colors"
       :class="[
         uploadHover
           ? 'accent-border bg-gray-100 dark:bg-white/[0.04]'
@@ -72,7 +77,25 @@ const onClickZone = () => {
           <p v-else class="text-sm text-gray-500 dark:text-[#8a8f98]">
             拖拽文件到此处或 <span class="accent-text cursor-pointer">浏览文件</span>
           </p>
-          <p class="mt-1 text-xs text-gray-400 dark:text-[#62666d]">PDF, PNG, JPG</p>
+          <p class="mt-1 text-xs text-gray-400 dark:text-[#62666d]">
+            支持PDF/PNG/JPG/BMP/TIF等各种图片格式
+          </p>
+          <p class="mt-1 text-xs text-gray-400 dark:text-[#62666d]">
+            单文件≤50MB&1000页 · 单图片≤10MB · 批量上传≤20个
+          </p>
+        </div>
+
+        <div class="mt-1 flex items-center gap-3" @click.stop @keydown.stop>
+          <span class="text-xs font-medium text-gray-500 dark:text-[#8a8f98]">选择模型</span>
+          <ModelProviderSelect
+            compact
+            :model-value="selectedLlmOptionId"
+            :model-options-data="modelOptionsData"
+            :disabled="splitting || splitCompleted"
+            :no-models="noModels"
+            :status-loading="statusLoading"
+            @update:model-value="(value) => emit('update:selected-llm-option-id', value)"
+          />
         </div>
       </div>
 

--- a/frontend/src/components/features/app/workspace/SplitLoading.vue
+++ b/frontend/src/components/features/app/workspace/SplitLoading.vue
@@ -130,7 +130,7 @@ defineProps({
 .core-pulse {
   position: absolute;
   inset: -4px;
-  border-radius: 1.25rem;
+  border-radius: 0.75rem;
   background: rgb(var(--accent-rgb) / 0.2);
   animation: pulse 2s ease-out infinite;
 }
@@ -172,7 +172,7 @@ defineProps({
   width: 100%;
   height: 4px;
   background: rgb(var(--accent-rgb) / 0.05);
-  border-radius: 10px;
+  border-radius: 999px;
   overflow: hidden;
 }
 
@@ -180,7 +180,7 @@ defineProps({
   width: 40%;
   height: 100%;
   background: linear-gradient(90deg, rgb(var(--accent-rgb)), rgb(var(--accent-hover-rgb)));
-  border-radius: 10px;
+  border-radius: 999px;
   position: relative;
   animation: progress-move 2.5s ease-in-out infinite;
 }

--- a/frontend/src/components/features/auth/ForgotPasswordModal.vue
+++ b/frontend/src/components/features/auth/ForgotPasswordModal.vue
@@ -133,7 +133,7 @@ async function resetPassword() {
     <Transition name="fp-content" appear>
       <div v-if="open" class="fixed inset-0 z-[51] flex items-center justify-center p-4">
         <div
-          class="relative w-full max-w-sm rounded-2xl border border-gray-200 bg-white/95 p-6 shadow-xl transition-colors duration-200 backdrop-blur-xl dark:border-white/[0.08] dark:bg-[#0A0A0F]/95"
+          class="relative w-full max-w-sm rounded-xl border border-gray-200 bg-white/95 p-6 shadow-xl transition-colors duration-200 backdrop-blur-xl dark:border-white/[0.08] dark:bg-[#0A0A0F]/95"
           @click.stop
         >
           <button

--- a/frontend/src/components/features/home/FeatureCard.vue
+++ b/frontend/src/components/features/home/FeatureCard.vue
@@ -27,7 +27,7 @@ const props = defineProps({
 
 <template>
   <div
-    class="reveal feature-card group relative flex flex-col rounded-[20px] p-[1px] overflow-hidden"
+    class="reveal feature-card group relative flex flex-col rounded-xl p-[1px] overflow-hidden"
     :class="spanClass"
     :style="{ transitionDelay: delay }"
   >
@@ -38,7 +38,7 @@ const props = defineProps({
     <div class="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 bg-gradient-to-br from-[rgb(var(--accent-rgb)/0.15)] via-[rgb(var(--accent-hover-rgb)/0.05)] to-transparent dark:from-[rgb(var(--accent-rgb)/0.1)] dark:via-[rgb(var(--accent-hover-rgb)/0.05)] dark:to-transparent z-0"></div>
 
     <!-- 卡片主体背景层 — brand-btn 风格白玻璃 -->
-    <div class="feature-card-inner relative h-full w-full rounded-[19px] p-6 flex flex-col items-start text-left transition-all duration-500 overflow-hidden">
+    <div class="feature-card-inner relative h-full w-full rounded-xl p-6 flex flex-col items-start text-left transition-all duration-500 overflow-hidden">
 
       <!-- 图标容器（BaseLogo 风格） -->
       <div class="feature-icon relative z-10 mb-4 flex h-10 w-10 items-center justify-center rounded-xl overflow-hidden">

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -44,7 +44,7 @@
   font-size: 13px;
   font-weight: 500;
   color: #62666d;
-  border-radius: 6px;
+  border-radius: 0.5rem;
   border: 1px solid rgba(0, 0, 0, 0.06);
   background: #ffffff;
   transition: all 0.15s;
@@ -380,7 +380,7 @@ mjx-container[jax="SVG"]>svg {
 
 .dark *::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.12);
-  border-radius: 3px;
+  border-radius: 999px;
 }
 
 .dark *::-webkit-scrollbar-thumb:hover {

--- a/frontend/src/views/app/ChatView.vue
+++ b/frontend/src/views/app/ChatView.vue
@@ -289,7 +289,7 @@ onBeforeUnmount(() => {
 
         <!-- 空状态 -->
         <div v-if="!messages.length && !streaming" class="flex h-full flex-col items-center justify-center text-center">
-          <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-2xl accent-bg-soft">
+          <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-xl accent-bg-soft">
             <i class="fa-solid fa-chalkboard-user text-2xl accent-text"></i>
           </div>
           <h3 class="text-lg font-bold text-slate-800 dark:text-slate-200">向 AI 老师提问吧</h3>
@@ -308,7 +308,7 @@ onBeforeUnmount(() => {
               <i class="fa-solid fa-graduation-cap"></i>
             </div>
 
-            <div class="max-w-[80%] rounded-2xl px-4 py-3 text-sm leading-relaxed shadow-sm" :class="msg.role === 'user'
+            <div class="max-w-[80%] rounded-xl px-4 py-3 text-sm leading-relaxed shadow-sm" :class="msg.role === 'user'
               ? 'accent-bg text-white'
               : 'border border-slate-200/60 bg-white text-slate-800 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-200'
               ">

--- a/frontend/src/views/app/DashboardView.vue
+++ b/frontend/src/views/app/DashboardView.vue
@@ -267,7 +267,7 @@ onBeforeUnmount(() => {
         <!-- 统计卡片骨架：精确复刻 StatCard 内部结构 -->
         <div class="mb-8 grid grid-cols-2 gap-4 sm:grid-cols-4">
           <div v-for="i in 4" :key="i"
-            class="animate-pulse rounded-2xl border border-slate-200/60 bg-white/70 p-6 shadow-sm dark:border-white/10 dark:bg-white/[0.03]">
+            class="animate-pulse rounded-xl border border-slate-200/60 bg-white/70 p-6 shadow-sm dark:border-white/10 dark:bg-white/[0.03]">
             <div class="flex items-center gap-4">
               <div class="size-12 shrink-0 rounded-lg bg-slate-200/80 dark:bg-white/[0.07]"></div>
               <div class="flex flex-col gap-2">
@@ -280,7 +280,7 @@ onBeforeUnmount(() => {
         <!-- 图表骨架：精确复刻 BaseCard + 标题行 + canvas 区域 -->
         <div class="mb-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
           <div v-for="i in 2" :key="i"
-            class="animate-pulse rounded-2xl border border-slate-200/60 bg-white/70 p-6 shadow-sm dark:border-white/10 dark:bg-white/[0.03]">
+            class="animate-pulse rounded-xl border border-slate-200/60 bg-white/70 p-6 shadow-sm dark:border-white/10 dark:bg-white/[0.03]">
             <div class="mb-4 flex items-center gap-2">
               <div class="h-4 w-4 rounded bg-slate-200/80 dark:bg-white/[0.07]"></div>
               <div class="h-4 w-28 rounded bg-slate-200/80 dark:bg-white/[0.07]"></div>
@@ -289,14 +289,14 @@ onBeforeUnmount(() => {
           </div>
         </div>
         <div class="mb-8 grid grid-cols-1 gap-6 lg:grid-cols-2">
-          <div class="animate-pulse rounded-2xl border border-slate-200/60 bg-white/70 p-6 shadow-sm dark:border-white/10 dark:bg-white/[0.03]">
+          <div class="animate-pulse rounded-xl border border-slate-200/60 bg-white/70 p-6 shadow-sm dark:border-white/10 dark:bg-white/[0.03]">
             <div class="mb-4 flex items-center gap-2">
               <div class="h-4 w-4 rounded bg-slate-200/80 dark:bg-white/[0.07]"></div>
               <div class="h-4 w-28 rounded bg-slate-200/80 dark:bg-white/[0.07]"></div>
             </div>
             <div class="h-[360px] w-full rounded-xl bg-slate-100/80 dark:bg-white/[0.04]"></div>
           </div>
-          <div class="animate-pulse rounded-2xl border border-slate-200/60 bg-white/70 p-6 shadow-sm dark:border-white/10 dark:bg-white/[0.03]">
+          <div class="animate-pulse rounded-xl border border-slate-200/60 bg-white/70 p-6 shadow-sm dark:border-white/10 dark:bg-white/[0.03]">
             <div class="mb-4 flex items-center gap-2">
               <div class="h-4 w-4 rounded bg-slate-200/80 dark:bg-white/[0.07]"></div>
               <div class="h-4 w-28 rounded bg-slate-200/80 dark:bg-white/[0.07]"></div>

--- a/frontend/src/views/app/ReviewView.vue
+++ b/frontend/src/views/app/ReviewView.vue
@@ -267,7 +267,7 @@ onMounted(() => { loadAll() })
 
         <!-- 空状态 -->
         <div v-else-if="!reviewItems.length"
-          class="flex flex-col items-center justify-center rounded-2xl border-2 border-dashed border-slate-200 bg-slate-50/50 py-20 dark:border-white/5 dark:bg-white/5">
+          class="flex flex-col items-center justify-center rounded-xl border-2 border-dashed border-slate-200 bg-slate-50/50 py-20 dark:border-white/5 dark:bg-white/5">
           <i class="fa-solid fa-circle-check mb-4 text-4xl text-emerald-400"></i>
           <p class="text-base font-black text-slate-900 dark:text-white">全部搞定了</p>
           <p class="mt-1 text-sm text-slate-500">没有待复习的题目，继续保持</p>

--- a/frontend/src/views/app/SearchHubView.vue
+++ b/frontend/src/views/app/SearchHubView.vue
@@ -655,7 +655,7 @@ watch(activeLibraryProject, (project) => {
   width: 100%;
   align-items: center;
   gap: 0.625rem;
-  border-radius: 0.375rem;
+  border-radius: 0.5rem;
   padding: 0.5rem 0.625rem;
   text-align: left;
   font-size: 0.8125rem;

--- a/frontend/src/views/auth/AuthLayout.vue
+++ b/frontend/src/views/auth/AuthLayout.vue
@@ -157,7 +157,7 @@ onMounted(() => {
               <div class="pointer-events-none absolute inset-0"
                 style="background: radial-gradient(80px circle at var(--ix, -500px) var(--iy, -500px), rgb(var(--accent-hover-rgb) / 0.7), transparent 50%);"></div>
               <!-- 图标内部 -->
-              <div class="relative h-full w-full bg-white dark:bg-[#15151e] rounded-[11px] flex items-center justify-center transition-colors">
+              <div class="relative h-full w-full bg-white dark:bg-[#15151e] rounded-lg flex items-center justify-center transition-colors">
                 <!-- 白色底层图标 -->
                 <i :class="`fas ${f.icon} text-xs text-gray-400 dark:text-white/50 absolute transition-colors`"></i>
                 <!-- 鼠标跟随染色图标 -->


### PR DESCRIPTION
## 变更背景

上传与分题流程涉及前后端状态、分割记录持久化和后续导入错题库的链路，需要补齐数据落库与界面反馈，避免刷新、历史记录导入或分题结果复用时状态不一致。

## 变更内容

1. 为分割记录补充原始上传图片信息持久化，历史分割记录可返回 `original_images`
2. 调整分割记录 CRUD、模型字段与迁移逻辑，兼容已有 SQLite 数据库增量升级
3. 上传分题成功后保存更完整的历史记录信息
4. `/api/save-to-db` 兼容 `record_id` 与 `split_record_id`，支持无 `run_id` 的历史分割记录导入
5. 优化上传流程与部分基础组件样式细节
6. 增加分割记录原图返回、历史记录导入错题库的回归测试
7. 将 `*.pem` 加入 `.gitignore`，避免本地服务器私钥误提交

## 自测清单

- [x] 基于最新上游 `main` 整理为单提交
- [x] 已推送到 fork：`IDhammaI/error_correction:codex/upload-flow-polish`
- [x] 确认 `Dianchuang-Prod.pem` 未进入本次提交和远端分支
- [x] 确认 `.gitignore` 已忽略 `*.pem` 私钥文件
- [x] 分割记录可序列化返回原始上传图片列表
- [x] 历史分割记录可通过 `split_record_id` 导入错题库
- [ ] 前端完整 Vitest 测试通过
- [ ] 线上环境验证上传、分题、导入错题库完整链路

## 验证

- `.\.venv\Scripts\python.exe -m pytest backend/tests/test_crud.py::TestSplitRecords::test_recent_records_include_original_uploaded_image backend/tests/test_web_routes.py::TestMultiUserWorkflowRunIsolation::test_save_to_db_imports_split_record_without_run_id -q`
  - 结果：`2 passed`
- `.\.venv\Scripts\python.exe -m pytest backend/tests/test_crud.py backend/tests/test_web_routes.py -q`
  - 结果：当前最新 `main` 下仍有多处旧测试未传 `project_id`，触发 `ValueError: PROJECT_REQUIRED`；本 PR 未扩大修复这些既有测试用例

## 注意事项

- 本 PR 未引入 MySQL/PostgreSQL 依赖，当前仍沿用 SQLite 本地持久化
- 服务器私钥文件只保留在本地工作区，没有提交到 GitHub
- 此 PR 从 fork 分支发起，便于后续继续在 fork 中维护